### PR TITLE
feat: persist diff view mode (inline/split) across sessions

### DIFF
--- a/crates/gitcomet-state/src/session.rs
+++ b/crates/gitcomet-state/src/session.rs
@@ -33,6 +33,7 @@ pub struct UiSession {
     pub diff_scroll_sync: Option<String>,
     pub diff_content_mode: Option<String>,
     pub diff_whitespace_mode: Option<String>,
+    pub diff_view_mode: Option<String>,
     pub diff_reveal_whitespace_chars: Option<bool>,
     pub diff_word_wrap: Option<bool>,
     pub diff_show_line_numbers: Option<bool>,
@@ -141,6 +142,7 @@ struct UiSessionFile {
     diff_scroll_sync: Option<String>,
     diff_content_mode: Option<String>,
     diff_whitespace_mode: Option<String>,
+    diff_view_mode: Option<String>,
     diff_reveal_whitespace_chars: Option<bool>,
     diff_word_wrap: Option<bool>,
     diff_show_line_numbers: Option<bool>,
@@ -224,6 +226,7 @@ pub fn load_from_path(path: &Path) -> UiSession {
         diff_scroll_sync: file.diff_scroll_sync,
         diff_content_mode: file.diff_content_mode,
         diff_whitespace_mode: file.diff_whitespace_mode,
+        diff_view_mode: file.diff_view_mode,
         diff_reveal_whitespace_chars: file.diff_reveal_whitespace_chars,
         diff_word_wrap: file.diff_word_wrap,
         diff_show_line_numbers: file.diff_show_line_numbers,
@@ -515,6 +518,7 @@ pub struct UiSettings {
     pub diff_scroll_sync: Option<String>,
     pub diff_content_mode: Option<String>,
     pub diff_whitespace_mode: Option<String>,
+    pub diff_view_mode: Option<String>,
     pub diff_reveal_whitespace_chars: Option<bool>,
     pub diff_word_wrap: Option<bool>,
     pub diff_show_line_numbers: Option<bool>,
@@ -590,6 +594,9 @@ pub fn persist_ui_settings_to_path(settings: UiSettings, path: &Path) -> io::Res
     }
     if let Some(value) = settings.diff_whitespace_mode {
         file.diff_whitespace_mode = Some(value);
+    }
+    if let Some(value) = settings.diff_view_mode {
+        file.diff_view_mode = Some(value);
     }
     if let Some(value) = settings.diff_reveal_whitespace_chars {
         file.diff_reveal_whitespace_chars = Some(value);

--- a/crates/gitcomet-state/tests/session_integration.rs
+++ b/crates/gitcomet-state/tests/session_integration.rs
@@ -304,6 +304,7 @@ fn persist_ui_settings_to_path_updates_optional_fields_and_requires_both_window_
             change_tracking_view: Some("split_untracked".to_string()),
             diff_scroll_sync: Some("both".to_string()),
             diff_whitespace_mode: Some("ignore".to_string()),
+            diff_view_mode: Some("inline".to_string()),
             diff_reveal_whitespace_chars: Some(true),
             diff_word_wrap: Some(true),
             change_tracking_height: Some(222),
@@ -340,6 +341,7 @@ fn persist_ui_settings_to_path_updates_optional_fields_and_requires_both_window_
     );
     assert_eq!(loaded.diff_scroll_sync.as_deref(), Some("both"));
     assert_eq!(loaded.diff_whitespace_mode.as_deref(), Some("ignore"));
+    assert_eq!(loaded.diff_view_mode.as_deref(), Some("inline"));
     assert_eq!(loaded.diff_reveal_whitespace_chars, Some(true));
     assert_eq!(loaded.diff_word_wrap, Some(true));
     assert_eq!(loaded.change_tracking_height, Some(222));

--- a/crates/gitcomet-ui-gpui/src/view/mod.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod.rs
@@ -748,6 +748,11 @@ impl GitCometView {
             .as_deref()
             .and_then(DiffWhitespaceMode::from_key)
             .unwrap_or_default();
+        let diff_view_mode = ui_session
+            .diff_view_mode
+            .as_deref()
+            .and_then(DiffViewMode::from_key)
+            .unwrap_or(DiffViewMode::Split);
         let diff_reveal_whitespace_chars = ui_session.diff_reveal_whitespace_chars.unwrap_or(false);
         let diff_word_wrap = ui_session.diff_word_wrap.unwrap_or(false);
         let diff_show_line_numbers = ui_session.diff_show_line_numbers.unwrap_or(true);
@@ -888,6 +893,7 @@ impl GitCometView {
                 diff_scroll_sync,
                 diff_content_mode,
                 diff_whitespace_mode,
+                diff_view_mode,
                 diff_reveal_whitespace_chars,
                 diff_word_wrap,
                 diff_show_line_numbers,
@@ -1103,6 +1109,7 @@ impl GitCometView {
             diff_scroll_sync,
             diff_content_mode,
             diff_whitespace_mode,
+            diff_view_mode,
             diff_reveal_whitespace_chars,
             diff_word_wrap,
             diff_show_line_numbers,
@@ -1388,6 +1395,21 @@ impl GitCometView {
         self.diff_scroll_sync = next;
         self.main_pane
             .update(cx, |pane, cx| pane.set_diff_scroll_sync(next, cx));
+        self.schedule_ui_settings_persist(cx);
+    }
+
+    pub(in crate::view) fn set_diff_view_mode(
+        &mut self,
+        next: DiffViewMode,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        if self.diff_view_mode == next {
+            return;
+        }
+
+        self.diff_view_mode = next;
+        self.main_pane
+            .update(cx, |pane, cx| pane.set_diff_view_mode(next, cx));
         self.schedule_ui_settings_persist(cx);
     }
 

--- a/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
@@ -165,6 +165,30 @@ pub(super) enum DiffViewMode {
     Split,
 }
 
+impl DiffViewMode {
+    pub(super) const fn key(self) -> &'static str {
+        match self {
+            Self::Inline => "inline",
+            Self::Split => "split",
+        }
+    }
+
+    pub(super) fn from_key(raw: &str) -> Option<Self> {
+        match raw {
+            "inline" => Some(Self::Inline),
+            "split" => Some(Self::Split),
+            _ => None,
+        }
+    }
+
+    pub(super) const fn settings_label(self) -> &'static str {
+        match self {
+            Self::Inline => "Inline",
+            Self::Split => "Split",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(super) enum RenderedPreviewKind {
     Svg,
@@ -3267,6 +3291,7 @@ pub struct GitCometView {
     pub(super) diff_scroll_sync: DiffScrollSync,
     pub(super) diff_content_mode: DiffContentMode,
     pub(super) diff_whitespace_mode: DiffWhitespaceMode,
+    pub(super) diff_view_mode: DiffViewMode,
     pub(super) diff_reveal_whitespace_chars: bool,
     pub(super) diff_word_wrap: bool,
     pub(super) diff_show_line_numbers: bool,

--- a/crates/gitcomet-ui-gpui/src/view/panels/main/diff_view.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/main/diff_view.rs
@@ -343,14 +343,32 @@ impl MainPaneView {
                         self.diff_view = DiffViewMode::Split;
                         self.clear_diff_text_style_caches();
                         handled = true;
+                        let root_view = self.root_view.clone();
+                        cx.defer(move |cx| {
+                            if let Some(root) = root_view.upgrade() {
+                                root.update(cx, |root, cx| {
+                                    root.set_diff_view_mode(DiffViewMode::Split, cx);
+                                });
+                            }
+                        });
                     } else if !markdown_preview_active && !self.is_file_preview_active() {
-                        self.diff_view = if key == "i" {
+                        let new_mode = if key == "i" {
                             DiffViewMode::Inline
                         } else {
                             DiffViewMode::Split
                         };
+                        self.diff_view = new_mode;
                         self.clear_diff_text_style_caches();
                         handled = true;
+                        let root_view = self.root_view.clone();
+                        let mode = new_mode;
+                        cx.defer(move |cx| {
+                            if let Some(root) = root_view.upgrade() {
+                                root.update(cx, |root, cx| {
+                                    root.set_diff_view_mode(mode, cx);
+                                });
+                            }
+                        });
                     }
                 }
                 "w" if !markdown_preview_active && !conflict_preview_active => {
@@ -1776,6 +1794,14 @@ impl MainPaneView {
                             this.diff_search_recompute_matches_preserving_current();
                         }
                         this.restore_diff_panel_focus_after_toolbar_action(window, cx);
+                        let root_view = this.root_view.clone();
+                        cx.defer(move |cx| {
+                            if let Some(root) = root_view.upgrade() {
+                                root.update(cx, |root, cx| {
+                                    root.set_diff_view_mode(DiffViewMode::Inline, cx);
+                                });
+                            }
+                        });
                         cx.notify();
                     })
                     .debug_selector(|| "diff_inline".to_string())
@@ -1793,6 +1819,14 @@ impl MainPaneView {
                             this.diff_search_recompute_matches_preserving_current();
                         }
                         this.restore_diff_panel_focus_after_toolbar_action(window, cx);
+                        let root_view = this.root_view.clone();
+                        cx.defer(move |cx| {
+                            if let Some(root) = root_view.upgrade() {
+                                root.update(cx, |root, cx| {
+                                    root.set_diff_view_mode(DiffViewMode::Split, cx);
+                                });
+                            }
+                        });
                         cx.notify();
                     })
                     .debug_selector(|| "diff_split".to_string())

--- a/crates/gitcomet-ui-gpui/src/view/panes/main/core_impl.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panes/main/core_impl.rs
@@ -900,6 +900,7 @@ impl MainPaneView {
         diff_scroll_sync: DiffScrollSync,
         diff_content_mode: DiffContentMode,
         diff_whitespace_mode: DiffWhitespaceMode,
+        diff_view_mode: DiffViewMode,
         diff_reveal_whitespace_chars: bool,
         diff_word_wrap: bool,
         diff_show_line_numbers: bool,
@@ -1118,7 +1119,7 @@ impl MainPaneView {
             layout_sidebar_collapsed: false,
             layout_details_collapsed: false,
             reveal_whitespace_chars: diff_reveal_whitespace_chars,
-            diff_view: DiffViewMode::Split,
+            diff_view: diff_view_mode,
             rendered_preview_modes: RenderedPreviewModes::default(),
             diff_word_wrap,
             diff_show_line_numbers,
@@ -2761,6 +2762,19 @@ impl MainPaneView {
         self.diff_scroll_sync = next;
         self.sync_diff_split_scroll();
         self.sync_conflict_preview_scroll();
+        cx.notify();
+    }
+
+    pub(in crate::view) fn set_diff_view_mode(
+        &mut self,
+        next: DiffViewMode,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        if self.diff_view == next {
+            return;
+        }
+
+        self.diff_view = next;
         cx.notify();
     }
 

--- a/crates/gitcomet-ui-gpui/src/view/panes/main/helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panes/main/helpers.rs
@@ -2325,7 +2325,7 @@ pub(crate) struct MainPaneView {
     pub(in crate::view) theme: AppTheme,
     pub(in crate::view) date_time_format: DateTimeFormat,
     pub(super) _ui_model_subscription: gpui::Subscription,
-    pub(super) root_view: WeakEntity<GitCometView>,
+    pub(in crate::view) root_view: WeakEntity<GitCometView>,
     pub(in crate::view) tooltip_host: WeakEntity<TooltipHost>,
     pub(super) notify_fingerprint: u64,
     pub(in crate::view) active_context_menu_invoker: Option<SharedString>,

--- a/crates/gitcomet-ui-gpui/src/view/settings_window.rs
+++ b/crates/gitcomet-ui-gpui/src/view/settings_window.rs
@@ -77,6 +77,19 @@ const DIFF_CONTENT_MODE_OPTIONS: &[(&str, DiffContentMode, &str)] = &[
     ),
 ];
 
+const DIFF_VIEW_MODE_OPTIONS: &[(&str, DiffViewMode, &str)] = &[
+    (
+        "settings_window_diff_view_mode_inline",
+        DiffViewMode::Inline,
+        "Show changes inline.",
+    ),
+    (
+        "settings_window_diff_view_mode_split",
+        DiffViewMode::Split,
+        "Show changes in split view.",
+    ),
+];
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SettingsSection {
     Theme,
@@ -88,6 +101,7 @@ enum SettingsSection {
     ChangeTracking,
     DiffContentMode,
     Diff,
+    DiffViewMode,
     GitLogDefaultMode,
     GitLogColumns,
     GitLogTagFetch,
@@ -161,12 +175,14 @@ pub(crate) struct SettingsWindowView {
     change_tracking_scroll: UniformListScrollHandle,
     diff_content_mode_scroll: UniformListScrollHandle,
     diff_scroll_sync_scroll: UniformListScrollHandle,
+    diff_view_mode_scroll: UniformListScrollHandle,
     date_time_format: DateTimeFormat,
     timezone: Timezone,
     show_timezone: bool,
     change_tracking_view: ChangeTrackingView,
     diff_content_mode: DiffContentMode,
     diff_whitespace_mode: DiffWhitespaceMode,
+    diff_view_mode: DiffViewMode,
     diff_reveal_whitespace_chars: bool,
     diff_word_wrap: bool,
     diff_show_line_numbers: bool,
@@ -512,6 +528,11 @@ impl SettingsWindowView {
             .as_deref()
             .and_then(DiffWhitespaceMode::from_key)
             .unwrap_or_default();
+        let diff_view_mode = ui_session
+            .diff_view_mode
+            .as_deref()
+            .and_then(DiffViewMode::from_key)
+            .unwrap_or(DiffViewMode::Split);
         let diff_reveal_whitespace_chars = ui_session.diff_reveal_whitespace_chars.unwrap_or(false);
         let diff_word_wrap = ui_session.diff_word_wrap.unwrap_or(false);
         let diff_show_line_numbers = ui_session.diff_show_line_numbers.unwrap_or(true);
@@ -599,12 +620,14 @@ impl SettingsWindowView {
             change_tracking_scroll: UniformListScrollHandle::default(),
             diff_content_mode_scroll: UniformListScrollHandle::default(),
             diff_scroll_sync_scroll: UniformListScrollHandle::default(),
+            diff_view_mode_scroll: UniformListScrollHandle::default(),
             date_time_format,
             timezone,
             show_timezone,
             change_tracking_view,
             diff_content_mode,
             diff_whitespace_mode,
+            diff_view_mode,
             diff_reveal_whitespace_chars,
             diff_word_wrap,
             diff_show_line_numbers,
@@ -660,6 +683,7 @@ impl SettingsWindowView {
             diff_scroll_sync: Some(self.diff_scroll_sync.key().to_string()),
             diff_content_mode: Some(self.diff_content_mode.key().to_string()),
             diff_whitespace_mode: Some(self.diff_whitespace_mode.key().to_string()),
+            diff_view_mode: Some(self.diff_view_mode.key().to_string()),
             diff_reveal_whitespace_chars: Some(self.diff_reveal_whitespace_chars),
             diff_word_wrap: Some(self.diff_word_wrap),
             diff_show_line_numbers: Some(self.diff_show_line_numbers),
@@ -1062,6 +1086,20 @@ impl SettingsWindowView {
         self.persist_preferences(cx);
         self.update_main_windows(cx, move |view, _window, cx| {
             view.set_diff_whitespace_mode(next, cx);
+        });
+        cx.notify();
+    }
+
+    fn set_diff_view_mode(&mut self, next: DiffViewMode, cx: &mut gpui::Context<Self>) {
+        if self.diff_view_mode == next {
+            return;
+        }
+
+        self.diff_view_mode = next;
+        self.expanded_section = None;
+        self.persist_preferences(cx);
+        self.update_main_windows(cx, move |view, _window, cx| {
+            view.set_diff_view_mode(next, cx);
         });
         cx.notify();
     }
@@ -2096,6 +2134,31 @@ impl SettingsWindowView {
             .collect()
     }
 
+    fn render_diff_view_mode_option_rows(
+        this: &mut Self,
+        range: Range<usize>,
+        _window: &mut Window,
+        cx: &mut gpui::Context<Self>,
+    ) -> Vec<AnyElement> {
+        let theme = this.theme;
+        range
+            .filter_map(|ix| DIFF_VIEW_MODE_OPTIONS.get(ix).copied())
+            .map(|(id, option, detail)| {
+                this.option_row(
+                    id,
+                    option.settings_label(),
+                    Some(detail.into()),
+                    this.diff_view_mode == option,
+                    theme,
+                )
+                .on_click(cx.listener(move |this, _e: &ClickEvent, _window, cx| {
+                    this.set_diff_view_mode(option, cx);
+                }))
+                .into_any_element()
+            })
+            .collect()
+    }
+
     fn render_diff_content_mode_option_rows(
         this: &mut Self,
         range: Range<usize>,
@@ -2931,6 +2994,54 @@ impl Render for SettingsWindowView {
                             "settings_window_diff_content_mode_scrollbar",
                             self.diff_content_mode_scroll.clone(),
                             DIFF_CONTENT_MODE_OPTIONS.len(),
+                            SETTINGS_DROPDOWN_DETAIL_ROW_HEIGHT_PX,
+                            SETTINGS_DROPDOWN_DETAIL_LIST_EXTRA_HEIGHT_PX,
+                            list,
+                            theme,
+                        ));
+                    }
+
+                    let diff_view_mode_row = self
+                        .summary_row(
+                            "settings_window_diff_view_mode",
+                            "View mode",
+                            self.diff_view_mode.settings_label().into(),
+                            self.expanded_section == Some(SettingsSection::DiffViewMode),
+                            theme,
+                        )
+                        .on_click(cx.listener(|this, _e: &ClickEvent, _window, cx| {
+                            this.toggle_section(SettingsSection::DiffViewMode, cx);
+                        }));
+
+                    diff_card = diff_card.child(diff_view_mode_row);
+
+                    if self.expanded_section == Some(SettingsSection::DiffViewMode) {
+                        let list = uniform_list(
+                            "settings_window_diff_view_mode_list",
+                            DIFF_VIEW_MODE_OPTIONS.len(),
+                            cx.processor(Self::render_diff_view_mode_option_rows),
+                        )
+                        .w_full()
+                        .min_w(px(0.0))
+                        .h_full()
+                        .min_h(px(0.0))
+                        .track_scroll(&self.diff_view_mode_scroll)
+                        .on_scroll_wheel({
+                            let scroll = self.diff_view_mode_scroll.clone();
+                            move |event, window, cx| {
+                                if uniform_list_should_stop_scroll_propagation(
+                                    &scroll, event, window,
+                                ) {
+                                    cx.stop_propagation();
+                                }
+                            }
+                        });
+                        let list = restrict_scroll_to_vertical_axis(list).into_any_element();
+                        diff_card = diff_card.child(self.dropdown_list_container(
+                            "settings_window_diff_view_mode_list_container",
+                            "settings_window_diff_view_mode_scrollbar",
+                            self.diff_view_mode_scroll.clone(),
+                            DIFF_VIEW_MODE_OPTIONS.len(),
                             SETTINGS_DROPDOWN_DETAIL_ROW_HEIGHT_PX,
                             SETTINGS_DROPDOWN_DETAIL_LIST_EXTRA_HEIGHT_PX,
                             list,

--- a/crates/gitcomet-ui-gpui/src/view/tooltip.rs
+++ b/crates/gitcomet-ui-gpui/src/view/tooltip.rs
@@ -125,6 +125,7 @@ impl GitCometView {
                             diff_whitespace_mode: Some(
                                 this.diff_whitespace_mode.key().to_string(),
                             ),
+                            diff_view_mode: Some(this.diff_view_mode.key().to_string()),
                             diff_reveal_whitespace_chars: Some(
                                 this.diff_reveal_whitespace_chars,
                             ),


### PR DESCRIPTION
- Add diff_view_mode field to UiSession and UiSettings in gitcomet-state

- Implement serialization/deserialization for diff_view_mode                                                                                                                            
- Add DiffViewMode helper methods (key, from_key, settings_label)                                                                                                                       
- Propagate diff_view_mode through GitCometView and MainPaneView                                                                                                                        
- Update keyboard shortcuts ('i'/'s') to persist view mode changes                                                                                                                      
- Update toolbar buttons (Inline/Split) to persist view mode changes                                                                                                                    
- Add View mode setting to Settings window Diff section                                                                                                                                 
- Fix root_view visibility to enable persistence from diff view                                                                                                                         
- Add test coverage for diff_view_mode persistence


Implements: https://github.com/Auto-Explore/GitComet/issues/231