### PR TITLE
Add Windows ARM 64 Native Build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 [target.x86_64-pc-windows-msvc]
 linker = "scripts/windows/msvc-linker.cmd"
 
+[target.aarch64-pc-windows-msvc]
+linker = "scripts/windows/msvc-linker.cmd"
+
 [target.'cfg(target_arch = "x86_64")']
 rustflags = ["-Ctarget-cpu=x86-64-v3"]

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -146,6 +146,9 @@ jobs:
           - target_platform: x86_64-windows
             artifact_arch: x86_64
             runs_on: windows-latest
+          - target_platform: aarch64-windows
+            artifact_arch: arm64
+            runs_on: windows-11-arm
     env:
       TAG: ${{ needs.prepare.outputs.tag }}
       VERSION: ${{ needs.prepare.outputs.version }}
@@ -203,8 +206,10 @@ jobs:
           $ErrorActionPreference = "Stop"
 
           $kitsRoot = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin"
+          # Prefer arch-matched signtool (arm64 on ARM runners, x64 on x64 runners), fall back to any.
+          $hostArch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
           $signTool = Get-ChildItem -Path $kitsRoot -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
-            Where-Object { $_.FullName -match '\\x64\\' } |
+            Where-Object { $_.FullName -match "\\$hostArch\\" } |
             Sort-Object FullName -Descending |
             Select-Object -First 1 -ExpandProperty FullName
 

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -231,6 +231,8 @@ jobs:
         include:
           - target_platform: x86_64-windows
             runs_on: windows-latest
+          - target_platform: aarch64-windows
+            runs_on: windows-11-arm
     steps:
       - uses: actions/checkout@v6
       - name: Show Git version

--- a/crates/gitcomet-git-gix/tests/git_ops_trace_integration.rs
+++ b/crates/gitcomet-git-gix/tests/git_ops_trace_integration.rs
@@ -5,19 +5,14 @@ use gitcomet_git_gix::GixBackend;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-#[cfg(windows)]
-const NULL_DEVICE: &str = "NUL";
-#[cfg(not(windows))]
-const NULL_DEVICE: &str = "/dev/null";
-
-fn run_git(repo: &Path, args: &[&str]) {
+fn run_git(repo: &Path, args: &[&str], empty_config: &Path) {
     let status = Command::new("git")
         .arg("-C")
         .arg(repo)
         .args(args)
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", NULL_DEVICE)
-        .env("GIT_CONFIG_SYSTEM", NULL_DEVICE)
+        .env("GIT_CONFIG_GLOBAL", empty_config)
+        .env("GIT_CONFIG_SYSTEM", empty_config)
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_EDITOR", "true")
         .env("EDITOR", "true")
@@ -32,22 +27,28 @@ fn git_op_trace_captures_backend_entry_points_once_per_operation() {
     let dir = tempfile::tempdir().expect("create tempdir");
     let repo = dir.path();
 
-    run_git(repo, &["init", "-b", "main"]);
-    run_git(repo, &["config", "user.email", "you@example.com"]);
-    run_git(repo, &["config", "user.name", "You"]);
-    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    // Use an empty file instead of NUL/​/dev/null — Git on Windows ARM64
+    // cannot access the NUL device as a config path.
+    let empty_config = dir.path().join("empty.gitconfig");
+    std::fs::write(&empty_config, "").expect("create empty git config");
+
+    run_git(repo, &["init", "-b", "main"], &empty_config);
+    run_git(repo, &["config", "user.email", "you@example.com"], &empty_config);
+    run_git(repo, &["config", "user.name", "You"], &empty_config);
+    run_git(repo, &["config", "commit.gpgsign", "false"], &empty_config);
 
     std::fs::write(repo.join("story.txt"), "one\ntwo\nthree\n").expect("write base file");
-    run_git(repo, &["add", "story.txt"]);
+    run_git(repo, &["add", "story.txt"], &empty_config);
     run_git(
         repo,
         &["-c", "commit.gpgsign=false", "commit", "-m", "base"],
+        &empty_config,
     );
 
-    run_git(repo, &["checkout", "-b", "feature"]);
+    run_git(repo, &["checkout", "-b", "feature"], &empty_config);
     std::fs::write(repo.join("story.txt"), "one\ntwo feature\nthree\n")
         .expect("write branch commit");
-    run_git(repo, &["add", "story.txt"]);
+    run_git(repo, &["add", "story.txt"], &empty_config);
     run_git(
         repo,
         &[
@@ -57,6 +58,7 @@ fn git_op_trace_captures_backend_entry_points_once_per_operation() {
             "-m",
             "feature change",
         ],
+        &empty_config,
     );
 
     std::fs::write(

--- a/crates/gitcomet-git-gix/tests/git_ops_trace_integration.rs
+++ b/crates/gitcomet-git-gix/tests/git_ops_trace_integration.rs
@@ -29,7 +29,10 @@ fn git_op_trace_captures_backend_entry_points_once_per_operation() {
 
     // Use an empty file instead of NUL/​/dev/null — Git on Windows ARM64
     // cannot access the NUL device as a config path.
-    let empty_config = dir.path().join("empty.gitconfig");
+    // Keep the config file in a separate tempdir so it does not appear as an
+    // untracked file inside the repo and skew the status assertion below.
+    let config_dir = tempfile::tempdir().expect("create config tempdir");
+    let empty_config = config_dir.path().join("empty.gitconfig");
     std::fs::write(&empty_config, "").expect("create empty git config");
 
     run_git(repo, &["init", "-b", "main"], &empty_config);

--- a/crates/gitcomet-git-gix/tests/git_ops_trace_integration.rs
+++ b/crates/gitcomet-git-gix/tests/git_ops_trace_integration.rs
@@ -33,7 +33,11 @@ fn git_op_trace_captures_backend_entry_points_once_per_operation() {
     std::fs::write(&empty_config, "").expect("create empty git config");
 
     run_git(repo, &["init", "-b", "main"], &empty_config);
-    run_git(repo, &["config", "user.email", "you@example.com"], &empty_config);
+    run_git(
+        repo,
+        &["config", "user.email", "you@example.com"],
+        &empty_config,
+    );
     run_git(repo, &["config", "user.name", "You"], &empty_config);
     run_git(repo, &["config", "commit.gpgsign", "false"], &empty_config);
 

--- a/crates/gitcomet-ui-gpui/src/view/rows/benchmarks/git_ops.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/benchmarks/git_ops.rs
@@ -1077,6 +1077,7 @@ fn run_git_with_input(repo: &Path, args: &[&str], input: &str) {
 // (`unable to access 'NUL': Invalid argument`).  Use a process-lifetime
 // empty file instead, which works identically on every platform.
 fn git_ops_empty_config() -> &'static Path {
+    use std::path::PathBuf;
     use std::sync::OnceLock;
     static EMPTY_CONFIG: OnceLock<PathBuf> = OnceLock::new();
     EMPTY_CONFIG.get_or_init(|| {

--- a/crates/gitcomet-ui-gpui/src/view/rows/benchmarks/git_ops.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/benchmarks/git_ops.rs
@@ -1,10 +1,5 @@
 use super::*;
 
-#[cfg(windows)]
-const GIT_OPS_NULL_DEVICE: &str = "NUL";
-#[cfg(not(windows))]
-const GIT_OPS_NULL_DEVICE: &str = "/dev/null";
-
 enum GitOpsScenario {
     StatusDirty {
         tracked_files: usize,
@@ -1078,14 +1073,28 @@ fn run_git_with_input(repo: &Path, args: &[&str], input: &str) {
     );
 }
 
+// Git on Windows ARM64 cannot access the NUL device as a config path
+// (`unable to access 'NUL': Invalid argument`).  Use a process-lifetime
+// empty file instead, which works identically on every platform.
+fn git_ops_empty_config() -> &'static Path {
+    use std::sync::OnceLock;
+    static EMPTY_CONFIG: OnceLock<PathBuf> = OnceLock::new();
+    EMPTY_CONFIG.get_or_init(|| {
+        let path = std::env::temp_dir().join("gitcomet-bench-empty.gitconfig");
+        fs::write(&path, "").expect("create empty git config for benchmarks");
+        path
+    })
+}
+
 pub(crate) fn git_command(repo: &Path) -> Command {
+    let empty_config = git_ops_empty_config();
     let mut command = Command::new("git");
     command
         .arg("-C")
         .arg(repo)
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", GIT_OPS_NULL_DEVICE)
-        .env("GIT_CONFIG_SYSTEM", GIT_OPS_NULL_DEVICE)
+        .env("GIT_CONFIG_GLOBAL", empty_config)
+        .env("GIT_CONFIG_SYSTEM", empty_config)
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_EDITOR", "true")
         .env("EDITOR", "true")

--- a/crates/gitcomet/src/bin/perf_app_launch.rs
+++ b/crates/gitcomet/src/bin/perf_app_launch.rs
@@ -32,10 +32,6 @@ const ENVIRONMENT_BLOCKER_MARKER: &str = "This is an environment blocker, not a 
 #[cfg(any(test, target_os = "linux", target_os = "freebsd"))]
 const APP_LAUNCH_HEADLESS_NOTE: &str = "GPUI headless mode is not a substitute for app_launch because it cannot open the main window or emit comparable first_paint/first_interactive metrics.";
 
-#[cfg(windows)]
-const GIT_NULL_DEVICE: &str = "NUL";
-#[cfg(not(windows))]
-const GIT_NULL_DEVICE: &str = "/dev/null";
 
 #[global_allocator]
 static GLOBAL: &gitcomet_ui_gpui::perf_alloc::PerfTrackingAllocator = &TRACKING_MIMALLOC;
@@ -1204,14 +1200,28 @@ fn run_git_with_input(repo: &Path, args: &[&str], input: &str) -> Result<(), Str
     ))
 }
 
+// Git on Windows ARM64 cannot access the NUL device as a config path
+// (`unable to access 'NUL': Invalid argument`).  Use a process-lifetime
+// empty file instead, which works identically on every platform.
+fn empty_git_config() -> &'static Path {
+    use std::sync::OnceLock;
+    static EMPTY_CONFIG: OnceLock<PathBuf> = OnceLock::new();
+    EMPTY_CONFIG.get_or_init(|| {
+        let path = std::env::temp_dir().join("gitcomet-perf-empty.gitconfig");
+        fs::write(&path, "").expect("create empty git config for perf harness");
+        path
+    })
+}
+
 fn git_command(repo: &Path) -> Command {
+    let empty_config = empty_git_config();
     let mut command = Command::new("git");
     command
         .arg("-C")
         .arg(repo)
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", GIT_NULL_DEVICE)
-        .env("GIT_CONFIG_SYSTEM", GIT_NULL_DEVICE)
+        .env("GIT_CONFIG_GLOBAL", empty_config)
+        .env("GIT_CONFIG_SYSTEM", empty_config)
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_EDITOR", "true")
         .env("EDITOR", "true")

--- a/crates/gitcomet/src/bin/perf_app_launch.rs
+++ b/crates/gitcomet/src/bin/perf_app_launch.rs
@@ -32,7 +32,6 @@ const ENVIRONMENT_BLOCKER_MARKER: &str = "This is an environment blocker, not a 
 #[cfg(any(test, target_os = "linux", target_os = "freebsd"))]
 const APP_LAUNCH_HEADLESS_NOTE: &str = "GPUI headless mode is not a substitute for app_launch because it cannot open the main window or emit comparable first_paint/first_interactive metrics.";
 
-
 #[global_allocator]
 static GLOBAL: &gitcomet_ui_gpui::perf_alloc::PerfTrackingAllocator = &TRACKING_MIMALLOC;
 

--- a/scripts/windows/msvc-linker.cmd
+++ b/scripts/windows/msvc-linker.cmd
@@ -1,6 +1,30 @@
 @echo off
 setlocal EnableExtensions
 
+rem ── Detect target architecture ────────────────────────────────────────────
+rem   Defaults to the host architecture.  Override with GITCOMET_TARGET_ARCH
+rem   (set to "x64" or "arm64") for cross-compilation scenarios.
+if defined GITCOMET_TARGET_ARCH goto :arch_set
+if /i "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+  set "GITCOMET_TARGET_ARCH=arm64"
+) else (
+  set "GITCOMET_TARGET_ARCH=x64"
+)
+:arch_set
+
+if /i "%GITCOMET_TARGET_ARCH%"=="arm64" (
+  set "VS_COMPONENT=Microsoft.VisualStudio.Component.VC.Tools.ARM64"
+  set "LINK_HOST_PRIMARY=Hostarm64\arm64"
+  set "LINK_HOST_FALLBACK=Hostx64\arm64"
+  set "SDK_ARCH=arm64"
+) else (
+  set "VS_COMPONENT=Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+  set "LINK_HOST_PRIMARY=Hostx64\x64"
+  set "LINK_HOST_FALLBACK="
+  set "SDK_ARCH=x64"
+)
+
+rem ── Locate Visual Studio ──────────────────────────────────────────────────
 set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 if not exist "%VSWHERE%" (
   echo gitcomet: could not find vswhere.exe at "%VSWHERE%".
@@ -9,15 +33,16 @@ if not exist "%VSWHERE%" (
 )
 
 set "VSINSTALL="
-for /f "usebackq delims=" %%I in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+for /f "usebackq delims=" %%I in (`"%VSWHERE%" -latest -products * -requires %VS_COMPONENT% -property installationPath`) do (
   set "VSINSTALL=%%I"
 )
 if not defined VSINSTALL (
-  echo gitcomet: could not locate a Visual Studio installation with MSVC tools.
-  echo gitcomet: install the "Desktop development with C++" workload.
+  echo gitcomet: could not locate a Visual Studio installation with MSVC %GITCOMET_TARGET_ARCH% tools.
+  echo gitcomet: install the "Desktop development with C++" workload ^(component: %VS_COMPONENT%^).
   exit /b 1
 )
 
+rem ── Locate MSVC toolset ───────────────────────────────────────────────────
 set "MSVC_TOOLS=%VSINSTALL%\VC\Tools\MSVC"
 if not exist "%MSVC_TOOLS%" (
   echo gitcomet: MSVC tools directory not found: "%MSVC_TOOLS%".
@@ -36,12 +61,23 @@ if not defined MSVC_VER (
 )
 
 set "MSVC_ROOT=%MSVC_TOOLS%\%MSVC_VER%"
-set "LINK_EXE=%MSVC_ROOT%\bin\Hostx64\x64\link.exe"
-if not exist "%LINK_EXE%" (
-  echo gitcomet: link.exe not found at "%LINK_EXE%".
+
+rem ── Locate link.exe ───────────────────────────────────────────────────────
+set "LINK_EXE="
+if exist "%MSVC_ROOT%\bin\%LINK_HOST_PRIMARY%\link.exe" (
+  set "LINK_EXE=%MSVC_ROOT%\bin\%LINK_HOST_PRIMARY%\link.exe"
+)
+if not defined LINK_EXE if defined LINK_HOST_FALLBACK (
+  if exist "%MSVC_ROOT%\bin\%LINK_HOST_FALLBACK%\link.exe" (
+    set "LINK_EXE=%MSVC_ROOT%\bin\%LINK_HOST_FALLBACK%\link.exe"
+  )
+)
+if not defined LINK_EXE (
+  echo gitcomet: link.exe not found for %GITCOMET_TARGET_ARCH% target under "%MSVC_ROOT%\bin".
   exit /b 1
 )
 
+rem ── Locate Windows SDK ────────────────────────────────────────────────────
 set "KITS_ROOT=%ProgramFiles(x86)%\Windows Kits\10"
 set "KITS_LIB=%KITS_ROOT%\Lib"
 set "KITS_INC=%KITS_ROOT%\Include"
@@ -54,22 +90,23 @@ if not exist "%KITS_LIB%" (
 
 set "SDK_VER="
 for /f "delims=" %%I in ('dir /b /ad "%KITS_LIB%" ^| sort /r') do (
-  if exist "%KITS_LIB%\%%I\um\x64\kernel32.lib" (
+  if exist "%KITS_LIB%\%%I\um\%SDK_ARCH%\kernel32.lib" (
     set "SDK_VER=%%I"
     goto :sdk_found
   )
 )
 :sdk_found
 if not defined SDK_VER (
-  echo gitcomet: Windows SDK libraries missing ^(kernel32.lib not found^).
-  echo gitcomet: install the Windows 10 or Windows 11 SDK component.
+  echo gitcomet: Windows SDK %SDK_ARCH% libraries missing ^(kernel32.lib not found^).
+  echo gitcomet: install the Windows 10 or Windows 11 SDK component with %SDK_ARCH% libs.
   exit /b 1
 )
 
-set "MSVC_LIB=%MSVC_ROOT%\lib\x64"
+rem ── Set up library and include paths ──────────────────────────────────────
+set "MSVC_LIB=%MSVC_ROOT%\lib\%SDK_ARCH%"
 set "MSVC_INCLUDE=%MSVC_ROOT%\include"
-set "SDK_UM_LIB=%KITS_LIB%\%SDK_VER%\um\x64"
-set "SDK_UCRT_LIB=%KITS_LIB%\%SDK_VER%\ucrt\x64"
+set "SDK_UM_LIB=%KITS_LIB%\%SDK_VER%\um\%SDK_ARCH%"
+set "SDK_UCRT_LIB=%KITS_LIB%\%SDK_VER%\ucrt\%SDK_ARCH%"
 set "SDK_SHARED_INC=%KITS_INC%\%SDK_VER%\shared"
 set "SDK_UM_INC=%KITS_INC%\%SDK_VER%\um"
 set "SDK_UCRT_INC=%KITS_INC%\%SDK_VER%\ucrt"
@@ -80,6 +117,7 @@ set "LIB=%MSVC_LIB%;%SDK_UM_LIB%;%SDK_UCRT_LIB%;%LIB%"
 set "LIBPATH=%MSVC_LIB%;%SDK_UM_LIB%;%SDK_UCRT_LIB%;%LIBPATH%"
 set "INCLUDE=%MSVC_INCLUDE%;%SDK_SHARED_INC%;%SDK_UM_INC%;%SDK_UCRT_INC%;%SDK_WINRT_INC%;%SDK_CPPWINRT_INC%;%INCLUDE%"
 
+rem ── Invoke link.exe ───────────────────────────────────────────────────────
 rem GitComet's GPUI diff/render paths are substantially deeper in debug builds.
 rem The Windows default 1 MiB main-thread stack is not enough there, which can
 rem abort the process with a stack overflow before Rust's panic hook runs.


### PR DESCRIPTION
With the rising popularity of Windows ARM 64 devices, such as the latest Surface / Snapdragon X laptops, recently released Snapdragon X2 devices and soon to be released Nvidia N1X SOC users are increasingly expecting native applications.

Modified GitHub build actions and tests for Windows ARM compatibility.

Couldn't fully test action since I don't have signing keys, but I did build locally and tested on my Snapdragon X2 Elite Extreme Asus Zenbook A16 on Windows 11 ARM 26H1.  