### PR TITLE
always keep the active branch graph lane left most in the graph colum...

### DIFF
--- a/crates/gitcomet-ui-gpui/src/view/history_graph.rs
+++ b/crates/gitcomet-ui-gpui/src/view/history_graph.rs
@@ -44,6 +44,7 @@ pub fn compute_graph(
     commits: &[Commit],
     theme: AppTheme,
     branch_heads: &HashSet<&str>,
+    active_head_target: Option<&str>,
 ) -> Vec<GraphRow> {
     let mut palette: Vec<Rgba> = Vec::with_capacity(LANE_COLOR_PALETTE_SIZE);
     for i in 0..LANE_COLOR_PALETTE_SIZE {
@@ -55,12 +56,14 @@ pub fn compute_graph(
 
     let known: HashSet<&str> = commits.iter().map(|c| c.id.as_ref()).collect();
     let by_id: HashMap<&str, &Commit> = commits.iter().map(|c| (c.id.as_ref(), c)).collect();
+    let main_target = active_head_target
+        .filter(|id| known.contains(*id))
+        .or_else(|| commits.first().map(|c| c.id.as_ref()));
 
-    // Approximate the "main line" as the first-parent chain from the first commit in the list,
-    // which is typically the checked-out branch HEAD in our log view.
+    // Follow the checked-out branch's first-parent chain when we know its target; otherwise fall
+    // back to the first visible commit.
     let mut head_chain: HashSet<&str> = HashSet::default();
-    if let Some(first) = commits.first() {
-        let mut cur: &str = first.id.as_ref();
+    if let Some(mut cur) = main_target {
         loop {
             if !head_chain.insert(cur) {
                 break;
@@ -85,6 +88,20 @@ pub fn compute_graph(
     let mut lanes: Vec<LaneState<'_>> = Vec::new();
     let mut rows: Vec<GraphRow> = Vec::with_capacity(commits.len());
     let mut main_lane_id: Option<LaneId> = None;
+    let mut seeded_main_lane_pending = false;
+
+    if let Some(main_target) = main_target {
+        let id = LaneId(next_id);
+        next_id += 1;
+        lanes.push(LaneState {
+            id,
+            color: palette[0],
+            target: main_target,
+        });
+        main_lane_id = Some(id);
+        next_color = 1;
+        seeded_main_lane_pending = true;
+    }
 
     let mut pick_lane_color = |lanes: &[LaneState]| -> Rgba {
         let start = next_color;
@@ -101,7 +118,19 @@ pub fn compute_graph(
     };
 
     for commit in commits.iter() {
-        let incoming_ids = lanes.iter().map(|l| l.id).collect::<HashSet<_>>();
+        let incoming_ids = lanes
+            .iter()
+            .filter_map(|lane| {
+                if seeded_main_lane_pending
+                    && Some(lane.id) == main_lane_id
+                    && main_target == Some(commit.id.as_ref())
+                {
+                    None
+                } else {
+                    Some(lane.id)
+                }
+            })
+            .collect::<HashSet<_>>();
 
         let mut hits = lanes
             .iter()
@@ -117,6 +146,7 @@ pub fn compute_graph(
             .map(|p| p.as_ref())
             .filter(|p| known.contains(p))
             .collect::<Vec<_>>();
+        let is_on_main_chain = head_chain.contains(commit.id.as_ref());
 
         if hits.is_empty() {
             let id = LaneId(next_id);
@@ -136,13 +166,16 @@ pub fn compute_graph(
         //
         // We currently only do this for non-merge commits to avoid interfering with merge-parent
         // lane assignment.
+        let only_hit_is_main_lane = hits.len() == 1
+            && main_lane_id.is_some_and(|id| lanes.get(hits[0]).is_some_and(|lane| lane.id == id));
         let force_branch_head_lane = had_hit_lanes
             && hits.len() == 1
             && branch_heads.contains(commit.id.as_ref())
-            && parent_ids.len() <= 1;
+            && parent_ids.len() <= 1
+            && !(main_target == Some(commit.id.as_ref()) && only_hit_is_main_lane);
 
         let mut node_col = if let Some(main_lane_id) = main_lane_id
-            && head_chain.contains(commit.id.as_ref())
+            && is_on_main_chain
         {
             hits.iter()
                 .copied()
@@ -153,19 +186,23 @@ pub fn compute_graph(
             hits.first().copied().unwrap_or(0)
         };
 
+        let keep_main_lane_as_node =
+            force_branch_head_lane && is_on_main_chain && only_hit_is_main_lane;
         let mut swap_node_into_col: Option<usize> = None;
         if force_branch_head_lane {
             let id = LaneId(next_id);
             next_id += 1;
             let color = pick_lane_color(&lanes);
-            swap_node_into_col = Some(node_col);
-            node_col = lanes.len();
+            if !keep_main_lane_as_node {
+                swap_node_into_col = Some(node_col);
+                node_col = lanes.len();
+            }
             lanes.push(LaneState {
                 id,
                 color,
                 target: commit.id.as_ref(),
             });
-            hits.push(node_col);
+            hits.push(lanes.len() - 1);
         }
 
         // Snapshot of lanes used for drawing this row (including any lanes that have converged
@@ -189,13 +226,6 @@ pub fn compute_graph(
 
         // Ensure the node lane is the first hit lane for the parent assignment logic below.
         node_col = hits.first().copied().unwrap_or(node_col);
-
-        let node_id = lanes[node_col].id;
-        if main_lane_id.is_none()
-            || (force_branch_head_lane && head_chain.contains(commit.id.as_ref()))
-        {
-            main_lane_id = Some(node_id);
-        }
 
         // Incoming join edges: other lanes that were targeting this commit join into the node.
         let mut joins_in = Vec::with_capacity(hits.len().saturating_sub(1));
@@ -311,6 +341,8 @@ pub fn compute_graph(
             node_col,
             is_merge,
         });
+
+        seeded_main_lane_pending = false;
     }
 
     rows
@@ -358,7 +390,7 @@ mod tests {
         commits.push(commit("p1", Vec::new()));
 
         let branch_heads = HashSet::default();
-        let graph = compute_graph(&commits, theme, &branch_heads);
+        let graph = compute_graph(&commits, theme, &branch_heads, None);
 
         let head1_ix = LANE_COLOR_PALETTE_SIZE + 1 + (LANE_COLOR_PALETTE_SIZE - 1);
         let row = &graph[head1_ix];
@@ -382,21 +414,18 @@ mod tests {
         branch_heads.insert("new1");
         branch_heads.insert("base");
 
-        let graph = compute_graph(&commits, theme, &branch_heads);
+        let graph = compute_graph(&commits, theme, &branch_heads, None);
 
         let base_row = &graph[1];
         assert_eq!(base_row.lanes_now.len(), 2);
         assert_eq!(base_row.incoming_mask, vec![true, false]);
         assert_eq!(base_row.joins_in.len(), 1);
-        assert_eq!(base_row.node_col, 1);
+        assert_eq!(base_row.node_col, 0);
         assert_ne!(base_row.lanes_now[0].color, base_row.lanes_now[1].color);
 
         assert_eq!(base_row.lanes_next.len(), 1);
-        assert_eq!(
-            base_row.lanes_next[0].id,
-            base_row.lanes_now[base_row.node_col].id
-        );
-        assert_eq!(base_row.next_from_cols, vec![Some(1)]);
+        assert_eq!(base_row.lanes_next[0].id, base_row.lanes_now[0].id);
+        assert_eq!(base_row.next_from_cols, vec![Some(0)]);
     }
 
     #[test]
@@ -413,7 +442,7 @@ mod tests {
         branch_heads.insert("top1");
         branch_heads.insert("base");
 
-        let graph = compute_graph(&commits, theme, &branch_heads);
+        let graph = compute_graph(&commits, theme, &branch_heads, None);
 
         let base_row = &graph[2];
         assert_eq!(base_row.lanes_now.len(), 2);
@@ -421,5 +450,31 @@ mod tests {
         assert_eq!(base_row.node_col, 0);
         assert_eq!(base_row.lanes_next.len(), 1);
         assert_eq!(base_row.next_from_cols, vec![Some(0)]);
+    }
+
+    #[test]
+    fn active_head_lane_stays_leftmost_even_when_head_commit_appears_later() {
+        let theme = AppTheme::zed_ayu_dark();
+        let commits = vec![
+            commit("feature2", vec!["base"]),
+            commit("main2", vec!["base"]),
+            commit("base", vec!["root"]),
+            commit("root", Vec::new()),
+        ];
+
+        let mut branch_heads = HashSet::default();
+        branch_heads.insert("feature2");
+        branch_heads.insert("main2");
+
+        let graph = compute_graph(&commits, theme, &branch_heads, Some("main2"));
+
+        let seeded_lane = graph[0].lanes_now[0].id;
+        assert_eq!(graph[0].lanes_now.len(), 2);
+        assert_eq!(graph[0].incoming_mask, vec![true, false]);
+        assert_eq!(graph[0].node_col, 1);
+        assert_eq!(graph[1].node_col, 0);
+        assert_eq!(graph[2].node_col, 0);
+        assert_eq!(graph[1].lanes_now[0].id, seeded_lane);
+        assert_eq!(graph[2].lanes_now[0].id, seeded_lane);
     }
 }

--- a/crates/gitcomet-ui-gpui/src/view/panes/history.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panes/history.rs
@@ -12,6 +12,22 @@ fn history_columns_available_width(window_width: Pixels) -> Pixels {
     available.max(px(0.0))
 }
 
+fn graph_branch_heads<'a>(
+    history_scope: LogScope,
+    branches: &'a [Branch],
+    remote_branches: &'a [RemoteBranch],
+) -> HashSet<&'a str> {
+    if history_scope == LogScope::CurrentBranch {
+        HashSet::default()
+    } else {
+        branches
+            .iter()
+            .map(|b| b.target.as_ref())
+            .chain(remote_branches.iter().map(|b| b.target.as_ref()))
+            .collect()
+    }
+}
+
 fn history_column_static_bounds(handle: HistoryColResizeHandle) -> (Pixels, Pixels) {
     match handle {
         HistoryColResizeHandle::Branch => {
@@ -812,22 +828,6 @@ impl HistoryView {
                         .filter_map(|ix| page.commits.get(*ix).cloned())
                         .collect::<Vec<_>>();
 
-                    let branch_heads: HashSet<&str> = branches
-                        .iter()
-                        .map(|b| b.target.as_ref())
-                        .chain(remote_branches.iter().map(|b| b.target.as_ref()))
-                        .collect();
-                    let graph_rows: Vec<Arc<history_graph::GraphRow>> =
-                        history_graph::compute_graph(&visible_commits, theme, &branch_heads)
-                            .into_iter()
-                            .map(Arc::new)
-                            .collect();
-                    let max_lanes = graph_rows
-                        .iter()
-                        .map(|r| r.lanes_now.len().max(r.lanes_next.len()))
-                        .max()
-                        .unwrap_or(1);
-
                     let head_target = match head_branch.as_deref() {
                         Some("HEAD") => request_for_build
                             .detached_head_commit
@@ -844,6 +844,27 @@ impl HistoryView {
                             .map(|b| b.target.as_ref()),
                         None => None,
                     };
+
+                    let branch_heads = graph_branch_heads(
+                        request_for_build.history_scope,
+                        branches.as_ref(),
+                        remote_branches.as_ref(),
+                    );
+                    let graph_rows: Vec<Arc<history_graph::GraphRow>> =
+                        history_graph::compute_graph(
+                            &visible_commits,
+                            theme,
+                            &branch_heads,
+                            head_target,
+                        )
+                        .into_iter()
+                        .map(Arc::new)
+                        .collect();
+                    let max_lanes = graph_rows
+                        .iter()
+                        .map(|r| r.lanes_now.len().max(r.lanes_next.len()))
+                        .max()
+                        .unwrap_or(1);
 
                     let mut branch_names_by_target: HashMap<&str, Vec<String>> =
                         HashMap::with_capacity_and_hasher(
@@ -1075,6 +1096,23 @@ mod tests {
         }
     }
 
+    fn branch(name: &str, target: &str) -> Branch {
+        Branch {
+            name: name.into(),
+            target: CommitId(target.into()),
+            upstream: None,
+            divergence: None,
+        }
+    }
+
+    fn remote_branch(remote: &str, name: &str, target: &str) -> RemoteBranch {
+        RemoteBranch {
+            remote: remote.into(),
+            name: name.into(),
+            target: CommitId(target.into()),
+        }
+    }
+
     #[test]
     fn stash_tip_detection_requires_stash_like_message_and_multiple_parents() {
         assert!(is_probable_stash_tip(&commit(
@@ -1110,6 +1148,22 @@ mod tests {
             Some("keep this")
         );
         assert_eq!(stash_summary_from_log_summary("no delimiter"), None);
+    }
+
+    #[test]
+    fn graph_branch_heads_are_hidden_for_current_branch_scope() {
+        let branches = vec![branch("main", "local-head")];
+        let remote_branches = vec![remote_branch("origin", "feature/x", "remote-head")];
+
+        let current_branch_heads =
+            graph_branch_heads(LogScope::CurrentBranch, &branches, &remote_branches);
+        assert!(current_branch_heads.is_empty());
+
+        let all_branch_heads =
+            graph_branch_heads(LogScope::AllBranches, &branches, &remote_branches);
+        assert_eq!(all_branch_heads.len(), 2);
+        assert!(all_branch_heads.contains("local-head"));
+        assert!(all_branch_heads.contains("remote-head"));
     }
 
     #[test]

--- a/crates/gitcomet-ui-gpui/src/view/rows/benchmarks.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/benchmarks.rs
@@ -73,7 +73,7 @@ impl OpenRepoFixture {
 
         // History graph is the main "long history" transformation.
         let branch_heads = HashSet::default();
-        let graph = history_graph::compute_graph(&self.commits, self.theme, &branch_heads);
+        let graph = history_graph::compute_graph(&self.commits, self.theme, &branch_heads, None);
 
         let mut h = FxHasher::default();
         rows.len().hash(&mut h);
@@ -233,7 +233,7 @@ impl HistoryGraphFixture {
             }
         }
 
-        let graph = history_graph::compute_graph(&self.commits, self.theme, &branch_heads);
+        let graph = history_graph::compute_graph(&self.commits, self.theme, &branch_heads, None);
         let mut h = FxHasher::default();
         graph.len().hash(&mut h);
         graph

--- a/crates/gitcomet-ui-gpui/src/view/rows/history.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/history.rs
@@ -1252,7 +1252,7 @@ impl HistoryView {
             .filter(|c| c.request.repo_id == repo.id);
         let worktree_node_color = cache
             .and_then(|c| c.graph_rows.first())
-            .and_then(|row| row.lanes_now.get(row.node_col).map(|l| l.color))
+            .and_then(|row| row.lanes_now.first().map(|l| l.color))
             .unwrap_or(theme.colors.accent);
 
         range
@@ -1287,7 +1287,8 @@ impl HistoryView {
                 let commit = page.commits.get(commit_ix)?;
                 let graph_row = cache.graph_rows.get(visible_ix)?;
                 let row_vm = cache.commit_row_vms.get(visible_ix)?;
-                let connect_incoming_node = show_working_tree_summary_row && visible_ix == 0;
+                let connect_from_top_col =
+                    (show_working_tree_summary_row && visible_ix == 0).then_some(0);
                 let selected = repo.history_state.selected_commit.as_ref() == Some(&commit.id);
                 let show_graph_color_marker = repo.history_state.history_scope
                     == gitcomet_core::domain::LogScope::AllBranches;
@@ -1311,7 +1312,7 @@ impl HistoryView {
                     repo.id,
                     commit,
                     Arc::clone(graph_row),
-                    connect_incoming_node,
+                    connect_from_top_col,
                     Arc::clone(&row_vm.tag_names),
                     row_vm.branches_text.clone(),
                     row_vm.author.clone(),
@@ -1347,7 +1348,7 @@ fn history_table_row(
     repo_id: RepoId,
     commit: &Commit,
     graph_row: Arc<history_graph::GraphRow>,
-    connect_incoming_node: bool,
+    connect_from_top_col: Option<usize>,
     tag_names: Arc<[SharedString]>,
     branches_text: SharedString,
     author: SharedString,
@@ -1379,7 +1380,7 @@ fn history_table_row(
         show_sha,
         show_graph_color_marker,
         is_stash_node,
-        connect_incoming_node,
+        connect_from_top_col,
         graph_row,
         tag_names,
         branches_text,

--- a/crates/gitcomet-ui-gpui/src/view/rows/history_canvas.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/history_canvas.rs
@@ -114,7 +114,7 @@ pub(super) fn history_commit_row_canvas(
     show_sha: bool,
     show_graph_color_marker: bool,
     is_stash_node: bool,
-    connect_incoming_node: bool,
+    connect_from_top_col: Option<usize>,
     graph_row: Arc<history_graph::GraphRow>,
     tag_names: Arc<[SharedString]>,
     branches_text: SharedString,
@@ -228,7 +228,7 @@ pub(super) fn history_commit_row_canvas(
                         super::history_graph_paint::paint_history_graph(
                             theme,
                             &graph_row,
-                            connect_incoming_node,
+                            connect_from_top_col,
                             is_stash_node,
                             graph_bounds,
                             window,

--- a/crates/gitcomet-ui-gpui/src/view/rows/history_graph_paint.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/history_graph_paint.rs
@@ -4,7 +4,7 @@ use gpui::{Bounds, Pixels, Window, fill, point, px, size};
 pub(super) fn paint_history_graph(
     theme: AppTheme,
     row: &history_graph::GraphRow,
-    connect_incoming_node: bool,
+    connect_from_top_col: Option<usize>,
     is_stash_node: bool,
     bounds: Bounds<Pixels>,
     window: &mut Window,
@@ -30,7 +30,7 @@ pub(super) fn paint_history_graph(
     // Incoming vertical segments.
     for (col, lane) in row.lanes_now.iter().enumerate() {
         let incoming = row.incoming_mask.get(col).copied().unwrap_or(false);
-        if !(incoming || (connect_incoming_node && col == row.node_col)) {
+        if !(incoming || connect_from_top_col == Some(col)) {
             continue;
         }
         let x = x_for_col(col);


### PR DESCRIPTION
always keep the active branch graph lane left most in the graph column to make it more clear where uncommitted changes belong