### PR TITLE
Exempt merge fixtures and fonts from line-ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,6 +20,12 @@ CONTRIBUTING.md text eol=lf
 LICENSE-AGPL-3.0 text eol=lf
 NOTICE      text eol=lf
 
+# Merge test fixtures encode exact line endings (some are CRLF on purpose);
+# git must never normalize them.
+crates/gitcomet-core/tests/fixtures/merge/*.txt -text
+# Third-party font files ship with their own line endings.
+crates/gitcomet-ui-gpui/assets/fonts/** -text
+
 *.bat       text eol=crlf
 *.cmd       text eol=crlf
 *.ps1       text eol=crlf


### PR DESCRIPTION
The .gitattributes added in 03f0d4f2 applies `*.txt text eol=lf`, but the libgit2 merge test fixtures are committed with CRLF bytes on purpose (they test CRLF conflict-marker handling), so git reported 71 files as modified on every fresh checkout. Mark the fixture and font paths -text so git never touches their line endings.