### PR TITLE
Include Gentoo installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ git clone https://aur.archlinux.org/gitcomet.git
 cd gitcomet && makepkg -si
 ```
 
+#### GURU (Gentoo Linux)
+
+```bash
+emerge --ask dev-vcs/gitcomet
+```
+
 #### apt (Debian/Ubuntu)
 
 ```bash


### PR DESCRIPTION
Add installation instructions for GURU on Gentoo Linux.

[Packaged it.](https://github.com/gentoo/guru/blob/dev/dev-vcs/gitcomet/gitcomet-0.1.6.ebuild)