### PR TITLE
Preserve custom Git paths for helper lookup

### DIFF
--- a/crates/gitcomet-core/src/process.rs
+++ b/crates/gitcomet-core/src/process.rs
@@ -1,4 +1,3 @@
-use crate::path_utils::canonicalize_or_original;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -162,18 +161,35 @@ pub fn normalize_git_executable_path(path: PathBuf) -> PathBuf {
     if path.as_os_str().is_empty() {
         return path;
     }
-    let path = if path.is_absolute() {
+    if path.is_absolute() {
         path
     } else {
         std::env::current_dir()
             .unwrap_or_else(|_| PathBuf::from("."))
             .join(path)
-    };
-    canonicalize_or_original(path)
+    }
 }
 
 fn git_command_for_preference(preference: &GitExecutablePreference) -> Command {
-    background_command(preference.command_program())
+    let mut command = background_command(preference.command_program());
+    if let GitExecutablePreference::Custom(path) = preference
+        && let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        prepend_command_path(&mut command, parent);
+    }
+    command
+}
+
+fn prepend_command_path(command: &mut Command, path: &Path) {
+    let mut paths = Vec::new();
+    paths.push(path.to_path_buf());
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    if let Ok(joined) = std::env::join_paths(paths) {
+        command.env("PATH", joined);
+    }
 }
 
 fn probe_git_runtime(preference: GitExecutablePreference) -> GitRuntimeState {
@@ -398,6 +414,21 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn normalize_git_executable_path_preserves_absolute_symlink() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let target = dir.path().join("store-git");
+        let link = dir.path().join("profile-git");
+        fs::write(&target, b"git").expect("write target");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        let normalized = normalize_git_executable_path(link.clone());
+
+        assert_eq!(normalized, link);
+        assert_ne!(normalized, target);
+    }
+
     #[test]
     fn git_executable_preference_from_optional_path_covers_all_variants() {
         let relative = PathBuf::from("test-git");
@@ -592,6 +623,54 @@ mod tests {
             git_runtime_probe_count(&probe_log),
             2,
             "running the returned command should invoke the configured executable"
+        );
+    }
+
+    #[test]
+    fn git_command_prepends_custom_git_parent_to_path() {
+        let _lock = lock_git_runtime_test();
+        let (_dir, script) = create_git_probe_script("git version 5.5.5-test", "", 0, None);
+        let _restore = GitRuntimePreferenceResetGuard::install(GitExecutablePreference::Custom(
+            script.clone(),
+        ));
+
+        let command = git_command();
+        let path_env = command
+            .get_envs()
+            .find(|(name, _)| *name == OsStr::new("PATH"))
+            .and_then(|(_, value)| value.map(ToOwned::to_owned))
+            .expect("custom git command should set PATH");
+        let paths: Vec<_> = std::env::split_paths(&path_env).collect();
+
+        assert_eq!(
+            paths.first().map(PathBuf::as_path),
+            script.parent(),
+            "custom git parent should be first in PATH"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn custom_git_can_resolve_sibling_helper_from_path() {
+        let _lock = lock_git_runtime_test();
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let git = dir.path().join("git");
+        let gpg = dir.path().join("gpg");
+
+        fs::write(&git, "#!/bin/sh\ngpg --version\n").expect("write git script");
+        fs::write(&gpg, "#!/bin/sh\nprintf 'sibling gpg 1.0\\n'\n").expect("write gpg script");
+        for path in [&git, &gpg] {
+            let mut permissions = fs::metadata(path).expect("script metadata").permissions();
+            permissions.set_mode(0o700);
+            fs::set_permissions(path, permissions).expect("set script permissions");
+        }
+
+        let _restore =
+            GitRuntimePreferenceResetGuard::install(GitExecutablePreference::Custom(git));
+
+        assert_eq!(
+            current_git_runtime().version_output(),
+            Some("sibling gpg 1.0")
         );
     }
 

--- a/crates/gitcomet-git-gix/src/util.rs
+++ b/crates/gitcomet-git-gix/src/util.rs
@@ -460,7 +460,8 @@ pub(crate) fn git_command_failed_error(label: &str, output: Output) -> Error {
         .into_iter()
         .map(bytes_to_text_preserving_utf8)
         .map(|text| text.trim().to_string())
-        .find(|text| !text.is_empty());
+        .find(|text| !text.is_empty())
+        .map(add_git_failure_hint);
     Error::new(ErrorKind::Git(GitFailure::new(
         label,
         GitFailureId::CommandFailed,
@@ -469,6 +470,22 @@ pub(crate) fn git_command_failed_error(label: &str, output: Output) -> Error {
         stderr,
         detail,
     )))
+}
+
+fn add_git_failure_hint(mut detail: String) -> String {
+    if git_failure_looks_like_missing_gpg(&detail)
+        && !detail.contains("git config --global gpg.program")
+    {
+        detail.push_str(
+            "\n\nHint: Git could not complete GPG signing. GitComet may be running with a GUI app PATH that differs from your shell PATH. If Git cannot find gpg, configure an absolute GPG path with `git config --global gpg.program /path/to/gpg`, or make gpg available on GitComet's PATH.",
+        );
+    }
+    detail
+}
+
+fn git_failure_looks_like_missing_gpg(detail: &str) -> bool {
+    let lower = detail.to_ascii_lowercase();
+    lower.contains("cannot run gpg") || lower.contains("gpg failed to sign the data")
 }
 
 fn run_command_with_timeout(
@@ -1207,6 +1224,20 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn failing_command_with_missing_gpg() -> Command {
+        shell_command(
+            "printf 'error: cannot run gpg: No such file or directory\nerror: gpg failed to sign the data:\nfatal: failed to write commit object\n' >&2; exit 128",
+        )
+    }
+
+    #[cfg(windows)]
+    fn failing_command_with_missing_gpg() -> Command {
+        shell_command(
+            "[Console]::Error.Write(\"error: cannot run gpg: No such file or directory`nerror: gpg failed to sign the data:`nfatal: failed to write commit object`n\"); exit 128",
+        )
+    }
+
+    #[cfg(unix)]
     fn sleep_command(seconds: u64) -> Command {
         shell_command(&format!("sleep {seconds}"))
     }
@@ -1249,6 +1280,22 @@ mod tests {
                 assert_eq!(failure.stderr(), b"");
                 assert_eq!(failure.detail(), Some("stdout only"));
                 assert_eq!(failure.to_string(), "git synthetic failed: stdout only");
+            }
+            other => panic!("expected structured git failure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_git_failure_adds_gpg_signing_hint() {
+        let err = run_git_with_output(failing_command_with_missing_gpg(), "git commit")
+            .expect_err("expected failing command");
+
+        match err.kind() {
+            ErrorKind::Git(failure) => {
+                let detail = failure.detail().expect("expected failure detail");
+                assert!(detail.contains("cannot run gpg"));
+                assert!(detail.contains("GUI app PATH"));
+                assert!(detail.contains("git config --global gpg.program /path/to/gpg"));
             }
             other => panic!("expected structured git failure, got {other:?}"),
         }

--- a/crates/gitcomet-ui-gpui/src/view/settings_window.rs
+++ b/crates/gitcomet-ui-gpui/src/view/settings_window.rs
@@ -465,7 +465,7 @@ fn applied_git_executable_path(runtime: &GitRuntimeState) -> Option<PathBuf> {
 }
 
 fn git_executable_scope_note() -> &'static str {
-    "Applies only to the main GitComet browser window. Git-invoked command modes keep using git from System PATH."
+    "Applies to the main GitComet browser window. Git-invoked command modes keep using git from System PATH. Helper tools such as gpg are resolved by Git from the app environment unless configured in Git."
 }
 
 impl SettingsWindowView {
@@ -3206,7 +3206,7 @@ impl Render for SettingsWindowView {
                         "settings_window_git_executable_custom",
                         "Custom executable",
                         Some(
-                            "Use a specific Git binary, such as a newer standalone installation."
+                            "Use a specific Git binary and add its directory when Git resolves helper tools."
                                 .into(),
                         ),
                         self.git_executable_mode == GitExecutableMode::Custom,


### PR DESCRIPTION
Keep custom Git executable paths stable by preserving absolute symlinks instead of canonicalizing them into volatile store paths. When a custom  Git executable is configured, prepend its parent directory to PATH so Git  can resolve sibling helper tools such as gpg.

Tries to fix: https://github.com/Auto-Explore/GitComet/issues/206