### PR TITLE
Changed diff staging section shortcuts to work globally without requiring to open menu

### DIFF
--- a/crates/gitcomet-ui-gpui/src/app.rs
+++ b/crates/gitcomet-ui-gpui/src/app.rs
@@ -615,10 +615,11 @@ fn install_app_actions(cx: &mut App, backend: Arc<dyn GitBackend>) {
 fn install_global_diff_shortcut_fallback(cx: &mut App) {
     cx.observe_keystrokes(|event, window, cx| {
         if !is_diff_shortcut_candidate(&event.keystroke)
-            || event
-                .context_stack
-                .iter()
-                .any(|context| context.contains("TextInput"))
+            || event.context_stack.iter().any(|context| {
+                context.contains("TextInput")
+                    || context.contains("ContextMenu")
+                    || context.contains("PopoverPrompt")
+            })
         {
             return;
         }

--- a/crates/gitcomet-ui-gpui/src/view/mod.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod.rs
@@ -78,7 +78,7 @@ pub(crate) fn is_diff_shortcut_candidate(keystroke: &gpui::Keystroke) -> bool {
         || ((mods.control || mods.platform)
             && !mods.alt
             && !mods.function
-            && matches!(key, "a" | "c"))
+            && matches!(key, "a" | "c" | "s" | "d" | "h" | "u"))
         || (matches!(key, "a" | "b" | "c" | "d") && no_command_modifiers)
 }
 

--- a/crates/gitcomet-ui-gpui/src/view/panels/main/diff_view.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/main/diff_view.rs
@@ -297,6 +297,142 @@ impl MainPaneView {
             handled = self.try_select_adjacent_diff_file(repo_id, direction, window, cx);
         }
 
+        if !handled
+            && !self.is_inline_submodule_diff_active()
+            && (mods.control || mods.platform)
+            && !mods.alt
+            && !mods.function
+            && !self
+                .diff_raw_input
+                .read(cx)
+                .focus_handle()
+                .is_focused(window)
+            && !self
+                .diff_search_input
+                .read(cx)
+                .focus_handle()
+                .is_focused(window)
+            && let Some(repo_id) = self.active_repo_id()
+            && let Some(repo) = self.active_repo()
+            && let Some(diff_target) = repo.diff_state.diff_target.clone()
+            && let DiffTarget::WorkingTree { path, area } = &diff_target
+        {
+            let path = path.clone();
+            let area = *area;
+            let status_ready = repo.status_entries_for_area(area).is_some();
+
+            match key {
+                "s" if area == DiffArea::Unstaged && !mods.shift => {
+                    let change_tracking_view = self.active_change_tracking_view(cx);
+                    let next_path_in_section = status_nav::status_navigation_context_for_repo(
+                        repo,
+                        &diff_target,
+                        change_tracking_view,
+                    )
+                    .and_then(|navigation| navigation.next_or_prev_path());
+
+                    if status_ready {
+                        self.store.dispatch(Msg::StagePath {
+                            repo_id,
+                            path: path.clone(),
+                        });
+                        if let Some(next_path) = next_path_in_section {
+                            self.store.dispatch(Msg::SelectDiff {
+                                repo_id,
+                                target: DiffTarget::WorkingTree {
+                                    path: next_path,
+                                    area: DiffArea::Unstaged,
+                                },
+                            });
+                        } else {
+                            self.clear_diff_selection_or_exit(repo_id, cx);
+                        }
+                    } else {
+                        self.store.dispatch(Msg::StagePath {
+                            repo_id,
+                            path: path.clone(),
+                        });
+                    }
+                    self.rebuild_diff_cache(cx);
+                    handled = true;
+                }
+                "u" if area == DiffArea::Staged && !mods.shift => {
+                    let change_tracking_view = self.active_change_tracking_view(cx);
+                    let next_path_in_section = status_nav::status_navigation_context_for_repo(
+                        repo,
+                        &diff_target,
+                        change_tracking_view,
+                    )
+                    .and_then(|navigation| navigation.next_or_prev_path());
+
+                    if status_ready {
+                        self.store.dispatch(Msg::UnstagePath {
+                            repo_id,
+                            path: path.clone(),
+                        });
+                        if let Some(next_path) = next_path_in_section {
+                            self.store.dispatch(Msg::SelectDiff {
+                                repo_id,
+                                target: DiffTarget::WorkingTree {
+                                    path: next_path,
+                                    area: DiffArea::Staged,
+                                },
+                            });
+                        } else {
+                            self.clear_diff_selection_or_exit(repo_id, cx);
+                        }
+                    } else {
+                        self.store.dispatch(Msg::UnstagePath {
+                            repo_id,
+                            path: path.clone(),
+                        });
+                    }
+                    self.rebuild_diff_cache(cx);
+                    handled = true;
+                }
+                "d" if !mods.shift => {
+                    let bounds = window.window_bounds().get_bounds();
+                    let anchor = point(
+                        (bounds.size.width * 0.5).max(px(64.0)),
+                        (bounds.size.height * 0.25).max(px(24.0)),
+                    );
+                    self.open_popover_at(
+                        PopoverKind::DiscardChangesConfirm {
+                            repo_id,
+                            area,
+                            path: Some(path),
+                        },
+                        anchor,
+                        window,
+                        cx,
+                    );
+                    handled = true;
+                }
+                "h" if !mods.shift => {
+                    let bounds = window.window_bounds().get_bounds();
+                    let anchor = point(
+                        (bounds.size.width * 0.5).max(px(64.0)),
+                        (bounds.size.height * 0.25).max(px(24.0)),
+                    );
+                    self.open_popover_at(
+                        PopoverKind::FileHistory {
+                            repo_id,
+                            path: path.clone(),
+                        },
+                        anchor,
+                        window,
+                        cx,
+                    );
+                    handled = true;
+                }
+                "c" if mods.shift => {
+                    crate::clipboard::write_text(cx, path.display().to_string());
+                    handled = true;
+                }
+                _ => {}
+            }
+        }
+
         let copy_target_is_focused = self
             .diff_raw_input
             .read(cx)
@@ -309,6 +445,7 @@ impl MainPaneView {
                 && (mods.control || mods.platform)
                 && !mods.alt
                 && !mods.function
+                && !mods.shift
                 && key == "c"
                 && self.diff_text_has_selection()
             {
@@ -434,6 +571,7 @@ impl MainPaneView {
             && (mods.control || mods.platform)
             && !mods.alt
             && !mods.function
+            && !mods.shift
             && key == "c"
             && self.diff_text_has_selection()
         {
@@ -1943,6 +2081,7 @@ impl MainPaneView {
                     ))
                     .style(components::ButtonStyle::Transparent)
                     .on_click(theme, cx, move |this, _e, _w, cx| {
+                        this.clear_status_multi_selection(repo_id, cx);
                         this.clear_diff_selection_or_exit(repo_id, cx);
                         cx.notify();
                     })

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu.rs
@@ -145,7 +145,12 @@ pub(in super::super) fn context_menu_shortcut_entry_ix(
             return None;
         }
         let shortcut = shortcut.as_ref()?;
-        shortcut.as_ref().eq_ignore_ascii_case(key).then_some(ix)
+        let shortcut_key = shortcut
+            .as_ref()
+            .rsplit('+')
+            .next()
+            .unwrap_or(shortcut.as_ref());
+        shortcut_key.eq_ignore_ascii_case(key).then_some(ix)
     })
 }
 
@@ -1322,7 +1327,7 @@ mod tests {
 
         assert_eq!(context_menu_shortcut_entry_ix(&model, "a"), Some(4));
         assert_eq!(context_menu_shortcut_entry_ix(&model, "A"), Some(4));
-        assert_eq!(context_menu_shortcut_entry_ix(&model, "c"), None);
+        assert_eq!(context_menu_shortcut_entry_ix(&model, "c"), Some(3));
         assert_eq!(context_menu_shortcut_entry_ix(&model, "e"), None);
         assert_eq!(context_menu_shortcut_entry_ix(&model, "enter"), None);
     }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/diff_hunk.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/diff_hunk.rs
@@ -5,8 +5,8 @@ fn diff_hunk_primary_metadata(
 ) -> (bool, &'static str, &'static str, Option<&'static str>) {
     match diff_target {
         Some(DiffTarget::WorkingTree { area, .. }) => match area {
-            DiffArea::Unstaged => (false, "Stage hunk", "icons/plus.svg", Some("S")),
-            DiffArea::Staged => (false, "Unstage hunk", "icons/minus.svg", Some("U")),
+            DiffArea::Unstaged => (false, "Stage hunk", "icons/plus.svg", Some("Ctrl+S")),
+            DiffArea::Staged => (false, "Unstage hunk", "icons/minus.svg", Some("Ctrl+U")),
         },
         _ => (true, "Stage/Unstage hunk", "icons/plus.svg", None),
     }
@@ -66,7 +66,7 @@ pub(super) fn model(this: &PopoverHost, repo_id: RepoId, src_ix: usize) -> Conte
     items.push(ContextMenuItem::Entry {
         label: "Discard hunk".into(),
         icon: Some("icons/refresh.svg".into()),
-        shortcut: Some("D".into()),
+        shortcut: Some("Ctrl+D".into()),
         disabled: !is_unstaged || patch.is_none(),
         action: Box::new(ContextMenuAction::ApplyWorktreePatch {
             repo_id,
@@ -93,7 +93,7 @@ mod tests {
         assert!(!disabled);
         assert_eq!(label, "Stage hunk");
         assert_eq!(icon, "icons/plus.svg");
-        assert_eq!(shortcut, Some("S"));
+        assert_eq!(shortcut, Some("Ctrl+S"));
         assert!(matches!(
             diff_hunk_primary_action(RepoId(9), 4, Some(&target)),
             ContextMenuAction::StageHunk {
@@ -114,7 +114,7 @@ mod tests {
         assert!(!disabled);
         assert_eq!(label, "Unstage hunk");
         assert_eq!(icon, "icons/minus.svg");
-        assert_eq!(shortcut, Some("U"));
+        assert_eq!(shortcut, Some("Ctrl+U"));
         assert!(matches!(
             diff_hunk_primary_action(RepoId(10), 5, Some(&target)),
             ContextMenuAction::UnstageHunk {

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/status_file.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/status_file.rs
@@ -152,7 +152,7 @@ pub(super) fn model(
     items.push(ContextMenuItem::Entry {
         label: "File history".into(),
         icon: Some("icons/refresh.svg".into()),
-        shortcut: Some("H".into()),
+        shortcut: Some("Ctrl+H".into()),
         disabled: false,
         action: Box::new(ContextMenuAction::OpenPopover {
             kind: PopoverKind::FileHistory {
@@ -171,7 +171,7 @@ pub(super) fn model(
                 "Resolve using ours".into()
             },
             icon: Some("icons/arrow_left.svg".into()),
-            shortcut: Some("O".into()),
+            shortcut: Some("Ctrl+O".into()),
             disabled: false,
             action: Box::new(ContextMenuAction::CheckoutConflictSideSelectionOrPath {
                 repo_id,
@@ -187,7 +187,7 @@ pub(super) fn model(
                 "Resolve using theirs".into()
             },
             icon: Some("icons/arrow_right.svg".into()),
-            shortcut: Some("T".into()),
+            shortcut: Some("Ctrl+T".into()),
             disabled: false,
             action: Box::new(ContextMenuAction::CheckoutConflictSideSelectionOrPath {
                 repo_id,
@@ -205,7 +205,7 @@ pub(super) fn model(
                 "Resolve manually… (select 1 file)".into()
             },
             icon: Some("icons/pencil.svg".into()),
-            shortcut: Some("M".into()),
+            shortcut: Some("Ctrl+M".into()),
             disabled: !can_manual,
             action: Box::new(ContextMenuAction::SelectConflictDiff {
                 repo_id,
@@ -238,7 +238,7 @@ pub(super) fn model(
                     "Stage".into()
                 },
                 icon: Some("icons/plus.svg".into()),
-                shortcut: Some("S".into()),
+                shortcut: Some("Ctrl+S".into()),
                 disabled: false,
                 action: Box::new(ContextMenuAction::StageSelectionOrPath {
                     repo_id,
@@ -253,7 +253,7 @@ pub(super) fn model(
                     "Unstage".into()
                 },
                 icon: Some("icons/minus.svg".into()),
-                shortcut: Some("U".into()),
+                shortcut: Some("Ctrl+U".into()),
                 disabled: false,
                 action: Box::new(ContextMenuAction::UnstageSelectionOrPath {
                     repo_id,
@@ -273,7 +273,7 @@ pub(super) fn model(
                 "Discard changes".into()
             },
             icon: Some("icons/refresh.svg".into()),
-            shortcut: Some("D".into()),
+            shortcut: Some("Ctrl+D".into()),
             disabled: !can_discard_worktree_changes,
             action: Box::new(ContextMenuAction::DiscardWorktreeChangesSelectionOrPath {
                 repo_id,
@@ -291,7 +291,7 @@ pub(super) fn model(
     items.push(ContextMenuItem::Entry {
         label: "Copy path".into(),
         icon: Some("icons/copy.svg".into()),
-        shortcut: Some("C".into()),
+        shortcut: Some("Ctrl+Shift+C".into()),
         disabled: false,
         action: Box::new(ContextMenuAction::CopyText {
             text: copy_path_text,
@@ -381,7 +381,7 @@ fn submodule_status_model(
                     "Stage".into()
                 },
                 icon: Some("icons/plus.svg".into()),
-                shortcut: Some("S".into()),
+                shortcut: Some("Ctrl+S".into()),
                 disabled: false,
                 action: Box::new(ContextMenuAction::StageSelectionOrPath {
                     repo_id,
@@ -396,7 +396,7 @@ fn submodule_status_model(
                     "Unstage".into()
                 },
                 icon: Some("icons/minus.svg".into()),
-                shortcut: Some("U".into()),
+                shortcut: Some("Ctrl+U".into()),
                 disabled: false,
                 action: Box::new(ContextMenuAction::UnstageSelectionOrPath {
                     repo_id,
@@ -423,7 +423,7 @@ fn submodule_status_model(
                 "Discard changes".into()
             },
             icon: Some("icons/refresh.svg".into()),
-            shortcut: Some("D".into()),
+            shortcut: Some("Ctrl+D".into()),
             disabled: !can_discard_worktree_changes,
             action: Box::new(ContextMenuAction::DiscardWorktreeChangesSelectionOrPath {
                 repo_id,
@@ -441,7 +441,7 @@ fn submodule_status_model(
     items.push(ContextMenuItem::Entry {
         label: "Copy path".into(),
         icon: Some("icons/copy.svg".into()),
-        shortcut: Some("C".into()),
+        shortcut: Some("Ctrl+Shift+C".into()),
         disabled: false,
         action: Box::new(ContextMenuAction::CopyText {
             text: copy_path_text,

--- a/crates/gitcomet-ui-gpui/src/view/panels/tests/shortcuts.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/tests/shortcuts.rs
@@ -1290,7 +1290,10 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
             },
         )
     });
-    assert_declared_shortcuts(&unstaged_status_model, &["H", "S", "D", "C"]);
+    assert_declared_shortcuts(
+        &unstaged_status_model,
+        &["Ctrl+H", "Ctrl+S", "Ctrl+D", "Ctrl+Shift+C"],
+    );
     assert_shortcut_action!(
         unstaged_status_model,
         "Enter",
@@ -1301,14 +1304,14 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         unstaged_status_model,
-        "H",
+        "Ctrl+H",
         ContextMenuAction::OpenPopover {
             kind: PopoverKind::FileHistory { repo_id: rid, path }
         } if *rid == repo_id && path == &unstaged_path
     );
     assert_shortcut_action!(
         unstaged_status_model,
-        "S",
+        "Ctrl+S",
         ContextMenuAction::StageSelectionOrPath {
             repo_id: rid,
             area,
@@ -1317,7 +1320,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         unstaged_status_model,
-        "D",
+        "Ctrl+D",
         ContextMenuAction::DiscardWorktreeChangesSelectionOrPath {
             repo_id: rid,
             area,
@@ -1326,7 +1329,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         unstaged_status_model,
-        "C",
+        "Ctrl+Shift+C",
         ContextMenuAction::CopyText { text } if copied_path_ends_with(text, &unstaged_path)
     );
 
@@ -1341,7 +1344,10 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
             },
         )
     });
-    assert_declared_shortcuts(&staged_status_model, &["H", "U", "D", "C"]);
+    assert_declared_shortcuts(
+        &staged_status_model,
+        &["Ctrl+H", "Ctrl+U", "Ctrl+D", "Ctrl+Shift+C"],
+    );
     assert_shortcut_action!(
         staged_status_model,
         "Enter",
@@ -1352,14 +1358,14 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         staged_status_model,
-        "H",
+        "Ctrl+H",
         ContextMenuAction::OpenPopover {
             kind: PopoverKind::FileHistory { repo_id: rid, path }
         } if *rid == repo_id && path == &staged_path
     );
     assert_shortcut_action!(
         staged_status_model,
-        "U",
+        "Ctrl+U",
         ContextMenuAction::UnstageSelectionOrPath {
             repo_id: rid,
             area,
@@ -1368,7 +1374,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         staged_status_model,
-        "D",
+        "Ctrl+D",
         ContextMenuAction::DiscardWorktreeChangesSelectionOrPath {
             repo_id: rid,
             area,
@@ -1377,7 +1383,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         staged_status_model,
-        "C",
+        "Ctrl+Shift+C",
         ContextMenuAction::CopyText { text } if copied_path_ends_with(text, &staged_path)
     );
 
@@ -1392,7 +1398,17 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
             },
         )
     });
-    assert_declared_shortcuts(&conflicted_status_model, &["H", "O", "T", "M", "D", "C"]);
+    assert_declared_shortcuts(
+        &conflicted_status_model,
+        &[
+            "Ctrl+H",
+            "Ctrl+O",
+            "Ctrl+T",
+            "Ctrl+M",
+            "Ctrl+D",
+            "Ctrl+Shift+C",
+        ],
+    );
     assert_shortcut_action!(
         conflicted_status_model,
         "Enter",
@@ -1403,14 +1419,14 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         conflicted_status_model,
-        "H",
+        "Ctrl+H",
         ContextMenuAction::OpenPopover {
             kind: PopoverKind::FileHistory { repo_id: rid, path }
         } if *rid == repo_id && path == &conflicted_path
     );
     assert_shortcut_action!(
         conflicted_status_model,
-        "O",
+        "Ctrl+O",
         ContextMenuAction::CheckoutConflictSideSelectionOrPath {
             repo_id: rid,
             area,
@@ -1423,7 +1439,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         conflicted_status_model,
-        "T",
+        "Ctrl+T",
         ContextMenuAction::CheckoutConflictSideSelectionOrPath {
             repo_id: rid,
             area,
@@ -1436,7 +1452,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         conflicted_status_model,
-        "M",
+        "Ctrl+M",
         ContextMenuAction::SelectConflictDiff {
             repo_id: rid,
             path
@@ -1444,7 +1460,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         conflicted_status_model,
-        "D",
+        "Ctrl+D",
         ContextMenuAction::DiscardWorktreeChangesSelectionOrPath {
             repo_id: rid,
             area,
@@ -1453,7 +1469,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         conflicted_status_model,
-        "C",
+        "Ctrl+Shift+C",
         ContextMenuAction::CopyText { text } if copied_path_ends_with(text, &conflicted_path)
     );
 
@@ -1537,10 +1553,10 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     let diff_hunk_unstaged_model = cx.update(|_window, app| {
         context_menu_model_for(&view, app, PopoverKind::DiffHunkMenu { repo_id, src_ix: 3 })
     });
-    assert_declared_shortcuts(&diff_hunk_unstaged_model, &["S", "D"]);
+    assert_declared_shortcuts(&diff_hunk_unstaged_model, &["Ctrl+S", "Ctrl+D"]);
     assert_shortcut_action!(
         diff_hunk_unstaged_model,
-        "S",
+        "Ctrl+S",
         ContextMenuAction::StageHunk {
             repo_id: rid,
             src_ix
@@ -1548,7 +1564,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
     );
     assert_shortcut_action!(
         diff_hunk_unstaged_model,
-        "D",
+        "Ctrl+D",
         ContextMenuAction::ApplyWorktreePatch {
             repo_id: rid,
             patch,
@@ -5109,5 +5125,310 @@ fn ui_scale_ctrl_scroll_wheel_changes_zoom(cx: &mut gpui::TestAppContext) {
     assert_eq!(
         zoomed_back_out, 100,
         "expected Ctrl/Cmd + wheel down to step the UI zoom back to the previous preset"
+    );
+}
+
+#[gpui::test]
+fn ctrl_s_stages_current_file_and_advances_diff(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_id = RepoId(70600);
+    let commit_id = CommitId("abcdef00112233bb".into());
+    let workdir = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_{}_ctrl_s_stage",
+        std::process::id()
+    ));
+    let first = std::path::PathBuf::from("src/first.rs");
+    let second = std::path::PathBuf::from("src/second.rs");
+    let repo = simple_worktree_repo(
+        repo_id,
+        &workdir,
+        &commit_id,
+        &[first.clone(), second.clone()],
+        &first,
+    );
+
+    apply_state(cx, &view, app_state_with_active_repo(repo));
+    bind_app_keys_and_global_diff_fallback_for_test(cx);
+    focus_diff_panel(cx, &view);
+
+    cx.simulate_keystrokes("ctrl-s");
+    draw_and_drain_test_window(cx);
+    wait_until_store_diff_target_path(cx, &view, second.as_path());
+    sync_store_snapshot(cx, &view);
+
+    assert_eq!(
+        active_worktree_diff_target_path(cx, &view),
+        Some(second),
+        "expected Ctrl+S to stage the active file and advance the diff target"
+    );
+}
+
+#[gpui::test]
+fn ctrl_s_stages_last_file_and_clears_diff(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_id = RepoId(70601);
+    let commit_id = CommitId("abcdef00112233cc".into());
+    let workdir = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_{}_ctrl_s_last_file",
+        std::process::id()
+    ));
+    let path = std::path::PathBuf::from("src/lib.rs");
+    let repo = simple_worktree_repo(
+        repo_id,
+        &workdir,
+        &commit_id,
+        std::slice::from_ref(&path),
+        &path,
+    );
+
+    apply_state(cx, &view, app_state_with_active_repo(repo));
+    bind_app_keys_and_global_diff_fallback_for_test(cx);
+    focus_diff_panel(cx, &view);
+
+    cx.simulate_keystrokes("ctrl-s");
+    draw_and_drain_test_window(cx);
+    sync_store_snapshot(cx, &view);
+
+    assert_eq!(
+        active_worktree_diff_target_path(cx, &view),
+        None,
+        "expected Ctrl+S on the last unstaged file to stage it and clear the diff target"
+    );
+}
+
+#[gpui::test]
+fn ctrl_shift_c_copies_current_file_path(cx: &mut gpui::TestAppContext) {
+    let _clipboard_guard = crate::test_support::lock_clipboard_test();
+
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_id = RepoId(70602);
+    let commit_id = CommitId("abcdef00112233dd".into());
+    let workdir = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_{}_ctrl_shift_c",
+        std::process::id()
+    ));
+    let path = std::path::PathBuf::from("src/lib.rs");
+    let repo = simple_worktree_repo(
+        repo_id,
+        &workdir,
+        &commit_id,
+        std::slice::from_ref(&path),
+        &path,
+    );
+
+    apply_state(cx, &view, app_state_with_active_repo(repo));
+    bind_app_keys_and_global_diff_fallback_for_test(cx);
+    focus_diff_panel(cx, &view);
+
+    cx.simulate_keystrokes("ctrl-shift-c");
+    draw_and_drain_test_window(cx);
+
+    let clipboard_text = cx.read_from_clipboard().and_then(|item| item.text());
+    assert!(
+        clipboard_text
+            .as_ref()
+            .is_some_and(|text| text.contains("src/lib.rs")),
+        "expected Ctrl+Shift+C to copy the current file path to clipboard, got: {clipboard_text:?}"
+    );
+}
+
+#[gpui::test]
+fn ctrl_d_opens_discard_confirm_popover(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_id = RepoId(70603);
+    let commit_id = CommitId("abcdef00112233ee".into());
+    let workdir = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_{}_ctrl_d_discard",
+        std::process::id()
+    ));
+    let path = std::path::PathBuf::from("src/lib.rs");
+    let repo = simple_worktree_repo(
+        repo_id,
+        &workdir,
+        &commit_id,
+        std::slice::from_ref(&path),
+        &path,
+    );
+
+    apply_state(cx, &view, app_state_with_active_repo(repo));
+    bind_app_keys_and_global_diff_fallback_for_test(cx);
+    focus_diff_panel(cx, &view);
+
+    cx.simulate_keystrokes("ctrl-d");
+    draw_and_drain_test_window(cx);
+
+    let is_discard_confirm = cx.update(|_window, app| {
+        let host = view.read(app).popover_host.read(app);
+        matches!(
+            host.popover_kind_for_tests(),
+            Some(PopoverKind::DiscardChangesConfirm { .. })
+        )
+    });
+    assert!(
+        is_discard_confirm,
+        "expected Ctrl+D to open the DiscardChangesConfirm popover"
+    );
+}
+
+#[gpui::test]
+fn ctrl_h_opens_file_history_popover(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_id = RepoId(70604);
+    let commit_id = CommitId("abcdef00112233ff".into());
+    let workdir = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_{}_ctrl_h_history",
+        std::process::id()
+    ));
+    let path = std::path::PathBuf::from("src/lib.rs");
+    let repo = simple_worktree_repo(
+        repo_id,
+        &workdir,
+        &commit_id,
+        std::slice::from_ref(&path),
+        &path,
+    );
+
+    apply_state(cx, &view, app_state_with_active_repo(repo));
+    bind_app_keys_and_global_diff_fallback_for_test(cx);
+    focus_diff_panel(cx, &view);
+
+    cx.simulate_keystrokes("ctrl-h");
+    draw_and_drain_test_window(cx);
+
+    let is_file_history = cx.update(|_window, app| {
+        let host = view.read(app).popover_host.read(app);
+        matches!(
+            host.popover_kind_for_tests(),
+            Some(PopoverKind::FileHistory { .. })
+        )
+    });
+    assert!(
+        is_file_history,
+        "expected Ctrl+H to open the FileHistory popover"
+    );
+}
+
+#[gpui::test]
+fn ctrl_shortcuts_do_not_crash_without_diff_target(cx: &mut gpui::TestAppContext) {
+    let _clipboard_guard = crate::test_support::lock_clipboard_test();
+
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_id = RepoId(70605);
+    let commit_id = CommitId("abcdef00112233gg".into());
+    let workdir = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_{}_ctrl_no_diff_target",
+        std::process::id()
+    ));
+    let path = std::path::PathBuf::from("src/lib.rs");
+
+    let mut repo = shortcut_fixture_repo(repo_id, &workdir, &commit_id);
+    repo.status = Loadable::Ready(
+        gitcomet_core::domain::RepoStatus {
+            staged: vec![],
+            unstaged: vec![gitcomet_core::domain::FileStatus {
+                path: path.clone(),
+                kind: gitcomet_core::domain::FileStatusKind::Modified,
+                conflict: None,
+            }],
+        }
+        .into(),
+    );
+
+    apply_state(cx, &view, app_state_with_active_repo(repo));
+    bind_app_keys_and_global_diff_fallback_for_test(cx);
+    focus_diff_panel(cx, &view);
+
+    cx.simulate_keystrokes("ctrl-s ctrl-d ctrl-h ctrl-shift-c");
+    draw_and_drain_test_window(cx);
+
+    let clipboard_text = cx.read_from_clipboard().and_then(|item| item.text());
+
+    assert!(
+        clipboard_text.is_none(),
+        "expected Ctrl+Shift+C to not copy anything without a diff target, got: {clipboard_text:?}"
+    );
+}
+
+#[gpui::test]
+fn ctrl_u_unstages_current_file_and_advances_diff(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_id = RepoId(70606);
+    let commit_id = CommitId("abcdef00112233hh".into());
+    let workdir = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_{}_ctrl_u_unstage",
+        std::process::id()
+    ));
+    let first = std::path::PathBuf::from("src/first.rs");
+    let second = std::path::PathBuf::from("src/second.rs");
+
+    let mut repo = shortcut_fixture_repo(repo_id, &workdir, &commit_id);
+    repo.status = Loadable::Ready(
+        gitcomet_core::domain::RepoStatus {
+            unstaged: vec![],
+            staged: vec![
+                gitcomet_core::domain::FileStatus {
+                    path: first.clone(),
+                    kind: gitcomet_core::domain::FileStatusKind::Added,
+                    conflict: None,
+                },
+                gitcomet_core::domain::FileStatus {
+                    path: second.clone(),
+                    kind: gitcomet_core::domain::FileStatusKind::Added,
+                    conflict: None,
+                },
+            ],
+        }
+        .into(),
+    );
+    let target = DiffTarget::WorkingTree {
+        path: first.clone(),
+        area: DiffArea::Staged,
+    };
+    repo.diff_state.diff_target = Some(target.clone());
+    repo.diff_state.diff = Loadable::Ready(simple_hunk_diff(target).into());
+    repo.diff_state.diff_rev = 1;
+    repo.diff_state.diff_state_rev = repo.diff_state.diff_state_rev.wrapping_add(1);
+
+    apply_state(cx, &view, app_state_with_active_repo(repo));
+    bind_app_keys_and_global_diff_fallback_for_test(cx);
+    focus_diff_panel(cx, &view);
+
+    cx.simulate_keystrokes("ctrl-u");
+    draw_and_drain_test_window(cx);
+    wait_until_store_diff_target_path(cx, &view, second.as_path());
+    sync_store_snapshot(cx, &view);
+
+    assert_eq!(
+        active_worktree_diff_target_path(cx, &view),
+        Some(second),
+        "expected Ctrl+U to unstage the active file and advance the diff target"
     );
 }

--- a/crates/gitcomet-ui-gpui/src/view/panes/details.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panes/details.rs
@@ -191,6 +191,7 @@ impl DetailsPaneView {
             repo.merge_message_rev.hash(&mut hasher);
             repo.head_branch_rev.hash(&mut hasher);
             repo.branches_rev.hash(&mut hasher);
+            repo.diff_state.diff_target_rev.hash(&mut hasher);
         }
 
         hasher.finish()


### PR DESCRIPTION
Changed diff staging section shortcuts to work globally without requiring to open menu Implements https://github.com/Auto-Explore/GitComet/issues/232