### PR TITLE
Feat/repository tab style changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,6 +2235,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "sysinfo",
  "tempfile",
  "wayland-client",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,6 +2234,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "serde",
  "serde_json",
+ "signal-hook",
  "tempfile",
  "wayland-client",
 ]
@@ -2503,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "gix-command"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
+checksum = "cf4363accdf6ef7ba861871d2d521ab7418a04aaaed919fadb022af71d379b12"
 dependencies = [
  "bstr",
  "gix-path",
@@ -2549,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f813e312a3f7f327187823cd4c754a3e4d948c98907d11e8f37554a2b6b8059"
+checksum = "6f6af5321bfd3711a279d6b244d58532ba1cfabf9eb6374791f19929d8970082"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -2867,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed3e8d7a82e886e17a72e03d4ba0c13db6f2219b6cd4e2900b4cae426ec20c9"
+checksum = "751d6bd162106f8c1e7e9aaccb5bbdd605267e91a930a17a4560c46e33a9100c"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -3079,9 +3080,9 @@ checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
 
 [[package]]
 name = "gix-transport"
-version = "0.58.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c1bcf30081eb8ab04540a5795c67a2fcb22cb2e976e8b1a4ea657b1ed61469"
+checksum = "3f36d045b840f8aeee1a527e677eab1fbebfbbe94bf2e708fa81d0b4b742d5fc"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3113,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.37.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10e53b8eae21ee601687f47bbbd6cb2ed7162cb4c1cafdd422fb7ec64cbee"
+checksum = "31bdfc93aa880cda3272718a5879ce3aa7723fa13514320dd6608151607afe72"
 dependencies = [
  "bstr",
  "gix-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ semver = "1.0.28"
 schemars = "1.2.2"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
+signal-hook = "0.4.4"
 smallvec = "1.15.2"
 smol = "2.0.2"
 stats_alloc = { version = "0.1.10", features = ["nightly"] }

--- a/crates/gitcomet-ui-gpui/assets/open_source_licenses.tsv
+++ b/crates/gitcomet-ui-gpui/assets/open_source_licenses.tsv
@@ -229,10 +229,10 @@ gix-attributes	0.34.0	MIT OR Apache-2.0
 gix-bitmap	0.3.3	MIT OR Apache-2.0
 gix-blame	0.16.0	MIT OR Apache-2.0
 gix-chunk	0.7.3	MIT OR Apache-2.0
-gix-command	0.9.1	MIT OR Apache-2.0
+gix-command	0.9.2	MIT OR Apache-2.0
 gix-commitgraph	0.38.0	MIT OR Apache-2.0
 gix-config	0.59.0	MIT OR Apache-2.0
-gix-config-value	0.19.0	MIT OR Apache-2.0
+gix-config-value	0.19.1	MIT OR Apache-2.0
 gix-date	0.15.6	MIT OR Apache-2.0
 gix-diff	0.66.0	MIT OR Apache-2.0
 gix-dir	0.28.0	MIT OR Apache-2.0
@@ -252,7 +252,7 @@ gix-object	0.63.0	MIT OR Apache-2.0
 gix-odb	0.83.0	MIT OR Apache-2.0
 gix-pack	0.73.0	MIT OR Apache-2.0
 gix-packetline	0.22.0	MIT OR Apache-2.0
-gix-path	0.12.3	MIT OR Apache-2.0
+gix-path	0.12.4	MIT OR Apache-2.0
 gix-pathspec	0.19.0	MIT OR Apache-2.0
 gix-protocol	0.64.0	MIT OR Apache-2.0
 gix-quote	0.7.2	MIT OR Apache-2.0
@@ -266,9 +266,9 @@ gix-status	0.33.0	MIT OR Apache-2.0
 gix-submodule	0.33.0	MIT OR Apache-2.0
 gix-tempfile	24.0.0	MIT OR Apache-2.0
 gix-trace	0.1.21	MIT OR Apache-2.0
-gix-transport	0.58.0	MIT OR Apache-2.0
+gix-transport	0.58.1	MIT OR Apache-2.0
 gix-traverse	0.60.0	MIT OR Apache-2.0
-gix-url	0.37.0	MIT OR Apache-2.0
+gix-url	0.37.1	MIT OR Apache-2.0
 gix-utils	0.3.5	MIT OR Apache-2.0
 gix-validate	0.11.3	MIT OR Apache-2.0
 gix-worktree	0.55.0	MIT OR Apache-2.0

--- a/crates/gitcomet-ui-gpui/src/app.rs
+++ b/crates/gitcomet-ui-gpui/src/app.rs
@@ -771,7 +771,7 @@ fn bind_app_keys(cx: &mut App) {
         KeyBinding::new("secondary-,", OpenSettings, None),
         KeyBinding::new("secondary-o", OpenRepository, None),
         KeyBinding::new("secondary-shift-o", SwitchRepository, None),
-        KeyBinding::new("ctrl-shift-a", SwitchRepository, None),
+        KeyBinding::new("secondary-shift-a", SwitchRepository, None),
         KeyBinding::new("secondary-f", OpenActiveViewSearch, None),
         KeyBinding::new("secondary-p", ToggleCommandPalette, None),
         KeyBinding::new("secondary-w", Close, None),
@@ -1693,7 +1693,7 @@ fn bind_terminal_keys(cx: &mut App) {
         #[cfg(not(target_os = "macos"))]
         KeyBinding::new("ctrl-shift-v", TerminalPaste, Some("Terminal")),
         #[cfg(not(target_os = "macos"))]
-        KeyBinding::new("ctrl-shift-a", TerminalSelectAll, Some("Terminal")),
+        KeyBinding::new("secondary-shift-a", TerminalSelectAll, Some("Terminal")),
     ]);
 }
 
@@ -2157,7 +2157,7 @@ mod tests {
         let cases = [
             ("ctrl-shift-c", TerminalCopy.name()),
             ("ctrl-shift-v", TerminalPaste.name()),
-            ("ctrl-shift-a", TerminalSelectAll.name()),
+            ("secondary-shift-a", TerminalSelectAll.name()),
         ];
 
         for (keystroke, expected_action) in cases {
@@ -2345,7 +2345,7 @@ mod tests {
             ("secondary-,", OpenSettings.name()),
             ("secondary-o", OpenRepository.name()),
             ("secondary-shift-o", SwitchRepository.name()),
-            ("ctrl-shift-a", SwitchRepository.name()),
+            ("secondary-shift-a", SwitchRepository.name()),
             ("secondary-f", crate::view::OpenActiveViewSearch.name()),
             ("secondary-p", crate::view::ToggleCommandPalette.name()),
             ("secondary-w", Close.name()),
@@ -2562,14 +2562,14 @@ mod tests {
         });
         seed_workspace_repo(cx, &store, view);
 
-        cx.simulate_keystrokes("ctrl-shift-a");
+        cx.simulate_keystrokes("secondary-shift-a");
         cx.update(|window, app| {
             let _ = window.draw(app);
         });
 
         assert!(cx.debug_bounds("app_popover").is_some());
 
-        cx.simulate_keystrokes("ctrl-shift-a");
+        cx.simulate_keystrokes("secondary-shift-a");
         cx.update(|window, app| {
             let _ = window.draw(app);
         });

--- a/crates/gitcomet-ui-gpui/src/app.rs
+++ b/crates/gitcomet-ui-gpui/src/app.rs
@@ -771,6 +771,7 @@ fn bind_app_keys(cx: &mut App) {
         KeyBinding::new("secondary-,", OpenSettings, None),
         KeyBinding::new("secondary-o", OpenRepository, None),
         KeyBinding::new("secondary-shift-o", SwitchRepository, None),
+        KeyBinding::new("ctrl-shift-a", SwitchRepository, None),
         KeyBinding::new("secondary-f", OpenActiveViewSearch, None),
         KeyBinding::new("secondary-p", ToggleCommandPalette, None),
         KeyBinding::new("secondary-w", Close, None),
@@ -2138,6 +2139,7 @@ mod tests {
 
         cx.update(|window, app| {
             app.clear_key_bindings();
+            bind_app_keys(app);
             bind_terminal_keys_for_test(app);
             let focus = view.update(app, |view, _cx| view.focus_handle());
             window.focus(&focus, app);
@@ -2343,6 +2345,7 @@ mod tests {
             ("secondary-,", OpenSettings.name()),
             ("secondary-o", OpenRepository.name()),
             ("secondary-shift-o", SwitchRepository.name()),
+            ("ctrl-shift-a", SwitchRepository.name()),
             ("secondary-f", crate::view::OpenActiveViewSearch.name()),
             ("secondary-p", crate::view::ToggleCommandPalette.name()),
             ("secondary-w", Close.name()),
@@ -2543,7 +2546,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn recent_picker_shortcut_opens_the_popover(cx: &mut gpui::TestAppContext) {
+    fn recent_picker_shortcut_toggles_the_popover(cx: &mut gpui::TestAppContext) {
         let _visual_guard = lock_visual_test();
         let backend: Arc<dyn GitBackend> = Arc::new(TestBackend);
         let (store, events) = AppStore::new(Arc::clone(&backend));
@@ -2559,12 +2562,22 @@ mod tests {
         });
         seed_workspace_repo(cx, &store, view);
 
-        cx.simulate_keystrokes("secondary-shift-o");
+        cx.simulate_keystrokes("ctrl-shift-a");
         cx.update(|window, app| {
             let _ = window.draw(app);
         });
 
         assert!(cx.debug_bounds("app_popover").is_some());
+
+        cx.simulate_keystrokes("ctrl-shift-a");
+        cx.update(|window, app| {
+            let _ = window.draw(app);
+        });
+
+        assert!(
+            cx.debug_bounds("app_popover").is_none(),
+            "pressing the shortcut again should close the repository picker"
+        );
     }
 
     #[gpui::test]

--- a/crates/gitcomet-ui-gpui/src/clipboard.rs
+++ b/crates/gitcomet-ui-gpui/src/clipboard.rs
@@ -129,7 +129,8 @@ fn write_copy_diagnostic_inner(
             ClipboardBackend::X11 => "x11",
         },
     );
-    let mut file = std::fs::File::create(dir.join("last-operation.log"))?;
+    let mut file =
+        std::fs::File::create(dir.join(format!("last-operation-{}.log", std::process::id())))?;
     use std::io::Write as _;
     file.write_all(text.as_bytes())?;
     file.sync_data()

--- a/crates/gitcomet-ui-gpui/src/smoke_tests.rs
+++ b/crates/gitcomet-ui-gpui/src/smoke_tests.rs
@@ -1501,6 +1501,10 @@ fn repo_tab_label_selector(repo_id: RepoId) -> &'static str {
     Box::leak(format!("repo_tab_label_{}", repo_id.0).into_boxed_str())
 }
 
+fn repo_tab_label_text_selector(repo_id: RepoId) -> &'static str {
+    Box::leak(format!("repo_tab_label_text_{}", repo_id.0).into_boxed_str())
+}
+
 fn worktrees_spinner_selector(repo_id: RepoId) -> &'static str {
     Box::leak(format!("worktrees_spinner_{}", repo_id.0).into_boxed_str())
 }
@@ -3907,6 +3911,27 @@ fn repo_tab_scroll(
     cx.update(|_window, app| crate::view::test_support::repo_tab_scroll(view.read(app), app))
 }
 
+fn resize_repo_tab_strip_to(
+    cx: &mut gpui::VisualTestContext,
+    view: &gpui::Entity<crate::view::GitCometView>,
+    target_width: Pixels,
+) {
+    let current_strip = cx.update(|_window, app| {
+        crate::view::test_support::repo_tab_strip_viewport(view.read(app), app)
+            .size
+            .width
+    });
+    let window_size = cx.update(|window, _app| window.viewport_size());
+    let delta = target_width - current_strip;
+    if f32::from(delta).abs() > 1.0 {
+        cx.simulate_resize(gpui::size(
+            (window_size.width + delta).max(px(640.0)),
+            window_size.height,
+        ));
+        sync_view_for_tests(cx, view);
+    }
+}
+
 fn scroll_over(cx: &mut gpui::VisualTestContext, position: gpui::Point<Pixels>, delta_y: Pixels) {
     cx.simulate_mouse_move(position, None, Modifiers::default());
     cx.simulate_event(ScrollWheelEvent {
@@ -3956,16 +3981,6 @@ fn titlebar_only_reserves_visible_repository_controls_from_window_drag(
                 .expect("expected repository picker bounds"),
         ),
         ("repository tab", repo_tab_bounds),
-        (
-            "left repository arrow",
-            cx.debug_bounds("tab_bar_scroll_left")
-                .expect("expected left repository arrow bounds"),
-        ),
-        (
-            "right repository arrow",
-            cx.debug_bounds("tab_bar_scroll_right")
-                .expect("expected right repository arrow bounds"),
-        ),
         (
             "add repository",
             cx.debug_bounds("add_repo_menu")
@@ -4054,14 +4069,14 @@ fn repo_tabs_scroll_with_the_wheel_once_they_overflow(cx: &mut gpui::TestAppCont
 }
 
 #[gpui::test]
-fn repo_tab_scroll_arrows_appear_only_when_tabs_overflow(cx: &mut gpui::TestAppContext) {
+fn repo_tab_strip_never_renders_scroll_arrows(cx: &mut gpui::TestAppContext) {
     let (store, events) = AppStore::new(Arc::new(TestBackend));
     let store_for_test = store.clone();
     let (view, cx) = cx.add_window_view(|window, cx| {
         crate::view::GitCometView::new(store, events, None, window, cx)
     });
 
-    let roomy_repo_ids = open_repo_tabs(cx, &store_for_test, view.clone(), "tab_arrows_few", 2);
+    let roomy_repo_ids = open_repo_tabs(cx, &store_for_test, view.clone(), "tab_no_arrows_few", 2);
     let roomy_tab = cx
         .debug_bounds(repo_tab_selector(roomy_repo_ids[0]))
         .expect("expected a repository tab in the roomy strip");
@@ -4080,7 +4095,7 @@ fn repo_tab_scroll_arrows_appear_only_when_tabs_overflow(cx: &mut gpui::TestAppC
         .map(|ix| {
             std::env::temp_dir()
                 .join(format!(
-                    "gitcomet_ui_test_tab_arrows_{}",
+                    "gitcomet_ui_test_tab_no_arrows_{}",
                     std::process::id()
                 ))
                 .join(format!("repository-number-{ix}"))
@@ -4090,9 +4105,9 @@ fn repo_tab_scroll_arrows_appear_only_when_tabs_overflow(cx: &mut gpui::TestAppC
     sync_view_for_tests(cx, &view);
 
     assert!(
-        cx.debug_bounds("tab_bar_scroll_left").is_some()
-            && cx.debug_bounds("tab_bar_scroll_right").is_some(),
-        "expected both scroll arrows once the tabs overflow"
+        cx.debug_bounds("tab_bar_scroll_left").is_none()
+            && cx.debug_bounds("tab_bar_scroll_right").is_none(),
+        "expected overflowing repository tabs to remain free of scroll arrows"
     );
     let dense_tab = cx
         .debug_bounds(repo_tab_selector(dense_repo_ids[0]))
@@ -4102,8 +4117,8 @@ fn repo_tab_scroll_arrows_appear_only_when_tabs_overflow(cx: &mut gpui::TestAppC
         .expect("expected a repository label in the dense strip");
     let dense_leading_inset = dense_label.left() - dense_tab.left();
     assert!(
-        dense_leading_inset < roomy_leading_inset,
-        "expected side padding to shrink as the tab strip gets denser, got \
+        (f32::from(dense_leading_inset) - f32::from(roomy_leading_inset)).abs() <= 0.5,
+        "expected fixed side padding at every tab-strip density, got \
          roomy={roomy_leading_inset:?}, dense={dense_leading_inset:?}"
     );
     let drag_region = cx
@@ -4113,6 +4128,157 @@ fn repo_tab_scroll_arrows_appear_only_when_tabs_overflow(cx: &mut gpui::TestAppC
         drag_region.size.width >= px(60.0),
         "expected repository tabs to leave a useful window drag region, got {:?}",
         drag_region.size.width
+    );
+}
+
+#[gpui::test]
+fn roomy_repo_tab_expands_to_show_its_full_repository_name(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let store_for_test = store.clone();
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        crate::view::GitCometView::new(store, events, None, window, cx)
+    });
+    let workdir =
+        std::env::temp_dir().join("repository-with-a-long-descriptive-name-that-still-fits");
+    let repo_ids = restore_session_and_draw(cx, &store_for_test, view.clone(), vec![workdir]);
+    let repo_id = repo_ids[0];
+
+    let tab = cx
+        .debug_bounds(repo_tab_selector(repo_id))
+        .expect("expected roomy repository tab bounds");
+    let label = cx
+        .debug_bounds(repo_tab_label_selector(repo_id))
+        .expect("expected roomy repository label bounds");
+    let natural_text = cx
+        .debug_bounds(repo_tab_label_text_selector(repo_id))
+        .expect("expected natural repository label text bounds");
+
+    assert!(
+        tab.size.width > px(180.0),
+        "expected a roomy tab to expand beyond the former 180px cap, got {:?}",
+        tab.size.width
+    );
+    assert!(
+        label.size.width + px(0.5) >= natural_text.size.width,
+        "expected the full repository name to fit without fading (label={:?}, text={:?})",
+        label.size.width,
+        natural_text.size.width
+    );
+    assert_eq!(
+        repo_tab_scroll(cx, &view).1,
+        px(0.0),
+        "expected the single naturally sized tab not to overflow the strip"
+    );
+}
+
+#[gpui::test]
+fn repository_tabs_shrink_long_names_before_short_names(cx: &mut gpui::TestAppContext) {
+    let _visual_guard = lock_visual_test();
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let store_for_test = store.clone();
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        crate::view::GitCometView::new(store, events, None, window, cx)
+    });
+    cx.simulate_resize(gpui::size(px(1800.0), px(700.0)));
+
+    let base = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_tab_priority_{}",
+        std::process::id()
+    ));
+    let repo_ids = restore_session_and_draw(
+        cx,
+        &store_for_test,
+        view.clone(),
+        vec![
+            base.join("small-project"),
+            base.join("medium-sized-repository"),
+            base.join("repository-with-an-exceptionally-long-descriptive-name"),
+        ],
+    );
+    sync_view_for_tests(cx, &view);
+
+    let tab_widths = |cx: &mut gpui::VisualTestContext| {
+        repo_ids
+            .iter()
+            .map(|repo_id| {
+                cx.debug_bounds(repo_tab_selector(*repo_id))
+                    .expect("expected repository tab bounds")
+                    .size
+                    .width
+            })
+            .collect::<Vec<_>>()
+    };
+    let natural = tab_widths(cx);
+    assert!(natural[0] < natural[1] && natural[1] < natural[2]);
+    let first_tab_left = cx
+        .debug_bounds(repo_tab_selector(repo_ids[0]))
+        .expect("expected first repository tab bounds")
+        .left();
+
+    // Keep the cap between the medium and long natural widths: only the long
+    // tab should have to yield at this pressure level.
+    let long_only_cap = (natural[1] + natural[2]) / 2.0;
+    let outer_chrome = px(36.0 + 6.0 * repo_ids.len() as f32);
+    resize_repo_tab_strip_to(
+        cx,
+        &view,
+        natural[0] + natural[1] + long_only_cap + outer_chrome,
+    );
+    let long_only = tab_widths(cx);
+    sync_view_for_tests(cx, &view);
+    assert_eq!(
+        tab_widths(cx),
+        long_only,
+        "repository tab widths must not adjust again on a follow-up frame"
+    );
+    assert_eq!(
+        cx.debug_bounds(repo_tab_selector(repo_ids[0]))
+            .expect("expected first repository tab bounds")
+            .left(),
+        first_tab_left,
+        "the repository tab strip must remain anchored while resizing"
+    );
+    assert_eq!(long_only[0], natural[0], "short tab should stay natural");
+    assert_eq!(long_only[1], natural[1], "medium tab should stay natural");
+    assert!(
+        long_only[2] < natural[2],
+        "the longest tab should fade first"
+    );
+
+    // Push the common cap below the shortest natural tab but above the 102px
+    // floor. At this threshold all three tabs should shrink together.
+    let all_tabs_cap = (px(102.0) + natural[0]) / 2.0;
+    resize_repo_tab_strip_to(
+        cx,
+        &view,
+        all_tabs_cap * repo_ids.len() as f32 + outer_chrome,
+    );
+    let all_shrunk = tab_widths(cx);
+    sync_view_for_tests(cx, &view);
+    assert_eq!(
+        tab_widths(cx),
+        all_shrunk,
+        "repository tabs must settle in the resize frame at every pressure level"
+    );
+    assert_eq!(
+        cx.debug_bounds(repo_tab_selector(repo_ids[0]))
+            .expect("expected first repository tab bounds")
+            .left(),
+        first_tab_left,
+        "the repository tab strip must not move horizontally as all tabs shrink"
+    );
+    assert!(
+        all_shrunk
+            .iter()
+            .zip(&natural)
+            .all(|(shrunk, natural)| shrunk < natural),
+        "every repository tab should shrink once the cap crosses the shortest name"
+    );
+    assert!(
+        all_shrunk
+            .windows(2)
+            .all(|pair| (f32::from(pair[0]) - f32::from(pair[1])).abs() <= 1.0),
+        "all tabs should share the same cap after the threshold: {all_shrunk:?}"
     );
 }
 
@@ -4144,43 +4310,6 @@ fn repo_tabs_show_separators_only_between_inactive_tabs(cx: &mut gpui::TestAppCo
 }
 
 #[gpui::test]
-fn repo_tab_scroll_arrows_move_the_strip(cx: &mut gpui::TestAppContext) {
-    let (store, events) = AppStore::new(Arc::new(TestBackend));
-    let store_for_test = store.clone();
-    let (view, cx) = cx.add_window_view(|window, cx| {
-        crate::view::GitCometView::new(store, events, None, window, cx)
-    });
-
-    open_repo_tabs(cx, &store_for_test, view.clone(), "tab_arrow_clicks", 30);
-
-    // The left arrow is inert at the start of the strip.
-    click_debug_selector(cx, "tab_bar_scroll_left", 1);
-    sync_view_for_tests(cx, &view);
-    let (scrolled, max_scroll) = repo_tab_scroll(cx, &view);
-    assert_eq!(
-        scrolled,
-        px(0.0),
-        "expected the left arrow to do nothing at the start of the strip"
-    );
-
-    click_debug_selector(cx, "tab_bar_scroll_right", 1);
-    sync_view_for_tests(cx, &view);
-    let (after_right, _) = repo_tab_scroll(cx, &view);
-    assert!(
-        after_right > px(0.0) && after_right <= max_scroll,
-        "expected the right arrow to scroll the strip, got {after_right:?}"
-    );
-
-    click_debug_selector(cx, "tab_bar_scroll_left", 1);
-    sync_view_for_tests(cx, &view);
-    let (after_left, _) = repo_tab_scroll(cx, &view);
-    assert!(
-        after_left < after_right,
-        "expected the left arrow to scroll back, went from {after_right:?} to {after_left:?}"
-    );
-}
-
-#[gpui::test]
 fn dragging_a_repo_tab_to_the_edge_scrolls_the_strip(cx: &mut gpui::TestAppContext) {
     let (store, events) = AppStore::new(Arc::new(TestBackend));
     let store_for_test = store.clone();
@@ -4197,9 +4326,9 @@ fn dragging_a_repo_tab_to_the_edge_scrolls_the_strip(cx: &mut gpui::TestAppConte
     let dragged_bounds = cx
         .debug_bounds(repo_tab_selector(dragged))
         .expect("expected dragged repo tab bounds");
-    let right_arrow = cx
-        .debug_bounds("tab_bar_scroll_right")
-        .expect("expected the right scroll arrow");
+    let strip = cx.update(|_window, app| {
+        crate::view::test_support::repo_tab_strip_viewport(view.read(app), app)
+    });
 
     let start = dragged_bounds.center();
     cx.simulate_mouse_move(start, None, Modifiers::default());
@@ -4212,7 +4341,7 @@ fn dragging_a_repo_tab_to_the_edge_scrolls_the_strip(cx: &mut gpui::TestAppConte
 
     // Park the pointer just inside the strip's trailing edge and let frames run
     // without moving it again.
-    let parked = gpui::point(right_arrow.left() - px(4.0), start.y);
+    let parked = gpui::point(strip.right() - px(38.0), start.y);
     cx.simulate_mouse_move(parked, Some(MouseButton::Left), Modifiers::default());
     for _ in 0..12 {
         std::thread::sleep(Duration::from_millis(10));
@@ -4239,10 +4368,7 @@ fn dragging_a_repo_tab_to_the_edge_scrolls_the_strip(cx: &mut gpui::TestAppConte
     );
 
     // Holding at the opposite edge winds it back.
-    let strip_left = cx
-        .debug_bounds("tab_bar_scroll_left")
-        .expect("expected the left scroll arrow");
-    let parked_left = gpui::point(strip_left.right() + px(4.0), start.y);
+    let parked_left = gpui::point(strip.left() + px(4.0), start.y);
     cx.simulate_mouse_move(parked_left, Some(MouseButton::Left), Modifiers::default());
     for _ in 0..12 {
         std::thread::sleep(Duration::from_millis(10));
@@ -4357,58 +4483,47 @@ fn add_repo_button_stays_pinned_right_of_overflowing_tabs(cx: &mut gpui::TestApp
     let plus = cx
         .debug_bounds("add_repo_menu")
         .expect("expected the + button to stay rendered while tabs overflow");
-    let right_arrow = cx
-        .debug_bounds("tab_bar_scroll_right")
-        .expect("expected the right scroll arrow");
-    let last_tab = cx
-        .debug_bounds(repo_tab_selector(*repo_ids.last().expect("repo ids")))
-        .expect("expected last repo tab bounds");
+    let strip = cx.update(|_window, app| {
+        crate::view::test_support::repo_tab_strip_viewport(view.read(app), app)
+    });
+    let first_tab = cx
+        .debug_bounds(repo_tab_selector(repo_ids[0]))
+        .expect("expected first repository tab bounds");
 
+    assert!(cx.debug_bounds("tab_bar_scroll_left").is_none());
+    assert!(cx.debug_bounds("tab_bar_scroll_right").is_none());
     assert!(
-        right_arrow.right() <= plus.left(),
-        "expected the right arrow to sit left of the + button"
+        plus.left() >= strip.right() - px(1.0),
+        "expected the + button to occupy a reserved rail after the scroll viewport"
     );
     assert!(
-        plus.left() < last_tab.left(),
-        "expected the + button to stay on screen while the last tab is scrolled out"
+        first_tab.right() <= strip.right() + px(1.0),
+        "expected visible repository tabs not to overlap the sticky + button"
     );
 }
 
 #[gpui::test]
-fn add_repo_button_follows_the_last_tab_until_they_overflow(cx: &mut gpui::TestAppContext) {
+fn add_repo_button_stays_at_the_strip_end_when_tabs_fit(cx: &mut gpui::TestAppContext) {
     let (store, events) = AppStore::new(Arc::new(TestBackend));
     let store_for_test = store.clone();
     let (view, cx) = cx.add_window_view(|window, cx| {
         crate::view::GitCometView::new(store, events, None, window, cx)
     });
 
-    // Few enough tabs to leave slack in the strip: the + belongs right after
-    // the last one, browser-style, not marooned at the far end of the bar.
-    let repo_ids = open_repo_tabs(cx, &store_for_test, view.clone(), "tab_plus_follows", 3);
+    let _repo_ids = open_repo_tabs(cx, &store_for_test, view.clone(), "tab_plus_sticky", 3);
     let (_, max_scroll) = repo_tab_scroll(cx, &view);
     assert_eq!(max_scroll, px(0.0), "expected three tabs not to overflow");
 
     let plus = cx
         .debug_bounds("add_repo_menu")
         .expect("expected the + button");
-    let last_tab = cx
-        .debug_bounds(repo_tab_selector(*repo_ids.last().expect("repo ids")))
-        .expect("expected last repo tab bounds");
     let strip = cx.update(|_window, app| {
         crate::view::test_support::repo_tab_strip_viewport(view.read(app), app)
     });
 
     assert!(
-        plus.left() >= last_tab.right() - px(1.0),
-        "expected the + button to sit after the last tab \
-         (plus left={:?}, last tab right={:?})",
-        plus.left(),
-        last_tab.right()
-    );
-    let gap = plus.left() - last_tab.right();
-    assert!(
-        gap < strip.size.width / 2.0,
-        "expected the + button to hug the last tab, not the end of the bar (gap={gap:?})"
+        plus.left() >= strip.right() - px(1.0),
+        "expected the + button to stay sticky after the repository scroll viewport"
     );
     assert!(
         cx.debug_bounds("tab_bar_scroll_right").is_none(),

--- a/crates/gitcomet-ui-gpui/src/smoke_tests.rs
+++ b/crates/gitcomet-ui-gpui/src/smoke_tests.rs
@@ -4550,7 +4550,7 @@ fn dragging_a_repo_tab_past_the_strip_ends_keeps_it_inside(cx: &mut gpui::TestAp
 }
 
 #[gpui::test]
-fn add_repo_button_follows_the_last_overflowing_tab(cx: &mut gpui::TestAppContext) {
+fn add_repo_button_stays_after_the_overflowing_tab_viewport(cx: &mut gpui::TestAppContext) {
     let (store, events) = AppStore::new(Arc::new(TestBackend));
     let store_for_test = store.clone();
     let (view, cx) = cx.add_window_view(|window, cx| {
@@ -4568,15 +4568,15 @@ fn add_repo_button_follows_the_last_overflowing_tab(cx: &mut gpui::TestAppContex
     let first_tab = cx
         .debug_bounds(repo_tab_selector(repo_ids[0]))
         .expect("expected first repository tab bounds");
-    let last_tab = cx
-        .debug_bounds(repo_tab_selector(*repo_ids.last().expect("repo ids")))
-        .expect("expected final repository tab bounds");
-
     assert!(cx.debug_bounds("tab_bar_scroll_left").is_none());
     assert!(cx.debug_bounds("tab_bar_scroll_right").is_none());
     assert!(
-        plus.left() >= last_tab.right(),
-        "expected the + button to follow the final overflowing repository tab"
+        plus.left() >= strip.right() - px(1.0),
+        "expected the + button immediately after the overflowing tab viewport"
+    );
+    assert!(
+        plus.left() <= strip.right() + px(12.0),
+        "expected the + button to stay attached to the overflowing tab viewport"
     );
     assert!(
         first_tab.right() <= strip.right() + px(1.0),
@@ -4599,9 +4599,6 @@ fn add_repo_button_stays_at_the_strip_end_when_tabs_fit(cx: &mut gpui::TestAppCo
     let plus = cx
         .debug_bounds("add_repo_menu")
         .expect("expected the + button");
-    let strip = cx.update(|_window, app| {
-        crate::view::test_support::repo_tab_strip_viewport(view.read(app), app)
-    });
     let last_tab = cx
         .debug_bounds(repo_tab_selector(*repo_ids.last().expect("repo ids")))
         .expect("expected final repository tab bounds");
@@ -4614,10 +4611,6 @@ fn add_repo_button_stays_at_the_strip_end_when_tabs_fit(cx: &mut gpui::TestAppCo
         plus.left() <= last_tab.right() + px(12.0),
         "expected the + button to hug the final repository tab, got a {:?} gap",
         plus.left() - last_tab.right()
-    );
-    assert!(
-        plus.right() < strip.right(),
-        "expected unused title-bar space to remain after the inline + button"
     );
     assert!(
         cx.debug_bounds("tab_bar_scroll_right").is_none(),

--- a/crates/gitcomet-ui-gpui/src/smoke_tests.rs
+++ b/crates/gitcomet-ui-gpui/src/smoke_tests.rs
@@ -3226,6 +3226,20 @@ fn popover_is_clickable_above_content(cx: &mut gpui::TestAppContext) {
         let _ = window.draw(app);
     });
 
+    let popover_bounds = cx
+        .debug_bounds("app_popover")
+        .expect("expected repository picker popover bounds");
+    assert_eq!(
+        popover_bounds.left(),
+        picker_bounds.left(),
+        "expected repository picker to stay aligned to the chevron's left edge"
+    );
+    assert_eq!(
+        popover_bounds.top(),
+        picker_bounds.bottom() + px(1.0),
+        "expected repository picker to stay attached below the chevron"
+    );
+
     let close_bounds = cx
         .debug_bounds("repo_popover_close")
         .expect("expected repo_popover_close in debug bounds");

--- a/crates/gitcomet-ui-gpui/src/smoke_tests.rs
+++ b/crates/gitcomet-ui-gpui/src/smoke_tests.rs
@@ -3918,6 +3918,98 @@ fn scroll_over(cx: &mut gpui::VisualTestContext, position: gpui::Point<Pixels>, 
 }
 
 #[gpui::test]
+fn titlebar_only_reserves_visible_repository_controls_from_window_drag(
+    cx: &mut gpui::TestAppContext,
+) {
+    let _visual_guard = lock_visual_test();
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let store_for_test = store.clone();
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        crate::view::GitCometView::new(store, events, None, window, cx)
+    });
+    let repo_ids = open_repo_tabs(
+        cx,
+        &store_for_test,
+        view.clone(),
+        "titlebar_visible_hitboxes",
+        30,
+    );
+
+    let drag_surface = cx
+        .debug_bounds("titlebar_drag")
+        .expect("expected the shared title-bar drag surface");
+    let repo_tab_bounds = cx
+        .debug_bounds(repo_tab_selector(repo_ids[0]))
+        .expect("expected repository tab bounds");
+    let repo_tab_viewport = cx.update(|_window, app| {
+        crate::view::test_support::repo_tab_strip_viewport(view.read(app), app)
+    });
+    assert_eq!(
+        (repo_tab_viewport.top(), repo_tab_viewport.bottom()),
+        (repo_tab_bounds.top(), repo_tab_bounds.bottom()),
+        "expected the scrollable tab strip hitbox to match the visible tab row"
+    );
+    let mut controls = vec![
+        (
+            "repository picker",
+            cx.debug_bounds("repo_picker_toggle")
+                .expect("expected repository picker bounds"),
+        ),
+        ("repository tab", repo_tab_bounds),
+        (
+            "left repository arrow",
+            cx.debug_bounds("tab_bar_scroll_left")
+                .expect("expected left repository arrow bounds"),
+        ),
+        (
+            "right repository arrow",
+            cx.debug_bounds("tab_bar_scroll_right")
+                .expect("expected right repository arrow bounds"),
+        ),
+        (
+            "add repository",
+            cx.debug_bounds("add_repo_menu")
+                .expect("expected add repository button bounds"),
+        ),
+    ];
+    if !cfg!(target_os = "macos") {
+        controls.push((
+            "application menu",
+            cx.debug_bounds("app_menu")
+                .expect("expected application menu bounds"),
+        ));
+    }
+
+    for (name, bounds) in controls {
+        let above = gpui::point(bounds.center().x, drag_surface.top() + px(1.0));
+        assert!(
+            above.y < bounds.top(),
+            "expected title chrome above the visible {name}"
+        );
+
+        cx.simulate_mouse_move(above, None, Modifiers::default());
+        cx.simulate_mouse_down(above, MouseButton::Left, Modifiers::default());
+        cx.update(|_window, app| {
+            assert!(
+                crate::view::test_support::titlebar_drag_is_armed(view.read(app), app),
+                "expected the area above the visible {name} to arm a window drag"
+            );
+        });
+        cx.simulate_mouse_up(above, MouseButton::Left, Modifiers::default());
+
+        cx.simulate_mouse_move(bounds.center(), None, Modifiers::default());
+        cx.simulate_mouse_down(bounds.center(), MouseButton::Left, Modifiers::default());
+        cx.update(|_window, app| {
+            assert!(
+                !crate::view::test_support::titlebar_drag_is_armed(view.read(app), app),
+                "expected the visible {name} to keep its own interaction"
+            );
+        });
+        cx.simulate_mouse_up(above, MouseButton::Left, Modifiers::default());
+    }
+}
+
+#[gpui::test]
 fn repo_tabs_scroll_with_the_wheel_once_they_overflow(cx: &mut gpui::TestAppContext) {
     let (store, events) = AppStore::new(Arc::new(TestBackend));
     let store_for_test = store.clone();

--- a/crates/gitcomet-ui-gpui/src/smoke_tests.rs
+++ b/crates/gitcomet-ui-gpui/src/smoke_tests.rs
@@ -1834,6 +1834,71 @@ fn repo_tabs_can_drag_reorder_by_right_half(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+fn repo_tab_reorder_does_not_bounce_on_minor_pointer_reversal(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let store_for_test = store.clone();
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        crate::view::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let base = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_repo_tabs_jitter_{}",
+        std::process::id()
+    ));
+    let repo_ids = restore_session_and_draw(
+        cx,
+        &store_for_test,
+        view.clone(),
+        vec![base.join("repo1"), base.join("repo2"), base.join("repo3")],
+    );
+
+    let dragged = repo_ids[0];
+    let expected = vec![repo_ids[1], repo_ids[0], repo_ids[2]];
+    let dragged_bounds = cx
+        .debug_bounds(repo_tab_selector(dragged))
+        .expect("expected dragged repository tab bounds");
+    let target_bounds = cx
+        .debug_bounds(repo_tab_selector(repo_ids[1]))
+        .expect("expected target repository tab bounds");
+
+    let start = dragged_bounds.center();
+    cx.simulate_mouse_move(start, None, Modifiers::default());
+    cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::default());
+    cx.simulate_mouse_move(
+        gpui::point(start.x + px(10.0), start.y),
+        Some(MouseButton::Left),
+        Modifiers::default(),
+    );
+
+    // Cross the rightward takeover point, then move back only a few pixels
+    // while the displaced neighbour is still animating through that point.
+    let takeover = gpui::point(
+        target_bounds.left() + target_bounds.size.width * 0.45,
+        target_bounds.center().y,
+    );
+    cx.simulate_mouse_move(takeover, Some(MouseButton::Left), Modifiers::default());
+    wait_for_repo_order(&store_for_test, &expected);
+    sync_view_for_tests(cx, &view);
+
+    let jitter = gpui::point(takeover.x - px(5.0), takeover.y);
+    cx.simulate_mouse_move(jitter, Some(MouseButton::Left), Modifiers::default());
+    sync_view_for_tests(cx, &view);
+
+    let got = store_for_test
+        .snapshot()
+        .repos
+        .iter()
+        .map(|repo| repo.id)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        got, expected,
+        "a small reverse movement must not make adjacent tabs swap back"
+    );
+
+    cx.simulate_mouse_up(jitter, MouseButton::Left, Modifiers::default());
+}
+
+#[gpui::test]
 fn repo_tabs_can_drag_reorder_by_left_half(cx: &mut gpui::TestAppContext) {
     let (store, events) = AppStore::new(Arc::new(TestBackend));
     let store_for_test = store.clone();
@@ -4485,7 +4550,7 @@ fn dragging_a_repo_tab_past_the_strip_ends_keeps_it_inside(cx: &mut gpui::TestAp
 }
 
 #[gpui::test]
-fn add_repo_button_stays_pinned_right_of_overflowing_tabs(cx: &mut gpui::TestAppContext) {
+fn add_repo_button_follows_the_last_overflowing_tab(cx: &mut gpui::TestAppContext) {
     let (store, events) = AppStore::new(Arc::new(TestBackend));
     let store_for_test = store.clone();
     let (view, cx) = cx.add_window_view(|window, cx| {
@@ -4503,16 +4568,19 @@ fn add_repo_button_stays_pinned_right_of_overflowing_tabs(cx: &mut gpui::TestApp
     let first_tab = cx
         .debug_bounds(repo_tab_selector(repo_ids[0]))
         .expect("expected first repository tab bounds");
+    let last_tab = cx
+        .debug_bounds(repo_tab_selector(*repo_ids.last().expect("repo ids")))
+        .expect("expected final repository tab bounds");
 
     assert!(cx.debug_bounds("tab_bar_scroll_left").is_none());
     assert!(cx.debug_bounds("tab_bar_scroll_right").is_none());
     assert!(
-        plus.left() >= strip.right() - px(1.0),
-        "expected the + button to occupy a reserved rail after the scroll viewport"
+        plus.left() >= last_tab.right(),
+        "expected the + button to follow the final overflowing repository tab"
     );
     assert!(
         first_tab.right() <= strip.right() + px(1.0),
-        "expected visible repository tabs not to overlap the sticky + button"
+        "expected visible repository tabs to stay within the scroll viewport"
     );
 }
 
@@ -4524,7 +4592,7 @@ fn add_repo_button_stays_at_the_strip_end_when_tabs_fit(cx: &mut gpui::TestAppCo
         crate::view::GitCometView::new(store, events, None, window, cx)
     });
 
-    let _repo_ids = open_repo_tabs(cx, &store_for_test, view.clone(), "tab_plus_sticky", 3);
+    let repo_ids = open_repo_tabs(cx, &store_for_test, view.clone(), "tab_plus_sticky", 3);
     let (_, max_scroll) = repo_tab_scroll(cx, &view);
     assert_eq!(max_scroll, px(0.0), "expected three tabs not to overflow");
 
@@ -4534,10 +4602,22 @@ fn add_repo_button_stays_at_the_strip_end_when_tabs_fit(cx: &mut gpui::TestAppCo
     let strip = cx.update(|_window, app| {
         crate::view::test_support::repo_tab_strip_viewport(view.read(app), app)
     });
+    let last_tab = cx
+        .debug_bounds(repo_tab_selector(*repo_ids.last().expect("repo ids")))
+        .expect("expected final repository tab bounds");
 
     assert!(
-        plus.left() >= strip.right() - px(1.0),
-        "expected the + button to stay sticky after the repository scroll viewport"
+        plus.left() >= last_tab.right(),
+        "expected the + button after the final repository tab"
+    );
+    assert!(
+        plus.left() <= last_tab.right() + px(12.0),
+        "expected the + button to hug the final repository tab, got a {:?} gap",
+        plus.left() - last_tab.right()
+    );
+    assert!(
+        plus.right() < strip.right(),
+        "expected unused title-bar space to remain after the inline + button"
     );
     assert!(
         cx.debug_bounds("tab_bar_scroll_right").is_none(),

--- a/crates/gitcomet-ui-gpui/src/smoke_tests.rs
+++ b/crates/gitcomet-ui-gpui/src/smoke_tests.rs
@@ -1493,6 +1493,14 @@ fn repo_tab_selector(repo_id: RepoId) -> &'static str {
     Box::leak(format!("repo_tab_{}", repo_id.0).into_boxed_str())
 }
 
+fn repo_tab_separator_selector(repo_id: RepoId) -> &'static str {
+    Box::leak(format!("repo_tab_separator_after_{}", repo_id.0).into_boxed_str())
+}
+
+fn repo_tab_label_selector(repo_id: RepoId) -> &'static str {
+    Box::leak(format!("repo_tab_label_{}", repo_id.0).into_boxed_str())
+}
+
 fn worktrees_spinner_selector(repo_id: RepoId) -> &'static str {
     Box::leak(format!("worktrees_spinner_{}", repo_id.0).into_boxed_str())
 }
@@ -3961,7 +3969,14 @@ fn repo_tab_scroll_arrows_appear_only_when_tabs_overflow(cx: &mut gpui::TestAppC
         crate::view::GitCometView::new(store, events, None, window, cx)
     });
 
-    open_repo_tabs(cx, &store_for_test, view.clone(), "tab_arrows_few", 2);
+    let roomy_repo_ids = open_repo_tabs(cx, &store_for_test, view.clone(), "tab_arrows_few", 2);
+    let roomy_tab = cx
+        .debug_bounds(repo_tab_selector(roomy_repo_ids[0]))
+        .expect("expected a repository tab in the roomy strip");
+    let roomy_label = cx
+        .debug_bounds(repo_tab_label_selector(roomy_repo_ids[0]))
+        .expect("expected a repository label in the roomy strip");
+    let roomy_leading_inset = roomy_label.left() - roomy_tab.left();
 
     assert!(
         cx.debug_bounds("tab_bar_scroll_left").is_none()
@@ -3979,13 +3994,60 @@ fn repo_tab_scroll_arrows_appear_only_when_tabs_overflow(cx: &mut gpui::TestAppC
                 .join(format!("repository-number-{ix}"))
         })
         .collect();
-    restore_session_and_draw(cx, &store_for_test, view.clone(), repos);
+    let dense_repo_ids = restore_session_and_draw(cx, &store_for_test, view.clone(), repos);
     sync_view_for_tests(cx, &view);
 
     assert!(
         cx.debug_bounds("tab_bar_scroll_left").is_some()
             && cx.debug_bounds("tab_bar_scroll_right").is_some(),
         "expected both scroll arrows once the tabs overflow"
+    );
+    let dense_tab = cx
+        .debug_bounds(repo_tab_selector(dense_repo_ids[0]))
+        .expect("expected a repository tab in the dense strip");
+    let dense_label = cx
+        .debug_bounds(repo_tab_label_selector(dense_repo_ids[0]))
+        .expect("expected a repository label in the dense strip");
+    let dense_leading_inset = dense_label.left() - dense_tab.left();
+    assert!(
+        dense_leading_inset < roomy_leading_inset,
+        "expected side padding to shrink as the tab strip gets denser, got \
+         roomy={roomy_leading_inset:?}, dense={dense_leading_inset:?}"
+    );
+    let drag_region = cx
+        .debug_bounds("titlebar_drag")
+        .expect("expected a window drag region after overflowing repository tabs");
+    assert!(
+        drag_region.size.width >= px(60.0),
+        "expected repository tabs to leave a useful window drag region, got {:?}",
+        drag_region.size.width
+    );
+}
+
+#[gpui::test]
+fn repo_tabs_show_separators_only_between_inactive_tabs(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let store_for_test = store.clone();
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        crate::view::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_ids = open_repo_tabs(cx, &store_for_test, view, "tab_inactive_separators", 3);
+
+    assert!(
+        cx.debug_bounds(repo_tab_separator_selector(repo_ids[0]))
+            .is_none(),
+        "expected no separator between the active tab and its inactive neighbour"
+    );
+    assert!(
+        cx.debug_bounds(repo_tab_separator_selector(repo_ids[1]))
+            .is_some(),
+        "expected a separator between adjacent inactive tabs"
+    );
+    assert!(
+        cx.debug_bounds(repo_tab_separator_selector(repo_ids[2]))
+            .is_none(),
+        "expected no separator after the final tab"
     );
 }
 

--- a/crates/gitcomet-ui-gpui/src/view/chrome.rs
+++ b/crates/gitcomet-ui-gpui/src/view/chrome.rs
@@ -140,6 +140,7 @@ pub(super) fn titlebar_control_button(
         .items_center()
         .justify_center()
         .cursor(CursorStyle::PointingHand)
+        .block_mouse_except_scroll()
         .child(
             div()
                 .id(id)
@@ -352,6 +353,11 @@ impl TitleBarView {
         self.app_menu_focus_handle.clone()
     }
 
+    #[cfg(test)]
+    pub(in crate::view) fn title_drag_armed_for_test(&self) -> bool {
+        self.title_drag_state.should_move
+    }
+
     pub(super) fn set_theme(&mut self, theme: AppTheme, cx: &mut gpui::Context<Self>) {
         self.theme = theme;
         cx.notify();
@@ -425,8 +431,6 @@ impl Render for TitleBarView {
         let app_menu_focus_handle = self.app_menu_focus_handle.clone();
 
         let menu_toggle = div()
-            .id("app_menu")
-            .debug_selector(|| "app_menu".to_string())
             .h_full()
             .pl(scaled_px(2.0))
             .flex()
@@ -455,13 +459,9 @@ impl Render for TitleBarView {
                     .h(scaled_px(26.0))
                     .w(scaled_px(32.0))
                     .rounded(px(theme.radii.pill))
+                    .block_mouse_except_scroll()
+                    .debug_selector(|| "app_menu".to_string())
                     .gitcomet_tooltip(theme, "Application menu".into()),
-            )
-            .on_mouse_up(
-                MouseButton::Right,
-                cx.listener(|_this, e: &MouseUpEvent, window, cx| {
-                    show_titlebar_secondary_menu(e.position, window, cx);
-                }),
             );
 
         // Browser-style repository switcher: a bare chevron beside the app menu
@@ -470,20 +470,22 @@ impl Render for TitleBarView {
         let repo_picker_open = self.repo_picker_open;
         let repo_picker_toggle_bounds = Rc::clone(&self.repo_picker_toggle_bounds);
         let repo_picker_toggle = div()
-            .id("repo_picker_toggle")
-            .debug_selector(|| "repo_picker_toggle".to_string())
             .h_full()
             .flex()
             .items_center()
-            .cursor(CursorStyle::PointingHand)
+            .on_children_prepainted(move |children_bounds, _window, _cx| {
+                repo_picker_toggle_bounds.set(children_bounds.first().copied());
+            })
             .child(
                 div()
                     .id("repo_picker_btn")
+                    .debug_selector(|| "repo_picker_toggle".to_string())
                     .h(scaled_px(26.0))
                     .w(scaled_px(32.0))
                     .flex()
                     .items_center()
                     .justify_center()
+                    .cursor(CursorStyle::PointingHand)
                     .rounded(px(theme.radii.pill))
                     // Stay lit in the pressed/open color while the picker popover
                     // is open, mirroring the app-menu button.
@@ -506,27 +508,22 @@ impl Render for TitleBarView {
                         "icons/chevron_down.svg",
                         theme.colors.text,
                         scaled_px(16.0),
-                    )),
-            )
-            .on_click(cx.listener(|this, e: &ClickEvent, window, cx| {
-                this.open_popover_at(PopoverKind::RepoPicker, e.position(), window, cx);
-            }))
-            .gitcomet_tooltip(theme, "Switch repository".into());
-        let repo_picker_toggle = div()
-            .on_children_prepainted(move |children_bounds, _window, _cx| {
-                repo_picker_toggle_bounds.set(children_bounds.first().copied());
-            })
-            .child(repo_picker_toggle);
+                    ))
+                    .block_mouse_except_scroll()
+                    .on_click(cx.listener(|this, e: &ClickEvent, window, cx| {
+                        this.open_popover_at(PopoverKind::RepoPicker, e.position(), window, cx);
+                    }))
+                    .gitcomet_tooltip(theme, "Switch repository".into()),
+            );
 
-        let drag_region = div()
+        // One drag surface spans the title bar underneath its controls. Each
+        // visible control occludes only its painted bounds, so the uncovered
+        // title above and below it behaves like ordinary window chrome.
+        let drag_surface = div()
             .id("title_drag")
             .debug_selector(|| "titlebar_drag".to_string())
-            .flex_1()
-            .h_full()
-            .flex()
-            .items_center()
-            .min_w(px(0.0))
-            .px(scaled_px(8.0))
+            .absolute()
+            .inset_0()
             .window_control_area(WindowControlArea::Drag)
             .on_click(cx.listener(|this, e: &ClickEvent, window, cx| {
                 if !should_handle_titlebar_double_click(e.click_count(), e.standard_click()) {
@@ -679,6 +676,7 @@ impl Render for TitleBarView {
                     .border_color(free_badge_active_border)
                     .text_color(theme.colors.accent)
             })
+            .block_mouse_except_scroll()
             .on_click(cx.listener(|_this, _e: &ClickEvent, _window, cx| {
                 cx.stop_propagation();
                 cx.open_url(EDITIONS_URL);
@@ -732,12 +730,11 @@ impl Render for TitleBarView {
                         .flex()
                         .flex_none()
                         .w(scaled_px(REPO_TABS_TRAILING_DRAG_WIDTH_PX))
-                        .h_full()
-                        .child(drag_region),
+                        .h_full(),
                 )
                 .into_any_element()
         } else {
-            drag_region.into_any_element()
+            div().flex_1().h_full().into_any_element()
         };
 
         let frame_rounding = client_frame_corner_rounding(theme, window);
@@ -767,6 +764,7 @@ impl Render for TitleBarView {
                         .bg(theme.colors.border),
                 )
             })
+            .child(drag_surface)
             .child(leading)
             .child(middle)
             .child(

--- a/crates/gitcomet-ui-gpui/src/view/chrome.rs
+++ b/crates/gitcomet-ui-gpui/src/view/chrome.rs
@@ -5,6 +5,9 @@ use std::rc::Rc;
 
 pub(super) const CLIENT_SIDE_DECORATION_INSET_PX: f32 = 10.0;
 pub(super) const TITLE_BAR_HEIGHT_PX: f32 = 38.0;
+/// Empty title-bar width kept beside repository tabs so the window always has
+/// an easy-to-hit drag surface, even when the tab strip overflows.
+const REPO_TABS_TRAILING_DRAG_WIDTH_PX: f32 = 64.0;
 const MACOS_TRAFFIC_LIGHTS_SAFE_INSET_PX: f32 = 78.0;
 #[cfg(test)]
 pub(super) const CLIENT_SIDE_DECORATION_INSET: Pixels = px(CLIENT_SIDE_DECORATION_INSET_PX);
@@ -711,11 +714,27 @@ impl Render for TitleBarView {
         };
         let middle: AnyElement = if let Some(repo_tabs) = repo_tabs {
             div()
+                .flex()
                 .flex_1()
                 .min_w(px(0.0))
                 .h_full()
                 .overflow_hidden()
-                .child(repo_tabs)
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w(px(0.0))
+                        .h_full()
+                        .overflow_hidden()
+                        .child(repo_tabs),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .flex_none()
+                        .w(scaled_px(REPO_TABS_TRAILING_DRAG_WIDTH_PX))
+                        .h_full()
+                        .child(drag_region),
+                )
                 .into_any_element()
         } else {
             drag_region.into_any_element()

--- a/crates/gitcomet-ui-gpui/src/view/chrome.rs
+++ b/crates/gitcomet-ui-gpui/src/view/chrome.rs
@@ -406,6 +406,18 @@ impl TitleBarView {
             root.open_popover_at(kind, anchor, window, cx);
         });
     }
+
+    fn open_popover_for_bounds(
+        &mut self,
+        kind: PopoverKind,
+        anchor_bounds: Bounds<Pixels>,
+        window: &mut Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let _ = self.root_view.update(cx, |root, cx| {
+            root.open_popover_for_bounds(kind, anchor_bounds, window, cx);
+        });
+    }
 }
 
 impl Render for TitleBarView {
@@ -468,13 +480,14 @@ impl Render for TitleBarView {
         // (and the repo tabs) that opens the repository picker. Replaces the old
         // labelled "Repositories" button that used to sit in the action bar.
         let repo_picker_open = self.repo_picker_open;
-        let repo_picker_toggle_bounds = Rc::clone(&self.repo_picker_toggle_bounds);
+        let repo_picker_toggle_bounds_for_prepaint = Rc::clone(&self.repo_picker_toggle_bounds);
+        let repo_picker_toggle_bounds_for_click = Rc::clone(&self.repo_picker_toggle_bounds);
         let repo_picker_toggle = div()
             .h_full()
             .flex()
             .items_center()
             .on_children_prepainted(move |children_bounds, _window, _cx| {
-                repo_picker_toggle_bounds.set(children_bounds.first().copied());
+                repo_picker_toggle_bounds_for_prepaint.set(children_bounds.first().copied());
             })
             .child(
                 div()
@@ -510,8 +523,18 @@ impl Render for TitleBarView {
                         scaled_px(16.0),
                     ))
                     .block_mouse_except_scroll()
-                    .on_click(cx.listener(|this, e: &ClickEvent, window, cx| {
-                        this.open_popover_at(PopoverKind::RepoPicker, e.position(), window, cx);
+                    .on_click(cx.listener(move |this, e: &ClickEvent, window, cx| {
+                        let anchor_bounds = repo_picker_toggle_bounds_for_click
+                            .get()
+                            .unwrap_or_else(|| {
+                                Bounds::new(e.position(), gpui::size(px(0.0), px(0.0)))
+                            });
+                        this.open_popover_for_bounds(
+                            PopoverKind::RepoPicker,
+                            anchor_bounds,
+                            window,
+                            cx,
+                        );
                     }))
                     .gitcomet_tooltip(theme, "Switch repository".into()),
             );
@@ -761,7 +784,7 @@ impl Render for TitleBarView {
                         .left_0()
                         .right_0()
                         .h(px(1.0))
-                        .bg(theme.colors.border),
+                        .bg(components::Tab::outline_color(theme)),
                 )
             })
             .child(drag_surface)

--- a/crates/gitcomet-ui-gpui/src/view/components/context_menu.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/context_menu.rs
@@ -285,15 +285,7 @@ fn context_menu_entry<V: 'static>(
         ContextMenuIconSlot::Reserved | ContextMenuIconSlot::None => None,
     };
     let icon_color = context_menu_icon_color(theme, disabled, label.as_ref(), icon_path);
-    let text_color = if disabled {
-        theme.colors.text_muted
-    } else if icon_color == theme.colors.danger {
-        // Destructive entries carry the danger tint on the label too, not
-        // just the icon.
-        theme.colors.danger
-    } else {
-        theme.colors.text
-    };
+    let text_color = context_menu_entry_text_color(theme, disabled, icon_color);
     // Text-alpha overlays stay visible on the elevated popover surface, where
     // the `hover` token (tuned for the darker canvas) has no contrast.
     let hover_overlay = theme.hover_overlay();
@@ -386,6 +378,21 @@ fn context_menu_entry<V: 'static>(
     row
 }
 
+fn context_menu_entry_text_color(
+    theme: AppTheme,
+    disabled: bool,
+    icon_color: gpui::Rgba,
+) -> gpui::Rgba {
+    if disabled {
+        theme.colors.text_muted
+    } else if icon_color == theme.colors.danger {
+        // Destructive entries carry the danger tint on both icon and label.
+        theme.colors.danger
+    } else {
+        theme.colors.text
+    }
+}
+
 fn context_menu_icon_color(
     theme: AppTheme,
     disabled: bool,
@@ -394,6 +401,10 @@ fn context_menu_icon_color(
 ) -> gpui::Rgba {
     if disabled {
         return theme.colors.text_muted;
+    }
+
+    if label == "Close" && icon_path == Some("icons/repo_tab_close.svg") {
+        return theme.colors.accent;
     }
 
     // Semantic-ish mapping for common actions.
@@ -624,11 +635,29 @@ mod tests {
         );
         assert_eq!(
             context_menu_icon_color(theme, false, "Close", Some("icons/repo_tab_close.svg")),
-            theme.colors.danger
+            theme.colors.text
         );
         assert_eq!(
             context_menu_icon_color(theme, false, "Force push", Some("icons/warning.svg")),
             theme.colors.warning
+        );
+    }
+
+    #[test]
+    fn context_menu_close_uses_normal_text_and_standard_icon_color() {
+        let theme = AppTheme::gitcomet_dark();
+        let close_icon =
+            context_menu_icon_color(theme, false, "Close", Some("icons/repo_tab_close.svg"));
+
+        assert_eq!(close_icon, theme.colors.accent);
+        assert_eq!(
+            context_menu_entry_text_color(theme, false, close_icon),
+            theme.colors.text
+        );
+        assert_eq!(
+            context_menu_entry_text_color(theme, false, theme.colors.danger),
+            theme.colors.danger,
+            "other destructive entries should retain their danger text"
         );
     }
 

--- a/crates/gitcomet-ui-gpui/src/view/components/context_menu.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/context_menu.rs
@@ -635,7 +635,7 @@ mod tests {
         );
         assert_eq!(
             context_menu_icon_color(theme, false, "Close", Some("icons/repo_tab_close.svg")),
-            theme.colors.text
+            theme.colors.accent
         );
         assert_eq!(
             context_menu_icon_color(theme, false, "Force push", Some("icons/warning.svg")),

--- a/crates/gitcomet-ui-gpui/src/view/components/mod.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/mod.rs
@@ -8,6 +8,7 @@ mod diff_stat;
 mod interactive_row;
 mod modal;
 mod picker_prompt;
+mod repository_badge;
 mod resize_grip;
 mod shortcut_keys;
 mod split_button;
@@ -38,12 +39,15 @@ pub use modal::{modal_scrim, modal_surface};
 pub use picker_prompt::{
     PickerPrompt, PickerPromptItem, PickerPromptItemPart, PickerPromptLayout, picker_prompt_layout,
 };
+pub use repository_badge::{
+    REPOSITORY_BADGE_SIZE_PX, repository_initials, repository_initials_box,
+};
 pub use resize_grip::{ResizeGripAxis, resize_grip};
 pub use shortcut_keys::shortcut_keys;
 pub use split_button::{SplitButton, SplitButtonStyle};
 pub use tab::Tab;
 pub use tab_bar::{TabBar, TabBarScroll};
-pub use text_fade::FadingText;
+pub use text_fade::{FadingText, trailing_fade};
 pub use toast::{ToastKind, toast};
 pub use tokens::*;
 pub(crate) use truncated_text::{

--- a/crates/gitcomet-ui-gpui/src/view/components/picker_prompt.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/picker_prompt.rs
@@ -40,6 +40,7 @@ pub struct PickerPromptItem {
     match_text: SharedString,
     parts: Vec<PickerPromptItemPart>,
     icon: Option<&'static str>,
+    repository_initials: Option<SharedString>,
     section: Option<SharedString>,
     removable: bool,
 }
@@ -334,7 +335,11 @@ impl PickerPrompt {
                 );
                 let on_select = Arc::clone(&on_select);
                 let original_index = m.index;
-                let row_icon = self.items[original_index].icon.or(leading_icon);
+                let row_initials = self.items[original_index].repository_initials.clone();
+                let row_icon = row_initials
+                    .is_none()
+                    .then(|| self.items[original_index].icon.or(leading_icon))
+                    .flatten();
                 let is_selected = selected_index == Some(display_ix);
                 let is_marked = self.marked_index == Some(original_index);
                 let is_removable = self.items[original_index].removable;
@@ -362,6 +367,19 @@ impl PickerPrompt {
                             },
                             scaled_px(14.0),
                         ))
+                    })
+                    .when_some(row_initials, |row, initials| {
+                        row.child(
+                            super::repository_initials_box(
+                                theme,
+                                ui_scale,
+                                initials,
+                                is_selected || is_marked,
+                            )
+                            .debug_selector(move || {
+                                format!("picker_prompt_repository_badge_{original_index}")
+                            }),
+                        )
                     })
                     .child(div().flex_1().min_w(px(0.0)).child(label))
                     .when(is_marked, |row| {
@@ -508,6 +526,7 @@ impl PickerPromptItem {
             match_text: match_text.into(),
             parts: built_parts,
             icon: None,
+            repository_initials: None,
             section: None,
             removable: false,
         }
@@ -515,6 +534,13 @@ impl PickerPromptItem {
 
     pub fn icon(mut self, icon: &'static str) -> Self {
         self.icon = Some(icon);
+        self
+    }
+
+    /// Uses the shared repository initials box in the row's leading slot.
+    /// This takes precedence over both item and picker-level SVG icons.
+    pub fn repository_initials(mut self, repository_name: &str) -> Self {
+        self.repository_initials = Some(super::repository_initials(repository_name).into());
         self
     }
 

--- a/crates/gitcomet-ui-gpui/src/view/components/repository_badge.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/repository_badge.rs
@@ -1,0 +1,154 @@
+use crate::theme::{AppTheme, with_alpha};
+use crate::ui_scale::UiScale;
+use gpui::prelude::*;
+use gpui::{Div, FontWeight, SharedString, TextRun, div, point, px};
+
+pub const REPOSITORY_BADGE_SIZE_PX: f32 = 18.0;
+const REPOSITORY_BADGE_FONT_SIZE_PX: f32 = 8.5;
+const REPOSITORY_BADGE_RADIUS_PX: f32 = 4.0;
+
+/// Prefer word/camel-case boundaries (`GitComet`, `git-comet` -> `GC`), then
+/// fill from the remaining letters so a single-word name still gets two
+/// characters (`repository` -> `RE`).
+pub fn repository_initials(name: &str) -> String {
+    let mut preferred = [(0, '\0'); 2];
+    let mut preferred_len = 0;
+    let mut previous = None;
+    for (ix, character) in name.char_indices() {
+        if !character.is_alphanumeric() {
+            previous = Some(character);
+            continue;
+        }
+        if previous.is_none_or(|previous| !previous.is_alphanumeric())
+            || previous.is_some_and(|previous| previous.is_lowercase() && character.is_uppercase())
+        {
+            preferred[preferred_len] = (ix, character);
+            preferred_len += 1;
+            if preferred_len == preferred.len() {
+                break;
+            }
+        }
+        previous = Some(character);
+    }
+
+    if preferred_len < preferred.len() {
+        for (ix, character) in name.char_indices() {
+            let already_selected = preferred[..preferred_len]
+                .iter()
+                .any(|&(selected_ix, _)| selected_ix == ix);
+            if character.is_alphanumeric() && !already_selected {
+                preferred[preferred_len] = (ix, character);
+                preferred_len += 1;
+                if preferred_len == preferred.len() {
+                    break;
+                }
+            }
+        }
+    }
+
+    let mut initials = String::new();
+    let mut initials_len = 0;
+    for &(_, character) in &preferred[..preferred_len] {
+        for uppercase in character.to_uppercase() {
+            initials.push(uppercase);
+            initials_len += 1;
+            if initials_len == 2 {
+                return initials;
+            }
+        }
+    }
+    if initials.is_empty() {
+        initials.push('?');
+    }
+    initials
+}
+
+/// Shared repository mark used by tabs and repository-picker rows. Capital
+/// ink is centered by cap height, and a slight radius keeps the silhouette a
+/// compact box rather than an avatar-like circle.
+pub fn repository_initials_box(
+    theme: AppTheme,
+    scale: impl Into<UiScale>,
+    initials: SharedString,
+    active: bool,
+) -> Div {
+    let scale = scale.into();
+    let foreground = if active {
+        theme.colors.accent
+    } else {
+        with_alpha(theme.colors.text, if theme.is_dark { 0.72 } else { 0.62 })
+    };
+    let background = if active {
+        with_alpha(theme.colors.accent, if theme.is_dark { 0.28 } else { 0.18 })
+    } else {
+        with_alpha(theme.colors.text, if theme.is_dark { 0.16 } else { 0.11 })
+    };
+    let size = scale.px(REPOSITORY_BADGE_SIZE_PX);
+    let font_size = scale.px(REPOSITORY_BADGE_FONT_SIZE_PX);
+
+    div()
+        .flex_none()
+        .size(size)
+        .rounded(scale.px(REPOSITORY_BADGE_RADIUS_PX))
+        .bg(background)
+        .child(
+            gpui::canvas(
+                |_bounds, _window, _cx| {},
+                move |bounds, (), window, cx| {
+                    let mut font = window.text_style().font();
+                    font.weight = FontWeight::SEMIBOLD;
+                    let run = TextRun {
+                        len: initials.len(),
+                        font,
+                        color: foreground.into(),
+                        background_color: None,
+                        underline: None,
+                        strikethrough: None,
+                    };
+                    let shaped =
+                        window
+                            .text_system()
+                            .shape_line(initials.clone(), font_size, &[run], None);
+                    let cap_height = shaped
+                        .runs
+                        .first()
+                        .map(|run| window.text_system().cap_height(run.font_id, font_size))
+                        .unwrap_or(font_size * 0.7);
+                    let origin = point(
+                        bounds.left() + (bounds.size.width - shaped.width).max(px(0.0)) * 0.5,
+                        super::initials_paint_origin_y(
+                            bounds.top(),
+                            bounds.size.height,
+                            bounds.size.height,
+                            shaped.ascent,
+                            shaped.descent,
+                            cap_height,
+                        ),
+                    );
+                    let _ = shaped.paint(
+                        origin,
+                        bounds.size.height,
+                        gpui::TextAlign::Left,
+                        None,
+                        window,
+                        cx,
+                    );
+                },
+            )
+            .size_full(),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repository_initials_use_name_boundaries_then_fill_from_the_name() {
+        assert_eq!(repository_initials("GitComet"), "GC");
+        assert_eq!(repository_initials("git-comet"), "GC");
+        assert_eq!(repository_initials("repository"), "RE");
+        assert_eq!(repository_initials("x"), "X");
+        assert_eq!(repository_initials("***"), "?");
+    }
+}

--- a/crates/gitcomet-ui-gpui/src/view/components/tab.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/tab.rs
@@ -1,11 +1,137 @@
 use crate::theme::AppTheme;
 use crate::ui_scale::UiScale;
 use gpui::prelude::*;
-use gpui::{AnyElement, Div, ElementId, IntoElement, Stateful, div, px};
+use gpui::{AnyElement, Div, ElementId, IntoElement, Pixels, Stateful, Window, div, point, px};
 
 /// Tab height inside the title bar; the difference to the bar height is the
 /// uncovered title chrome above a browser-style repository tab.
 pub(super) const TAB_HEIGHT_PX: f32 = 34.0;
+
+/// Paints the selected tab as one continuous browser-style silhouette. The
+/// lower curves are deliberately concave: each starts on a vertical tab edge
+/// one radius above the rail and ends one radius outside the tab on the rail.
+fn selected_tab_shape(
+    fill: gpui::Rgba,
+    border: gpui::Rgba,
+    top_radius: Pixels,
+    bottom_curve_radius: Pixels,
+) -> AnyElement {
+    let paint = move |bounds: gpui::Bounds<Pixels>, window: &mut Window| {
+        use gpui::PathBuilder;
+
+        // Cubic approximation of a quarter circle.
+        const K: f32 = 0.552_284_7;
+
+        let body_left = bounds.left() + bottom_curve_radius;
+        let body_right = bounds.right() - bottom_curve_radius;
+        let top = bounds.top();
+        let bottom = bounds.bottom();
+        let top_radius = top_radius
+            .min((body_right - body_left) * 0.5)
+            .min(bounds.size.height);
+        let bottom_curve_radius = bottom_curve_radius.min(bounds.size.height);
+        let top_k = top_radius * K;
+        let bottom_k = bottom_curve_radius * K;
+
+        let mut silhouette = PathBuilder::fill();
+        silhouette.move_to(point(body_left + top_radius, top));
+        silhouette.line_to(point(body_right - top_radius, top));
+        silhouette.cubic_bezier_to(
+            point(body_right, top + top_radius),
+            point(body_right - top_radius + top_k, top),
+            point(body_right, top + top_radius - top_k),
+        );
+        silhouette.line_to(point(body_right, bottom - bottom_curve_radius));
+        silhouette.cubic_bezier_to(
+            point(bounds.right(), bottom),
+            point(body_right, bottom - bottom_curve_radius + bottom_k),
+            point(bounds.right() - bottom_k, bottom),
+        );
+        silhouette.line_to(point(bounds.left(), bottom));
+        silhouette.cubic_bezier_to(
+            point(body_left, bottom - bottom_curve_radius),
+            point(bounds.left() + bottom_k, bottom),
+            point(body_left, bottom - bottom_curve_radius + bottom_k),
+        );
+        silhouette.line_to(point(body_left, top + top_radius));
+        silhouette.cubic_bezier_to(
+            point(body_left + top_radius, top),
+            point(body_left, top + top_radius - top_k),
+            point(body_left + top_radius - top_k, top),
+        );
+        silhouette.close();
+        if let Ok(path) = silhouette.build() {
+            window.paint_path(path, fill);
+        }
+
+        // Leave the baseline open so the selected tab remains fused to the
+        // workspace surface below it. Unlike filled layout borders, a stroked
+        // path is centered on its coordinates. Snap those coordinates to
+        // physical pixel centers and use exactly one physical pixel of width;
+        // otherwise the straight portions straddle two pixels and look soft.
+        let stroke_width = px(1.0 / window.scale_factor().max(1.0));
+        let half_stroke = stroke_width * 0.5;
+        let outline_left = window.pixel_snap(bounds.left()) + half_stroke;
+        let outline_right = window.pixel_snap(bounds.right()) - half_stroke;
+        let outline_body_left = window.pixel_snap(body_left) + half_stroke;
+        let outline_body_right = window.pixel_snap(body_right) - half_stroke;
+        let outline_top = window.pixel_snap(top) + half_stroke;
+        let outline_bottom = window.pixel_snap(bottom) - half_stroke;
+
+        let mut outline = PathBuilder::stroke(stroke_width);
+        outline.move_to(point(outline_left, outline_bottom));
+        outline.cubic_bezier_to(
+            point(outline_body_left, outline_bottom - bottom_curve_radius),
+            point(outline_left + bottom_k, outline_bottom),
+            point(
+                outline_body_left,
+                outline_bottom - bottom_curve_radius + bottom_k,
+            ),
+        );
+        outline.line_to(point(outline_body_left, outline_top + top_radius));
+        outline.cubic_bezier_to(
+            point(outline_body_left + top_radius, outline_top),
+            point(outline_body_left, outline_top + top_radius - top_k),
+            point(outline_body_left + top_radius - top_k, outline_top),
+        );
+        outline.line_to(point(outline_body_right - top_radius, outline_top));
+        outline.cubic_bezier_to(
+            point(outline_body_right, outline_top + top_radius),
+            point(outline_body_right - top_radius + top_k, outline_top),
+            point(outline_body_right, outline_top + top_radius - top_k),
+        );
+        outline.line_to(point(
+            outline_body_right,
+            outline_bottom - bottom_curve_radius,
+        ));
+        outline.cubic_bezier_to(
+            point(outline_right, outline_bottom),
+            point(
+                outline_body_right,
+                outline_bottom - bottom_curve_radius + bottom_k,
+            ),
+            point(outline_right - bottom_k, outline_bottom),
+        );
+        if let Ok(path) = outline.build() {
+            window.paint_path(path, border);
+        }
+    };
+
+    div()
+        .absolute()
+        .top_0()
+        .bottom_0()
+        .left(-bottom_curve_radius)
+        .right(-bottom_curve_radius)
+        .child(
+            gpui::canvas(
+                |_, _, _| (),
+                move |bounds, _, window, _| paint(bounds, window),
+            )
+            .size_full(),
+        )
+        .into_any_element()
+}
 
 pub struct Tab {
     div: Stateful<Div>,
@@ -21,7 +147,10 @@ impl Tab {
     /// the bar's bottom edge, so without this its label would sit below the
     /// bar midline that the title bar icons center on.
     const TAB_BOTTOM_FUSE_PAD_PX: f32 = 4.0;
+    const TAB_TOP_PADDING_PX: f32 = 2.0;
     const TAB_HORIZONTAL_PADDING_PX: f32 = 10.0;
+    const TAB_HORIZONTAL_MARGIN_PX: f32 = 4.0;
+    const TAB_BOTTOM_CURVE_RADIUS_PX: f32 = 8.0;
     /// Tabs shrink no further than this before the strip scrolls.
     const TAB_MIN_WIDTH_PX: f32 = 102.0;
 
@@ -29,6 +158,21 @@ impl Tab {
     /// top of a tab (the label fade) can flatten it into a matching color.
     pub fn hover_overlay(theme: AppTheme) -> gpui::Rgba {
         theme.hover_overlay()
+    }
+
+    /// Stronger shared rule for the active tab outline and the workspace edge
+    /// it joins. Pulling the theme border toward its text color increases
+    /// contrast in the correct direction for both dark and light themes.
+    pub fn outline_color(theme: AppTheme) -> gpui::Rgba {
+        let amount = if theme.is_dark { 0.18 } else { 0.14 };
+        let border = theme.colors.border;
+        let text = theme.colors.text;
+        gpui::Rgba {
+            r: border.r + (text.r - border.r) * amount,
+            g: border.g + (text.g - border.g) * amount,
+            b: border.b + (text.b - border.b) * amount,
+            a: border.a + (text.a - border.a) * amount,
+        }
     }
 
     pub fn new(id: impl Into<ElementId>) -> Self {
@@ -98,14 +242,20 @@ impl Tab {
         } else {
             theme.colors.text_muted
         };
-        let hover_bg = Self::hover_overlay(theme);
-        let active_bg = theme.colors.active;
         let natural_width = self.natural_width;
+        let selected_shape = self.selected.then(|| {
+            selected_tab_shape(
+                theme.colors.sidebar_bg,
+                Self::outline_color(theme),
+                px(theme.radii.control),
+                scaled_px(Self::TAB_BOTTOM_CURVE_RADIUS_PX),
+            )
+        });
 
         let end_slot = self.end_slot.map(|slot| {
             div()
                 .absolute()
-                .top_0()
+                .top(scaled_px(Self::TAB_TOP_PADDING_PX))
                 .bottom(scaled_px(Self::TAB_BOTTOM_FUSE_PAD_PX))
                 .right(horizontal_padding)
                 .flex()
@@ -114,22 +264,25 @@ impl Tab {
                 .child(slot)
         });
 
-        // Browser-style tab: both states share the shape — inset from the bar
-        // top, sitting on the bar's bottom edge, rounded top corners only.
-        // Every tab reserves the active tab's top/side border so changing
-        // selection never shifts its contents. The active tab colors that
-        // border and fills with the content-strip color; the bottom stays open
-        // to fuse with the workspace below. Tabs take their label's natural
-        // width while the strip is roomy. Responsive tabs share free space
-        // from the minimum floor upward, so shorter labels reach their natural
-        // width before longer labels and the strip scrolls only at the floor.
+        // Browser-style tab: both states are inset from the bar top and sit on
+        // its bottom edge. The selected state adds concave lower curves which
+        // flare across the gutter and meet the rail at the next tab edge.
+        // Every tab reserves transparent top/side borders so changing
+        // selection never shifts its contents. The selected-state canvas
+        // supplies the visible outline and content-strip fill while leaving
+        // the bottom open to fuse with the workspace below. Tabs take their
+        // label's natural width while the strip is roomy. Responsive tabs
+        // share free space from the minimum floor upward, so shorter labels
+        // reach their natural width before longer labels and the strip scrolls
+        // only at the floor.
         let mut base = self
             .div
             .group("tab")
             .h(scaled_px(TAB_HEIGHT_PX))
             .min_w(scaled_px(Self::TAB_MIN_WIDTH_PX))
-            .mx(scaled_px(3.0))
+            .mx(scaled_px(Self::TAB_HORIZONTAL_MARGIN_PX))
             .px(horizontal_padding)
+            .pt(scaled_px(Self::TAB_TOP_PADDING_PX))
             .pb(scaled_px(Self::TAB_BOTTOM_FUSE_PAD_PX))
             .relative()
             .flex()
@@ -143,6 +296,7 @@ impl Tab {
             .text_color(text_color)
             .cursor_pointer()
             .block_mouse_except_scroll()
+            .children(selected_shape)
             .children(self.children)
             .children(end_slot);
 
@@ -153,15 +307,9 @@ impl Tab {
             base = base.flex_1().max_w(width);
         }
 
-        if self.selected {
-            base = base
-                .bg(theme.colors.sidebar_bg)
-                .border_color(theme.colors.border);
-        } else {
-            base = base
-                .bg(gpui::rgba(0x00000000))
-                .hover(move |s| s.bg(hover_bg))
-                .active(move |s| s.bg(active_bg));
+        if !self.selected {
+            let hover_text = theme.colors.text;
+            base = base.hover(move |s| s.text_color(hover_text));
         }
 
         base

--- a/crates/gitcomet-ui-gpui/src/view/components/tab.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/tab.rs
@@ -3,6 +3,10 @@ use crate::ui_scale::UiScale;
 use gpui::prelude::*;
 use gpui::{AnyElement, Div, ElementId, IntoElement, Stateful, div, px};
 
+/// Tab height inside the title bar; the difference to the bar height is the
+/// uncovered title chrome above a browser-style repository tab.
+pub(super) const TAB_HEIGHT_PX: f32 = 34.0;
+
 pub struct Tab {
     div: Stateful<Div>,
     selected: bool,
@@ -13,9 +17,6 @@ pub struct Tab {
 
 impl Tab {
     const END_TAB_SLOT_SIZE_PX: f32 = 14.0;
-    /// Tab height inside the title bar; the difference to the bar height is
-    /// the top inset that lets the active tab rise like a browser tab.
-    const TAB_HEIGHT_PX: f32 = 34.0;
     /// Bottom padding matching the title bar's top inset. The tab is fused to
     /// the bar's bottom edge, so without this its label would sit below the
     /// bar midline that the title bar icons center on.
@@ -23,7 +24,7 @@ impl Tab {
     const TAB_HORIZONTAL_PADDING_PX: f32 = 10.0;
     const TAB_CONTENT_GAP_PX: f32 = 2.0;
     /// Tabs shrink no further than this before the strip scrolls.
-    const TAB_MIN_WIDTH_PX: f32 = 96.0;
+    const TAB_MIN_WIDTH_PX: f32 = 100.0;
     /// Long repository names truncate rather than widening the tab past this.
     const TAB_MAX_WIDTH_PX: f32 = 180.0;
 
@@ -99,7 +100,7 @@ impl Tab {
         let mut base = self
             .div
             .group("tab")
-            .h(scaled_px(Self::TAB_HEIGHT_PX))
+            .h(scaled_px(TAB_HEIGHT_PX))
             .min_w(scaled_px(Self::TAB_MIN_WIDTH_PX))
             .max_w(scaled_px(Self::TAB_MAX_WIDTH_PX))
             .mx(scaled_px(3.0))
@@ -116,6 +117,7 @@ impl Tab {
             .border_color(gpui::transparent_black())
             .text_color(text_color)
             .cursor_pointer()
+            .block_mouse_except_scroll()
             .children(self.children)
             .child(end_slot);
 

--- a/crates/gitcomet-ui-gpui/src/view/components/tab.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/tab.rs
@@ -11,22 +11,19 @@ pub struct Tab {
     div: Stateful<Div>,
     selected: bool,
     horizontal_padding: Option<gpui::Pixels>,
+    natural_width: Option<gpui::Pixels>,
     end_slot: Option<AnyElement>,
     children: Vec<AnyElement>,
 }
 
 impl Tab {
-    const END_TAB_SLOT_SIZE_PX: f32 = 14.0;
     /// Bottom padding matching the title bar's top inset. The tab is fused to
     /// the bar's bottom edge, so without this its label would sit below the
     /// bar midline that the title bar icons center on.
     const TAB_BOTTOM_FUSE_PAD_PX: f32 = 4.0;
     const TAB_HORIZONTAL_PADDING_PX: f32 = 10.0;
-    const TAB_CONTENT_GAP_PX: f32 = 2.0;
     /// Tabs shrink no further than this before the strip scrolls.
-    const TAB_MIN_WIDTH_PX: f32 = 100.0;
-    /// Long repository names truncate rather than widening the tab past this.
-    const TAB_MAX_WIDTH_PX: f32 = 180.0;
+    const TAB_MIN_WIDTH_PX: f32 = 102.0;
 
     /// Overlay an idle tab picks up on hover. Exposed so anything painted on
     /// top of a tab (the label fade) can flatten it into a matching color.
@@ -40,6 +37,7 @@ impl Tab {
             div: div().id(id.clone()),
             selected: false,
             horizontal_padding: None,
+            natural_width: None,
             end_slot: None,
             children: Vec::new(),
         }
@@ -50,11 +48,33 @@ impl Tab {
         self
     }
 
-    /// Overrides the default side padding. Repository tabs use this to become
-    /// denser as the available strip width per tab decreases.
+    /// Overrides the default side padding.
     pub fn horizontal_padding(mut self, padding: gpui::Pixels) -> Self {
         self.horizontal_padding = Some(padding);
         self
+    }
+
+    /// Lets the layout grow this tab evenly from its minimum width up to its
+    /// natural width. Tabs with short labels reach their cap first, leaving
+    /// the remaining space for longer labels without a measured-width redraw.
+    pub fn responsive_width(mut self, natural_width: gpui::Pixels) -> Self {
+        self.natural_width = Some(natural_width);
+        self
+    }
+
+    /// Natural border-box width for `content_width`, including the tab's
+    /// padding and side borders. The trailing action is an overlay and does
+    /// not participate in this width.
+    pub fn natural_width(
+        content_width: gpui::Pixels,
+        horizontal_padding: gpui::Pixels,
+        ui_scale: impl Into<UiScale>,
+    ) -> gpui::Pixels {
+        let ui_scale = ui_scale.into();
+        let chrome = horizontal_padding * 2.0
+            // Left and right borders are physical one-pixel rules.
+            + px(2.0);
+        (content_width + chrome).max(ui_scale.px(Self::TAB_MIN_WIDTH_PX))
     }
 
     pub fn end_slot(mut self, slot: impl IntoElement) -> Self {
@@ -80,35 +100,40 @@ impl Tab {
         };
         let hover_bg = Self::hover_overlay(theme);
         let active_bg = theme.colors.active;
+        let natural_width = self.natural_width;
 
-        let end_slot = div()
-            .flex_none()
-            .size(scaled_px(Self::END_TAB_SLOT_SIZE_PX))
-            .flex()
-            .items_center()
-            .justify_center()
-            .children(self.end_slot);
+        let end_slot = self.end_slot.map(|slot| {
+            div()
+                .absolute()
+                .top_0()
+                .bottom(scaled_px(Self::TAB_BOTTOM_FUSE_PAD_PX))
+                .right(horizontal_padding)
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(slot)
+        });
 
         // Browser-style tab: both states share the shape — inset from the bar
         // top, sitting on the bar's bottom edge, rounded top corners only.
         // Every tab reserves the active tab's top/side border so changing
         // selection never shifts its contents. The active tab colors that
         // border and fills with the content-strip color; the bottom stays open
-        // to fuse with the workspace below. Width is clamped: long repo names
-        // truncate at the max, and tabs shrink no further than the min before
-        // the strip starts scrolling.
+        // to fuse with the workspace below. Tabs take their label's natural
+        // width while the strip is roomy. Responsive tabs share free space
+        // from the minimum floor upward, so shorter labels reach their natural
+        // width before longer labels and the strip scrolls only at the floor.
         let mut base = self
             .div
             .group("tab")
             .h(scaled_px(TAB_HEIGHT_PX))
             .min_w(scaled_px(Self::TAB_MIN_WIDTH_PX))
-            .max_w(scaled_px(Self::TAB_MAX_WIDTH_PX))
             .mx(scaled_px(3.0))
             .px(horizontal_padding)
             .pb(scaled_px(Self::TAB_BOTTOM_FUSE_PAD_PX))
+            .relative()
             .flex()
             .items_center()
-            .gap(scaled_px(Self::TAB_CONTENT_GAP_PX))
             .rounded_tl(px(theme.radii.control))
             .rounded_tr(px(theme.radii.control))
             .border_t_1()
@@ -119,7 +144,14 @@ impl Tab {
             .cursor_pointer()
             .block_mouse_except_scroll()
             .children(self.children)
-            .child(end_slot);
+            .children(end_slot);
+
+        if let Some(width) = natural_width {
+            // A zero flex basis makes every tab start at the same minimum.
+            // Flex max-width then freezes short tabs as soon as they are full
+            // and redistributes the remaining room among longer tabs.
+            base = base.flex_1().max_w(width);
+        }
 
         if self.selected {
             base = base

--- a/crates/gitcomet-ui-gpui/src/view/components/tab.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/tab.rs
@@ -6,6 +6,7 @@ use gpui::{AnyElement, Div, ElementId, IntoElement, Stateful, div, px};
 pub struct Tab {
     div: Stateful<Div>,
     selected: bool,
+    horizontal_padding: Option<gpui::Pixels>,
     end_slot: Option<AnyElement>,
     children: Vec<AnyElement>,
 }
@@ -19,6 +20,8 @@ impl Tab {
     /// the bar's bottom edge, so without this its label would sit below the
     /// bar midline that the title bar icons center on.
     const TAB_BOTTOM_FUSE_PAD_PX: f32 = 4.0;
+    const TAB_HORIZONTAL_PADDING_PX: f32 = 10.0;
+    const TAB_CONTENT_GAP_PX: f32 = 2.0;
     /// Tabs shrink no further than this before the strip scrolls.
     const TAB_MIN_WIDTH_PX: f32 = 96.0;
     /// Long repository names truncate rather than widening the tab past this.
@@ -35,6 +38,7 @@ impl Tab {
         Self {
             div: div().id(id.clone()),
             selected: false,
+            horizontal_padding: None,
             end_slot: None,
             children: Vec::new(),
         }
@@ -42,6 +46,13 @@ impl Tab {
 
     pub fn selected(mut self, selected: bool) -> Self {
         self.selected = selected;
+        self
+    }
+
+    /// Overrides the default side padding. Repository tabs use this to become
+    /// denser as the available strip width per tab decreases.
+    pub fn horizontal_padding(mut self, padding: gpui::Pixels) -> Self {
+        self.horizontal_padding = Some(padding);
         self
     }
 
@@ -58,6 +69,9 @@ impl Tab {
     pub fn render(self, theme: AppTheme, ui_scale: impl Into<UiScale>) -> Stateful<Div> {
         let ui_scale = ui_scale.into();
         let scaled_px = |value| ui_scale.px(value);
+        let horizontal_padding = self
+            .horizontal_padding
+            .unwrap_or_else(|| scaled_px(Self::TAB_HORIZONTAL_PADDING_PX));
         let text_color = if self.selected {
             theme.colors.text
         } else {
@@ -89,11 +103,11 @@ impl Tab {
             .min_w(scaled_px(Self::TAB_MIN_WIDTH_PX))
             .max_w(scaled_px(Self::TAB_MAX_WIDTH_PX))
             .mx(scaled_px(3.0))
-            .px(scaled_px(10.0))
+            .px(horizontal_padding)
             .pb(scaled_px(Self::TAB_BOTTOM_FUSE_PAD_PX))
             .flex()
             .items_center()
-            .gap_1()
+            .gap(scaled_px(Self::TAB_CONTENT_GAP_PX))
             .rounded_tl(px(theme.radii.control))
             .rounded_tr(px(theme.radii.control))
             .border_t_1()

--- a/crates/gitcomet-ui-gpui/src/view/components/tab_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/tab_bar.rs
@@ -135,8 +135,9 @@ impl TabBar {
         self
     }
 
-    /// Element pinned after the scroll viewport. Its normal layout width is
-    /// always reserved, so it never overlaps tabs or shifts when they overflow.
+    /// Element laid out directly after the final tab. Keeping it in the scroll
+    /// row makes controls such as the add-repository button follow the tabs
+    /// instead of floating at the far edge of otherwise empty title-bar space.
     pub fn tab_end(mut self, tab_end: impl IntoElement) -> Self {
         self.tab_end = Some(tab_end.into_any_element());
         self
@@ -172,7 +173,8 @@ impl TabBar {
             .when_some(scroll.as_ref(), |this, scroll| {
                 this.track_scroll(&scroll.handle)
             })
-            .children(tabs);
+            .children(tabs)
+            .children(tab_end);
 
         let viewport = div()
             .relative()
@@ -191,6 +193,5 @@ impl TabBar {
             .w_full()
             .h_full()
             .child(viewport.child(tabs))
-            .children(tab_end)
     }
 }

--- a/crates/gitcomet-ui-gpui/src/view/components/tab_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/tab_bar.rs
@@ -1,4 +1,4 @@
-use super::{Button, ButtonStyle};
+use super::{Button, ButtonStyle, tab::TAB_HEIGHT_PX};
 use crate::theme::{AppTheme, with_alpha};
 use crate::ui_scale::UiScale;
 use crate::view::icons::svg_icon;
@@ -226,7 +226,8 @@ impl TabBar {
             .id((id.clone(), "tabs"))
             .flex()
             .items_end()
-            .size_full()
+            .w_full()
+            .h(ui_scale.px(TAB_HEIGHT_PX))
             .overflow_x_scroll()
             .scrollbar_width(px(0.0))
             .when_some(scroll.as_ref(), |this, scroll| {
@@ -242,6 +243,8 @@ impl TabBar {
 
         let mut viewport = div()
             .relative()
+            .flex()
+            .items_end()
             .flex_1()
             .min_w(px(0.0))
             .h_full()
@@ -259,7 +262,6 @@ impl TabBar {
 
         div()
             .id(id)
-            .group("tab_bar")
             .flex()
             .flex_none()
             .items_center()
@@ -324,6 +326,7 @@ fn scroll_arrow(
             .disabled(!enabled)
             .render(theme, ui_scale)
             .debug_selector(move || id.to_string())
+            .block_mouse_except_scroll()
             .when(enabled, |this| {
                 this.on_click(move |_e, window, _cx: &mut App| on_click(window))
             }),

--- a/crates/gitcomet-ui-gpui/src/view/components/tab_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/tab_bar.rs
@@ -3,8 +3,8 @@ use crate::theme::AppTheme;
 use crate::ui_scale::UiScale;
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, Bounds, Div, ElementId, IntoElement, Pixels, Point, ScrollHandle, Stateful, div,
-    point, px,
+    AnyElement, App, Bounds, Div, Element, ElementId, GlobalElementId, InspectorElementId,
+    IntoElement, LayoutId, Pixels, Point, ScrollHandle, Stateful, Window, div, point, px,
 };
 
 /// Sub-pixel slack: layout rounding leaves a hair of scrollable width behind
@@ -22,6 +22,88 @@ pub struct TabBarScroll {
 impl Default for TabBarScroll {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Keeps a trailing control outside the scroll container's input hitbox while
+/// painting it at the measured end of the visible tab run. Its normal layout
+/// width remains reserved at the viewport edge for overflowing tabs.
+struct TabBarEnd {
+    child: Option<AnyElement>,
+    scroll: Option<TabBarScroll>,
+    tab_count: usize,
+}
+
+impl IntoElement for TabBarEnd {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for TabBarEnd {
+    type RequestLayoutState = AnyElement;
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut child = self.child.take().expect("tab bar end child");
+        (child.request_layout(window, cx), child)
+    }
+
+    fn prepaint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        child: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        let offset_x = self
+            .scroll
+            .as_ref()
+            .and_then(|scroll| {
+                let viewport = scroll.viewport();
+                let desired_left = self
+                    .tab_count
+                    .checked_sub(1)
+                    .and_then(|ix| scroll.tab_bounds(ix))
+                    .map_or(viewport.left(), |last| last.right().min(viewport.right()));
+                (viewport.size.width > px(0.0)).then(|| (desired_left - bounds.left()).min(px(0.0)))
+            })
+            .unwrap_or(px(0.0));
+
+        window.with_element_offset(point(offset_x, px(0.0)), |window| {
+            child.prepaint(window, cx);
+        });
+    }
+
+    fn paint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        child: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        child.paint(window, cx);
     }
 }
 
@@ -135,9 +217,8 @@ impl TabBar {
         self
     }
 
-    /// Element laid out directly after the final tab. Keeping it in the scroll
-    /// row makes controls such as the add-repository button follow the tabs
-    /// instead of floating at the far edge of otherwise empty title-bar space.
+    /// Element laid out after the tab viewport and visually attached to the
+    /// final visible tab without becoming part of the scroll hitbox.
     pub fn tab_end(mut self, tab_end: impl IntoElement) -> Self {
         self.tab_end = Some(tab_end.into_any_element());
         self
@@ -157,6 +238,12 @@ impl TabBar {
             tab_end,
             scroll,
         } = self;
+        let tab_count = tabs.len();
+        let tab_end = tab_end.map(|child| TabBarEnd {
+            child: Some(child),
+            scroll: scroll.clone(),
+            tab_count,
+        });
 
         // The tabs are direct children of the scroll container on purpose:
         // GPUI measures scrollable content from its immediate children, so a
@@ -173,8 +260,7 @@ impl TabBar {
             .when_some(scroll.as_ref(), |this, scroll| {
                 this.track_scroll(&scroll.handle)
             })
-            .children(tabs)
-            .children(tab_end);
+            .children(tabs);
 
         let viewport = div()
             .relative()
@@ -193,5 +279,6 @@ impl TabBar {
             .w_full()
             .h_full()
             .child(viewport.child(tabs))
+            .children(tab_end)
     }
 }

--- a/crates/gitcomet-ui-gpui/src/view/components/tab_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/tab_bar.rs
@@ -1,39 +1,22 @@
-use super::{Button, ButtonStyle, tab::TAB_HEIGHT_PX};
-use crate::theme::{AppTheme, with_alpha};
+use super::tab::TAB_HEIGHT_PX;
+use crate::theme::AppTheme;
 use crate::ui_scale::UiScale;
-use crate::view::icons::svg_icon;
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, Bounds, Div, ElementId, IntoElement, Pixels, Point, ScrollHandle, Stateful,
-    Window, div, point, px,
+    AnyElement, Bounds, Div, ElementId, IntoElement, Pixels, Point, ScrollHandle, Stateful, div,
+    point, px,
 };
-use std::cell::Cell;
-use std::rc::Rc;
 
-/// Fraction of the visible strip a single arrow click travels.
-const ARROW_SCROLL_PAGE_FRACTION: f32 = 0.75;
-/// Floor for an arrow click so a narrow strip still moves a useful amount.
-const ARROW_SCROLL_MIN_PX: f32 = 120.0;
 /// Sub-pixel slack: layout rounding leaves a hair of scrollable width behind
-/// that must not count as overflow or light up an arrow.
+/// that must not count as overflow.
 const SCROLL_EPSILON: Pixels = px(0.5);
 
-/// How the strip's scroll arrows should look, derived from the last measured
-/// layout: whether they show at all, and which way they can still travel.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct ArrowState {
-    visible: bool,
-    can_scroll_left: bool,
-    can_scroll_right: bool,
-}
-
 /// Scroll state of a tab strip. The view owns one of these so the offset and
-/// the last measured layout survive re-renders; the strip has no visible
-/// scrollbar, so the arrows are the only affordance and have to track it.
+/// the last measured overflow state survive re-renders. Repository tabs use
+/// wheel/trackpad input and active-tab reveal instead of visible scroll arrows.
 #[derive(Clone, Debug)]
 pub struct TabBarScroll {
     handle: ScrollHandle,
-    arrows: Rc<Cell<ArrowState>>,
 }
 
 impl Default for TabBarScroll {
@@ -46,7 +29,6 @@ impl TabBarScroll {
     pub fn new() -> Self {
         Self {
             handle: ScrollHandle::new(),
-            arrows: Rc::new(Cell::new(ArrowState::default())),
         }
     }
 
@@ -94,17 +76,6 @@ impl TabBarScroll {
         self.handle.max_offset().x
     }
 
-    /// Arrow state implied by the layout measured during the last prepaint.
-    fn arrow_state(&self) -> ArrowState {
-        let max_scroll = self.max_scroll();
-        let scrolled = self.scrolled();
-        ArrowState {
-            visible: max_scroll > SCROLL_EPSILON,
-            can_scroll_left: scrolled > SCROLL_EPSILON,
-            can_scroll_right: scrolled < max_scroll - SCROLL_EPSILON,
-        }
-    }
-
     /// Bounds of the visible strip, as measured during the last prepaint.
     pub fn viewport(&self) -> Bounds<Pixels> {
         self.handle.bounds()
@@ -120,11 +91,12 @@ impl TabBarScroll {
 
     /// Whether the strip can still travel in `direction` (negative is left).
     pub fn can_scroll(&self, direction: f32) -> bool {
-        let arrows = self.arrow_state();
+        let max_scroll = self.max_scroll();
+        let scrolled = self.scrolled();
         if direction < 0.0 {
-            arrows.can_scroll_left
+            scrolled > SCROLL_EPSILON
         } else {
-            arrows.can_scroll_right
+            scrolled < max_scroll - SCROLL_EPSILON
         }
     }
 
@@ -139,17 +111,11 @@ impl TabBarScroll {
         self.handle.set_offset(point(x, offset.y));
         true
     }
-
-    fn page(&self) -> Pixels {
-        let visible = self.handle.bounds().size.width;
-        (visible * ARROW_SCROLL_PAGE_FRACTION).max(px(ARROW_SCROLL_MIN_PX))
-    }
 }
 
 pub struct TabBar {
     id: ElementId,
     tabs: Vec<AnyElement>,
-    filler: Option<AnyElement>,
     tab_end: Option<AnyElement>,
     scroll: Option<TabBarScroll>,
 }
@@ -159,7 +125,6 @@ impl TabBar {
         Self {
             id: id.into(),
             tabs: Vec::new(),
-            filler: None,
             tab_end: None,
             scroll: None,
         }
@@ -170,17 +135,8 @@ impl TabBar {
         self
     }
 
-    /// Element stretched into the empty space after the tabs (e.g. a window
-    /// drag surface). It collapses to zero width once tabs fill the bar.
-    pub fn filler(mut self, filler: impl IntoElement) -> Self {
-        self.filler = Some(filler.into_any_element());
-        self
-    }
-
-    /// Element that follows the last tab, browser-style. While the tabs fit it
-    /// rides inside the strip, sitting where the next tab would appear; once
-    /// they overflow it moves out beside the scroll arrows, where the tabs can
-    /// never scroll it out of reach.
+    /// Element pinned after the scroll viewport. Its normal layout width is
+    /// always reserved, so it never overlaps tabs or shifts when they overflow.
     pub fn tab_end(mut self, tab_end: impl IntoElement) -> Self {
         self.tab_end = Some(tab_end.into_any_element());
         self
@@ -192,31 +148,14 @@ impl TabBar {
         self
     }
 
-    pub fn render(self, theme: AppTheme, ui_scale_percent: u32) -> Stateful<Div> {
+    pub fn render(self, _theme: AppTheme, ui_scale_percent: u32) -> Stateful<Div> {
         let ui_scale = UiScale::from_percent(ui_scale_percent);
         let Self {
             id,
             tabs,
-            filler,
             tab_end,
             scroll,
         } = self;
-
-        // Reflects the previous frame's layout; the listener below asks for a
-        // redraw whenever this frame's layout disagrees with it.
-        let arrows = scroll
-            .as_ref()
-            .map(TabBarScroll::arrow_state)
-            .unwrap_or_default();
-
-        // The strip carries the end element while everything fits, and hands it
-        // to the pinned slot once the arrows appear. The swap cannot oscillate:
-        // the pair of arrows is wider than the element, so a strip that
-        // overflows with the element inside still overflows once it moves out.
-        let (strip_end, pinned_end) = match tab_end {
-            Some(tab_end) if arrows.visible => (None, Some(tab_end)),
-            tab_end => (tab_end, None),
-        };
 
         // The tabs are direct children of the scroll container on purpose:
         // GPUI measures scrollable content from its immediate children, so a
@@ -233,15 +172,9 @@ impl TabBar {
             .when_some(scroll.as_ref(), |this, scroll| {
                 this.track_scroll(&scroll.handle)
             })
-            .children(tabs)
-            // After the tabs, so tab indices still address tabs: the scroll
-            // handle addresses its children positionally.
-            .children(strip_end)
-            .when_some(filler, |this, filler| {
-                this.child(div().flex_1().min_w(px(0.0)).h_full().child(filler))
-            });
+            .children(tabs);
 
-        let mut viewport = div()
+        let viewport = div()
             .relative()
             .flex()
             .items_end()
@@ -249,16 +182,6 @@ impl TabBar {
             .min_w(px(0.0))
             .h_full()
             .overflow_x_hidden();
-        if let Some(scroll) = scroll.clone() {
-            viewport = viewport.on_children_prepainted(move |_bounds, _window, cx| {
-                let measured = scroll.arrow_state();
-                if scroll.arrows.replace(measured) != measured {
-                    // `Window::refresh` is a no-op mid-draw; an app effect is
-                    // the way to get another frame out of prepaint.
-                    cx.refresh_windows();
-                }
-            });
-        }
 
         div()
             .id(id)
@@ -267,68 +190,7 @@ impl TabBar {
             .items_center()
             .w_full()
             .h_full()
-            .when(arrows.visible, |this| {
-                let scroll = scroll
-                    .clone()
-                    .expect("visible arrows imply a scroll handle");
-                this.child(scroll_arrow(
-                    "tab_bar_scroll_left",
-                    "icons/chevron_left.svg",
-                    theme,
-                    ui_scale,
-                    arrows.can_scroll_left,
-                    move |window| {
-                        scroll.scroll_by(-scroll.page());
-                        window.refresh();
-                    },
-                ))
-            })
             .child(viewport.child(tabs))
-            .when(arrows.visible, |this| {
-                let scroll = scroll
-                    .clone()
-                    .expect("visible arrows imply a scroll handle");
-                this.child(scroll_arrow(
-                    "tab_bar_scroll_right",
-                    "icons/chevron_right.svg",
-                    theme,
-                    ui_scale,
-                    arrows.can_scroll_right,
-                    move |window| {
-                        scroll.scroll_by(scroll.page());
-                        window.refresh();
-                    },
-                ))
-            })
-            .children(pinned_end)
+            .children(tab_end)
     }
-}
-
-fn scroll_arrow(
-    id: &'static str,
-    icon: &'static str,
-    theme: AppTheme,
-    ui_scale: UiScale,
-    enabled: bool,
-    on_click: impl Fn(&mut Window) + 'static,
-) -> impl IntoElement {
-    let color = if enabled {
-        theme.colors.text_muted
-    } else {
-        with_alpha(theme.colors.text_muted, 0.35)
-    };
-
-    div().flex_none().h_full().flex().items_center().child(
-        Button::new(id, "")
-            .start_slot(svg_icon(icon, color, ui_scale.px(12.0)))
-            .style(ButtonStyle::Transparent)
-            .borderless()
-            .disabled(!enabled)
-            .render(theme, ui_scale)
-            .debug_selector(move || id.to_string())
-            .block_mouse_except_scroll()
-            .when(enabled, |this| {
-                this.on_click(move |_e, window, _cx: &mut App| on_click(window))
-            }),
-    )
 }

--- a/crates/gitcomet-ui-gpui/src/view/components/text_fade.rs
+++ b/crates/gitcomet-ui-gpui/src/view/components/text_fade.rs
@@ -98,6 +98,12 @@ fn fade_gradient(bg: Rgba) -> Background {
     )
 }
 
+/// Standalone version of the same trailing ramp, used when an overlay sits on
+/// top of text rather than the text itself overflowing its layout box.
+pub fn trailing_fade(bg: Rgba, width: gpui::Pixels) -> Div {
+    div().flex_none().w(width).h_full().bg(fade_gradient(bg))
+}
+
 struct ProbeLayout {
     child: AnyElement,
     child_layout_id: LayoutId,

--- a/crates/gitcomet-ui-gpui/src/view/panels/mod.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/mod.rs
@@ -47,6 +47,9 @@ pub(in crate::view) enum ContextMenuAction {
         repo_id: RepoId,
         path: std::path::PathBuf,
     },
+    OpenRepositoryLocation {
+        path: std::path::PathBuf,
+    },
     OpenInCodeEditor {
         repo_id: Option<RepoId>,
         path: std::path::PathBuf,

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -104,6 +104,7 @@ const CONFLICT_INPUT_MENU_WIDTH: PopoverWidthSpec = PopoverWidthSpec::range(220.
 const CONFLICT_CHUNK_MENU_WIDTH: PopoverWidthSpec = PopoverWidthSpec::range(320.0, 220.0, 360.0);
 const CONFLICT_OUTPUT_MENU_WIDTH: PopoverWidthSpec = PopoverWidthSpec::range(240.0, 200.0, 300.0);
 const STASH_MENU_WIDTH: PopoverWidthSpec = PopoverWidthSpec::range(220.0, 180.0, 360.0);
+const REPO_TAB_MENU_WIDTH: PopoverWidthSpec = PopoverWidthSpec::fixed(360.0);
 const PICKER_WIDTH: PopoverWidthSpec = PopoverWidthSpec::range(420.0, 420.0, 820.0);
 const LARGE_PICKER_WIDTH: PopoverWidthSpec = PopoverWidthSpec::range(520.0, 520.0, 820.0);
 const DIALOG_320_WIDTH: PopoverWidthSpec = PopoverWidthSpec::fixed(320.0);
@@ -114,7 +115,9 @@ const DIALOG_440_WIDTH: PopoverWidthSpec = PopoverWidthSpec::fixed(440.0);
 const DIALOG_460_WIDTH: PopoverWidthSpec = PopoverWidthSpec::fixed(460.0);
 const DIALOG_540_WIDTH: PopoverWidthSpec = PopoverWidthSpec::fixed(540.0);
 const DIALOG_640_WIDTH: PopoverWidthSpec = PopoverWidthSpec::fixed(640.0);
-const APP_MENU_WIDTH: PopoverWidthSpec = PopoverWidthSpec::fixed(250.0);
+// Leaves enough room for “Open in code editor” and its three-key shortcut
+// badge to remain on one line on non-macOS platforms.
+const APP_MENU_WIDTH: PopoverWidthSpec = PopoverWidthSpec::fixed(320.0);
 
 /// Cancel/submit focus-handle pair shared by every prompt dialog.
 pub(super) struct DialogFocus {
@@ -783,7 +786,6 @@ pub(in super::super) fn popover_width_spec(kind: &PopoverKind) -> Option<Popover
         | PopoverKind::PushPicker
         | PopoverKind::CommitOptionsMenu { .. }
         | PopoverKind::PreviousCommitMessagesMenu { .. }
-        | PopoverKind::RepoTabMenu { .. }
         | PopoverKind::TagMenu { .. }
         | PopoverKind::TagRefMenu { .. }
         | PopoverKind::StatusFileMenu { .. }
@@ -811,6 +813,7 @@ pub(in super::super) fn popover_width_spec(kind: &PopoverKind) -> Option<Popover
         | PopoverKind::CommitFileMenu { .. }
         | PopoverKind::FileBrowserFileMenu { .. }
         | PopoverKind::BrowseHistoryMenu { .. } => Some(DEFAULT_CONTEXT_MENU_WIDTH),
+        PopoverKind::RepoTabMenu { .. } => Some(REPO_TAB_MENU_WIDTH),
         PopoverKind::HistoryBranchFilter { .. }
         | PopoverKind::DiffContentModeSettings
         | PopoverKind::UiScalePicker

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/app_menu.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/app_menu.rs
@@ -28,7 +28,7 @@ pub(super) fn model(this: &PopoverHost) -> ContextMenuModel {
     let external_editor_configured = crate::external_editor::configured_setting().is_some();
     let show_command_palette = command_palette_available(this.root_view_mode);
 
-    let mut items = vec![ContextMenuItem::Header("Application".into())];
+    let mut items = Vec::new();
     let mut debug_selectors = std::collections::HashMap::new();
 
     if show_command_palette {
@@ -66,7 +66,6 @@ pub(super) fn model(this: &PopoverHost) -> ContextMenuModel {
     }
 
     items.push(ContextMenuItem::Separator);
-    items.push(ContextMenuItem::Header("Patches".into()));
     push_entry(
         &mut items,
         &mut debug_selectors,
@@ -96,20 +95,20 @@ pub(super) fn model(this: &PopoverHost) -> ContextMenuModel {
     push_entry(
         &mut items,
         &mut debug_selectors,
-        "app_menu_quit",
-        "Quit",
-        Shortcut::Secondary("Q"),
-        false,
-        AppMenuAction::Quit,
-    );
-    push_entry(
-        &mut items,
-        &mut debug_selectors,
         "app_menu_close_window",
         "Close Window",
         Shortcut::Secondary("Shift+W"),
         false,
         AppMenuAction::CloseWindow,
+    );
+    push_entry(
+        &mut items,
+        &mut debug_selectors,
+        "app_menu_quit",
+        "Quit",
+        Shortcut::Secondary("Q"),
+        false,
+        AppMenuAction::Quit,
     );
 
     ContextMenuModel::new(items)

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu.rs
@@ -199,6 +199,36 @@ impl PopoverHost {
         super::super::super::platform_open::open_file_location(path)
     }
 
+    fn reveal_path_in_file_manager(
+        &mut self,
+        path: std::path::PathBuf,
+        fallback: Option<std::path::PathBuf>,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let target = if path.exists() {
+            path
+        } else {
+            path.parent()
+                .map(ToOwned::to_owned)
+                .or(fallback)
+                .unwrap_or(path)
+        };
+
+        if !target.exists() {
+            self.push_toast(
+                components::ToastKind::Error,
+                format!("Path not found: {}", target.display()),
+                cx,
+            );
+        } else if let Err(err) = self.open_file_location(&target) {
+            self.push_toast(
+                components::ToastKind::Error,
+                format!("Failed to open location: {err}"),
+                cx,
+            );
+        }
+    }
+
     fn take_status_paths_for_action(
         &mut self,
         repo_id: RepoId,
@@ -495,31 +525,11 @@ impl PopoverHost {
                     }
                 };
 
-                let target = if full_path.exists() {
-                    full_path
-                } else {
-                    full_path
-                        .parent()
-                        .map(ToOwned::to_owned)
-                        .unwrap_or_else(|| {
-                            self.workdir_for_repo(repo_id)
-                                .unwrap_or_else(|| full_path.clone())
-                        })
-                };
-
-                if !target.exists() {
-                    self.push_toast(
-                        components::ToastKind::Error,
-                        format!("Path not found: {}", target.display()),
-                        cx,
-                    );
-                } else if let Err(err) = self.open_file_location(&target) {
-                    self.push_toast(
-                        components::ToastKind::Error,
-                        format!("Failed to open location: {err}"),
-                        cx,
-                    );
-                }
+                let fallback = self.workdir_for_repo(repo_id);
+                self.reveal_path_in_file_manager(full_path, fallback, cx);
+            }
+            ContextMenuAction::OpenRepositoryLocation { path } => {
+                self.reveal_path_in_file_manager(path, None, cx);
             }
             ContextMenuAction::OpenInCodeEditor { repo_id, path } => {
                 let full_path = match repo_id {

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/repo_tab.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/repo_tab.rs
@@ -38,17 +38,29 @@ fn model_for_state(
         .map(|_| repo_id);
 
     let mut items = vec![ContextMenuItem::Entry {
-        label: "Active".into(),
+        label: "Activate".into(),
         icon: Some("icons/check.svg".into()),
         shortcut: None,
         disabled: state.active_repo == Some(repo_id),
         action: Box::new(ContextMenuAction::ActivateRepo { repo_id }),
     }];
 
+    if let Some(ref workdir) = workdir {
+        items.push(ContextMenuItem::Separator);
+        items.push(ContextMenuItem::Entry {
+            label: "Open repository location".into(),
+            icon: Some("icons/folder.svg".into()),
+            shortcut: None,
+            disabled: false,
+            action: Box::new(ContextMenuAction::OpenRepositoryLocation {
+                path: workdir.clone(),
+            }),
+        });
+    }
+
     if crate::external_editor::configured_setting().is_some()
         && let Some(ref workdir) = workdir
     {
-        items.push(ContextMenuItem::Separator);
         items.push(ContextMenuItem::Entry {
             label: "Open in code editor".into(),
             icon: Some("icons/open_external.svg".into()),
@@ -92,7 +104,7 @@ fn model_for_state(
         },
     ]);
 
-    ContextMenuModel::new(items)
+    ContextMenuModel::new(items).with_shortcut_keycaps()
 }
 
 #[cfg(test)]
@@ -145,11 +157,11 @@ mod tests {
     }
 
     #[test]
-    fn active_entry_activates_inactive_repo_tab() {
+    fn activate_entry_activates_inactive_repo_tab() {
         let state = state_with_repo_tabs(RepoId(1), 3);
         let model = model_for_state(&state, RepoId(2), None);
 
-        let (disabled, action) = entry_action(&model, "Active");
+        let (disabled, action) = entry_action(&model, "Activate");
 
         assert!(!disabled);
         assert!(matches!(
@@ -159,11 +171,11 @@ mod tests {
     }
 
     #[test]
-    fn active_entry_is_disabled_for_active_repo_tab() {
+    fn activate_entry_is_disabled_for_active_repo_tab() {
         let state = state_with_repo_tabs(RepoId(2), 3);
         let model = model_for_state(&state, RepoId(2), None);
 
-        let (disabled, action) = entry_action(&model, "Active");
+        let (disabled, action) = entry_action(&model, "Activate");
 
         assert!(disabled);
         assert!(matches!(
@@ -196,6 +208,33 @@ mod tests {
             action.as_ref(),
             ContextMenuAction::CloseRepo { repo_id } if *repo_id == RepoId(2)
         ));
+    }
+
+    #[test]
+    fn open_repository_location_entry_targets_the_repository_workdir() {
+        let state = state_with_repo_tabs(RepoId(1), 3);
+        let workdir = PathBuf::from("/tmp/repo-tab-menu-2");
+        let model = model_for_state(&state, RepoId(2), Some(workdir.clone()));
+
+        let (disabled, action) = entry_action(&model, "Open repository location");
+
+        assert!(!disabled);
+        assert!(matches!(
+            action,
+            ContextMenuAction::OpenRepositoryLocation { path } if path == &workdir
+        ));
+    }
+
+    #[test]
+    fn repo_tab_menu_uses_shared_shortcut_keycaps() {
+        let state = state_with_repo_tabs(RepoId(1), 3);
+        let model = model_for_state(
+            &state,
+            RepoId(2),
+            Some(PathBuf::from("/tmp/repo-tab-menu-2")),
+        );
+
+        assert!(model.shortcut_keycaps);
     }
 
     #[test]

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/repo_picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/repo_picker.rs
@@ -144,7 +144,6 @@ pub(super) fn entries(this: &PopoverHost) -> Vec<(RepoPickerEntry, components::P
             sortable_row(
                 RepoPickerEntry::Open(repo.id),
                 &repo.spec.workdir,
-                "icons/folder.svg",
                 OPEN_SECTION,
                 recency,
                 false,
@@ -172,7 +171,6 @@ pub(super) fn entries(this: &PopoverHost) -> Vec<(RepoPickerEntry, components::P
             sortable_row(
                 RepoPickerEntry::RecentlyClosed(path.clone()),
                 path,
-                "icons/history.svg",
                 RECENTLY_CLOSED_SECTION,
                 recency,
                 // Only recents can be forgotten; open repositories leave the
@@ -195,7 +193,6 @@ pub(super) fn entries(this: &PopoverHost) -> Vec<(RepoPickerEntry, components::P
 fn sortable_row(
     entry: RepoPickerEntry,
     workdir: &std::path::Path,
-    icon: &'static str,
     section: &'static str,
     recency: usize,
     removable: bool,
@@ -203,7 +200,10 @@ fn sortable_row(
     SortableRow {
         entry,
         item: {
-            let item = repo_picker_item(workdir).icon(icon).section(section);
+            let repository_name = path_display::repo_path_name(workdir);
+            let item = repo_picker_item(workdir)
+                .repository_initials(repository_name.as_ref())
+                .section(section);
             if removable { item.removable() } else { item }
         },
         name_key: workdir
@@ -224,7 +224,6 @@ mod tests {
         sortable_row(
             RepoPickerEntry::RecentlyClosed(std::path::PathBuf::from(path)),
             std::path::Path::new(path),
-            "icons/history.svg",
             RECENTLY_CLOSED_SECTION,
             recency,
             true,
@@ -276,6 +275,20 @@ mod tests {
             );
         }
         assert_eq!(RepoPickerSort::from_storage_key("nonsense"), None);
+    }
+
+    #[test]
+    fn sort_toggle_includes_the_selected_sort() {
+        assert_eq!(sort_toggle_label(RepoPickerSort::Newest), "Sort: Newest");
+        assert_eq!(sort_toggle_label(RepoPickerSort::Oldest), "Sort: Oldest");
+        assert_eq!(
+            sort_toggle_label(RepoPickerSort::Name),
+            format!("Sort: {}", RepoPickerSort::Name.label())
+        );
+        assert_eq!(
+            sort_toggle_label(RepoPickerSort::Path),
+            format!("Sort: {}", RepoPickerSort::Path.label())
+        );
     }
 }
 
@@ -391,7 +404,7 @@ fn sort_toggle(this: &PopoverHost, cx: &mut gpui::Context<PopoverHost>) -> impl 
         .when(menu_open, |toggle| toggle.bg(active_overlay))
         .hover(move |s| s.bg(hover_overlay))
         .active(move |s| s.bg(active_overlay))
-        .child("Sort")
+        .child(sort_toggle_label(this.repo_picker_sort))
         .child(crate::view::icons::svg_icon(
             "icons/chevron_down.svg",
             theme.colors.text_muted,
@@ -400,6 +413,10 @@ fn sort_toggle(this: &PopoverHost, cx: &mut gpui::Context<PopoverHost>) -> impl 
         .on_click(cx.listener(|this, _e: &ClickEvent, _w, cx| {
             toggle_sort_menu(this, cx);
         }))
+}
+
+fn sort_toggle_label(sort: RepoPickerSort) -> String {
+    format!("Sort: {}", sort.label())
 }
 
 /// The sort options, rendered in place of the repository rows while the menu is

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/app_menu.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/app_menu.rs
@@ -44,6 +44,22 @@ fn app_menu_offers_close_window_rather_than_a_dismiss_entry(cx: &mut gpui::TestA
 }
 
 #[gpui::test]
+fn app_menu_places_quit_after_close_window(cx: &mut gpui::TestAppContext) {
+    let (_view, cx) = open_app_menu(cx);
+    let close_window = cx
+        .debug_bounds("app_menu_close_window")
+        .expect("app menu should offer Close Window");
+    let quit = cx
+        .debug_bounds("app_menu_quit")
+        .expect("app menu should offer Quit");
+
+    assert!(
+        quit.top() >= close_window.bottom(),
+        "Quit should be the final row after Close Window"
+    );
+}
+
+#[gpui::test]
 fn app_menu_hides_desktop_integration_on_unsupported_platforms(cx: &mut gpui::TestAppContext) {
     let (_view, cx) = open_app_menu(cx);
 
@@ -83,8 +99,8 @@ fn app_menu_owns_keyboard_focus_and_escape_dismisses_it(cx: &mut gpui::TestAppCo
         );
         assert_eq!(
             host.context_menu_selected_ix,
-            Some(1),
-            "the first selectable row follows the Application header"
+            Some(0),
+            "the first application action should be selected"
         );
     });
 
@@ -95,7 +111,7 @@ fn app_menu_owns_keyboard_focus_and_escape_dismisses_it(cx: &mut gpui::TestAppCo
                 .popover_host
                 .read(app)
                 .context_menu_selected_ix,
-            Some(2),
+            Some(1),
             "Tab should select Settings"
         );
     });
@@ -107,7 +123,7 @@ fn app_menu_owns_keyboard_focus_and_escape_dismisses_it(cx: &mut gpui::TestAppCo
                 .popover_host
                 .read(app)
                 .context_menu_selected_ix,
-            Some(1),
+            Some(0),
             "Shift+Tab should select Command Palette"
         );
     });

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/layout.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/layout.rs
@@ -25,6 +25,27 @@ fn mergetool_settings_menu_is_wider_than_diff_actions() {
 }
 
 #[test]
+fn repository_tab_menu_has_dedicated_wider_layout() {
+    let scale = ui_scale::UiScale::from_percent(100);
+    let repo_tab = popover_width_spec(&PopoverKind::RepoTabMenu { repo_id: RepoId(1) })
+        .expect("repository tab menu width");
+
+    assert_eq!(repo_tab.preferred_px(scale), px(360.0));
+    assert_eq!(repo_tab.min_px(scale), px(360.0));
+    assert!(repo_tab.preferred_px(scale) > DEFAULT_CONTEXT_MENU_WIDTH.preferred_px(scale));
+}
+
+#[test]
+fn application_menu_is_wide_enough_for_editor_action_and_shortcut() {
+    let scale = ui_scale::UiScale::from_percent(100);
+    let app_menu = popover_width_spec(&PopoverKind::AppMenu).expect("application menu width");
+
+    assert_eq!(app_menu.preferred_px(scale), px(320.0));
+    assert_eq!(app_menu.min_px(scale), px(320.0));
+    assert!(app_menu.preferred_px(scale) > DEFAULT_CONTEXT_MENU_WIDTH.preferred_px(scale));
+}
+
+#[test]
 fn choose_popover_anchor_corner_prefers_side_with_more_space() {
     assert_eq!(
         choose_popover_anchor_corner(Anchor::TopRight, px(260.0), px(640.0), px(420.0),),

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/picker.rs
@@ -243,6 +243,23 @@ fn repo_picker_lists_recently_closed_repositories_subprocess(cx: &mut gpui::Test
         !recently_closed.contains(&open_workdir),
         "an open repository must not also appear under recently closed"
     );
+
+    let expected_badge_size = gpui::size(
+        gpui::px(components::REPOSITORY_BADGE_SIZE_PX),
+        gpui::px(components::REPOSITORY_BADGE_SIZE_PX),
+    );
+    assert_eq!(
+        cx.debug_bounds("picker_prompt_repository_badge_0")
+            .expect("expected an initials badge for the open repository")
+            .size,
+        expected_badge_size,
+    );
+    assert_eq!(
+        cx.debug_bounds("picker_prompt_repository_badge_1")
+            .expect("expected an initials badge for the recently closed repository")
+            .size,
+        expected_badge_size,
+    );
 }
 
 /// Drives the picker's sort menu over a seeded set of closed repositories.

--- a/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
@@ -86,6 +86,9 @@ const REPO_TAB_STATUS_SIZE_PX: f32 = components::REPOSITORY_BADGE_SIZE_PX;
 const REPO_TAB_LABEL_GAP_PX: f32 = 6.0;
 const REPO_TAB_CLOSE_FADE_WIDTH_PX: f32 = 16.0;
 const REPO_TAB_SIDE_PADDING_PX: f32 = 10.0;
+const REPO_TAB_HOVER_BOX_X_OVERHANG_PX: f32 = 4.0;
+const REPO_TAB_HOVER_BOX_Y_OVERHANG_PX: f32 = 3.0;
+const REPO_TAB_HOVER_BOX_RADIUS_PX: f32 = 4.0;
 
 fn repo_tab_text_width(label: SharedString, font_size: Pixels, window: &mut Window) -> Pixels {
     if label.is_empty() {
@@ -801,12 +804,27 @@ impl Render for RepoTabsBarView {
                 status_color
             };
             let tab_label = div()
+                .relative()
                 .flex()
                 .flex_1()
                 .items_center()
                 .h(scaled_px(REPO_TAB_CONTENT_HEIGHT_PX))
                 .gap(scaled_px(REPO_TAB_LABEL_GAP_PX))
                 .min_w(px(0.0))
+                // Idle tabs highlight only their compact content box. The
+                // plate overhang adds breathing room around the initials and
+                // label without changing tab measurement or hit geometry.
+                .child(
+                    div()
+                        .debug_selector(move || format!("repo_tab_hover_box_{}", repo_id.0))
+                        .absolute()
+                        .top(scaled_px(-REPO_TAB_HOVER_BOX_Y_OVERHANG_PX))
+                        .bottom(scaled_px(-REPO_TAB_HOVER_BOX_Y_OVERHANG_PX))
+                        .left(scaled_px(-REPO_TAB_HOVER_BOX_X_OVERHANG_PX))
+                        .right(scaled_px(-REPO_TAB_HOVER_BOX_X_OVERHANG_PX))
+                        .rounded(scaled_px(REPO_TAB_HOVER_BOX_RADIUS_PX))
+                        .bg(label_bg),
+                )
                 .child(
                     div()
                         .size(scaled_px(REPO_TAB_STATUS_SIZE_PX))
@@ -877,14 +895,17 @@ impl Render for RepoTabsBarView {
                                 format!("repo_tab_separator_after_{}", repo_id.0)
                             })
                             .absolute()
-                            // Each tab has 3px horizontal margins. Paint in
+                            // Each tab has 4px horizontal margins. Paint in
                             // their shared gap so the divider sits between the
                             // two idle tab shapes rather than on either one.
-                            .right(scaled_px(-3.0))
+                            .right(scaled_px(-4.0))
                             .top(scaled_px(7.0))
                             .w(px(1.0))
                             .h(scaled_px(16.0))
-                            .bg(theme.colors.border_variant),
+                            .bg(with_alpha(
+                                components::Tab::outline_color(theme),
+                                if theme.is_dark { 0.55 } else { 0.50 },
+                            )),
                     )
                 })
                 .debug_selector(move || format!("repo_tab_{}", repo_id.0))

--- a/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
@@ -36,7 +36,7 @@ struct RepoTabDrag {
     repo_id: RepoId,
     cursor_offset_x: Rc<Cell<Pixels>>,
     tab_width: Rc<Cell<Pixels>>,
-    last_center_x: Rc<Cell<Pixels>>,
+    direction_anchor_x: Rc<Cell<Pixels>>,
     direction: Rc<Cell<i8>>,
 }
 
@@ -48,6 +48,18 @@ impl RepoTabDrag {
         } else {
             cursor_x - self.cursor_offset_x.get() + width / 2.0
         }
+    }
+
+    fn update_direction(&self, cursor_x: Pixels, reversal_threshold: Pixels) -> i8 {
+        let (direction, anchor_x) = repo_tab_drag_direction(
+            self.direction.get(),
+            self.direction_anchor_x.get(),
+            cursor_x,
+            reversal_threshold,
+        );
+        self.direction.set(direction);
+        self.direction_anchor_x.set(anchor_x);
+        direction
     }
 }
 
@@ -69,6 +81,10 @@ impl Render for RepoTabDragCarrier {
 
 const REPO_TAB_SLIDE_DURATION: Duration = Duration::from_millis(100);
 const REPO_TAB_TAKEOVER_BIAS: f32 = 0.25;
+/// Ignore tiny pointer reversals while neighbouring tabs are sliding into
+/// their new slots. Without this dead band, trackpad noise can reverse the
+/// takeover bias every frame and make the same two tabs trade places rapidly.
+const REPO_TAB_DIRECTION_REVERSAL_PX: f32 = 12.0;
 /// How close to a strip edge a dragged tab has to get before the strip starts
 /// scrolling under it.
 const REPO_TAB_DRAG_EDGE_PX: f32 = 40.0;
@@ -89,6 +105,28 @@ const REPO_TAB_SIDE_PADDING_PX: f32 = 10.0;
 const REPO_TAB_HOVER_BOX_X_OVERHANG_PX: f32 = 4.0;
 const REPO_TAB_HOVER_BOX_Y_OVERHANG_PX: f32 = 3.0;
 const REPO_TAB_HOVER_BOX_RADIUS_PX: f32 = 4.0;
+
+/// Returns the drag direction and its new high/low-water mark. A direction is
+/// established immediately, but reversing it requires deliberate travel away
+/// from the furthest point reached in the current direction.
+fn repo_tab_drag_direction(
+    direction: i8,
+    anchor_x: Pixels,
+    cursor_x: Pixels,
+    reversal_threshold: Pixels,
+) -> (i8, Pixels) {
+    match direction {
+        1 if cursor_x >= anchor_x => (1, cursor_x),
+        1 if anchor_x - cursor_x >= reversal_threshold => (-1, cursor_x),
+        1 => (1, anchor_x),
+        -1 if cursor_x <= anchor_x => (-1, cursor_x),
+        -1 if cursor_x - anchor_x >= reversal_threshold => (1, cursor_x),
+        -1 => (-1, anchor_x),
+        _ if cursor_x > anchor_x => (1, cursor_x),
+        _ if cursor_x < anchor_x => (-1, cursor_x),
+        _ => (0, anchor_x),
+    }
+}
 
 fn repo_tab_text_width(label: SharedString, font_size: Pixels, window: &mut Window) -> Pixels {
     if label.is_empty() {
@@ -651,6 +689,7 @@ impl Render for RepoTabsBarView {
         let theme = self.theme;
         let ui_scale_percent = ui_scale::current(cx).percent;
         let scaled_px = |value| ui_scale::design_px_from_percent(value, ui_scale_percent);
+        let drag_direction_reversal = scaled_px(REPO_TAB_DIRECTION_REVERSAL_PX);
         let active = self.active_repo_id();
         let spinner = |id: (&'static str, u64), color: gpui::Rgba| {
             svg_spinner(id, color, scaled_px(REPO_TAB_STATUS_SIZE_PX))
@@ -914,12 +953,12 @@ impl Render for RepoTabsBarView {
                         repo_id,
                         cursor_offset_x: Rc::new(Cell::new(px(0.0))),
                         tab_width: Rc::new(Cell::new(px(0.0))),
-                        last_center_x: Rc::new(Cell::new(px(0.0))),
+                        direction_anchor_x: Rc::new(Cell::new(px(0.0))),
                         direction: Rc::new(Cell::new(0)),
                     },
                     move |drag, offset, window, cx| {
                         drag.cursor_offset_x.set(offset.x);
-                        drag.last_center_x.set(window.mouse_position().x);
+                        drag.direction_anchor_x.set(window.mouse_position().x);
                         cx.new(|_cx| RepoTabDragCarrier)
                     },
                 )
@@ -935,12 +974,14 @@ impl Render for RepoTabsBarView {
                             return;
                         }
 
+                        let direction =
+                            drag.update_direction(e.event.position.x, drag_direction_reversal);
                         let dragged_ix = this
                             .state
                             .repos
                             .iter()
                             .position(|repo| repo.id == dragged_repo_id);
-                        match (drag.direction.get(), dragged_ix) {
+                        match (direction, dragged_ix) {
                             (1, Some(dragged_ix)) if ix <= dragged_ix => return,
                             (-1, Some(dragged_ix)) if ix >= dragged_ix => return,
                             _ => {}
@@ -952,7 +993,7 @@ impl Render for RepoTabsBarView {
                             next_repo_id,
                             point(drag_center_x, e.event.position.y),
                             e.bounds,
-                            drag.direction.get(),
+                            direction,
                         ) else {
                             return;
                         };
@@ -1029,10 +1070,10 @@ impl Render for RepoTabsBarView {
 
         // A single interactive element: putting the hover style on an inner
         // non-interactive div makes the highlight lag behind the pointer.
-        // Browser-style "+" at the end of the strip: one entry point for
-        // opening or cloning a repository. It is pinned outside the scroll
-        // area so it stays reachable however far the tabs are scrolled, with
-        // extra room on its right so it doesn't crowd the title bar badge.
+        // Browser-style "+" at the end of the repository run: one entry point
+        // for opening or cloning a repository. Keeping it in the same scroll
+        // row makes it hug the final tab instead of occupying blank title-bar
+        // space, with a little trailing room before the title-bar badge.
         let root_view = self.root_view.clone();
         let add_repo = div()
             .flex_none()
@@ -1069,17 +1110,12 @@ impl Render for RepoTabsBarView {
         // Keeps repository-tab drag reordering alive across the empty part of
         // the strip. Ordinary pointer input falls through to the title bar's
         // shared drag surface underneath.
-        let tab_strip_drag_listener =
-            cx.listener(|this, e: &gpui::DragMoveEvent<RepoTabDrag>, _window, cx| {
+        let tab_strip_drag_listener = cx.listener(
+            move |this, e: &gpui::DragMoveEvent<RepoTabDrag>, _window, cx| {
                 let (repo_id, cursor_offset_x, drag_center_x, dragged_tab_width) = {
                     let drag = e.drag(cx);
                     let drag_center_x = drag.center_x(e.event.position.x);
-                    let previous_center_x = drag.last_center_x.replace(drag_center_x);
-                    if drag_center_x > previous_center_x {
-                        drag.direction.set(1);
-                    } else if drag_center_x < previous_center_x {
-                        drag.direction.set(-1);
-                    }
+                    drag.update_direction(e.event.position.x, drag_direction_reversal);
                     (
                         drag.repo_id,
                         drag.cursor_offset_x.get(),
@@ -1100,7 +1136,21 @@ impl Render for RepoTabsBarView {
                     cx.notify();
                 }
 
-                if drag_center_x < e.bounds.left() {
+                // A sliding neighbour can briefly leave the pointer over the
+                // strip-level hitbox. That is not an instruction to append
+                // the dragged tab: only the area genuinely after the final
+                // repository is the trailing drop zone.
+                let Some(last_tab_right) = this
+                    .state
+                    .repos
+                    .len()
+                    .checked_sub(1)
+                    .and_then(|ix| this.tab_scroll.tab_bounds(ix))
+                    .map(|bounds| bounds.right())
+                else {
+                    return;
+                };
+                if drag_center_x < last_tab_right {
                     return;
                 }
 
@@ -1108,7 +1158,8 @@ impl Render for RepoTabsBarView {
                     repo_id,
                     insert_before: None,
                 });
-            });
+            },
+        );
 
         let bar = bar.tab_end(add_repo).render(theme, ui_scale_percent);
         div()
@@ -1189,8 +1240,8 @@ fn repo_tab_insert_before_for_drop(
 #[cfg(test)]
 mod tests {
     use super::{
-        RepoTabsBarView, repo_tab_close_button_fill, repo_tab_insert_before_for_drag_cursor,
-        repo_tab_insert_before_for_drop,
+        RepoTabsBarView, repo_tab_close_button_fill, repo_tab_drag_direction,
+        repo_tab_insert_before_for_drag_cursor, repo_tab_insert_before_for_drop,
     };
     use gitcomet_core::domain::RepoSpec;
     use gitcomet_state::model::{RepoId, RepoState};
@@ -1329,6 +1380,27 @@ mod tests {
                 -1,
             ),
             Some(Some(RepoId(5)))
+        );
+    }
+
+    #[test]
+    fn repo_tab_drag_direction_ignores_small_reversals() {
+        let threshold = px(12.0);
+        let (direction, anchor) = repo_tab_drag_direction(0, px(100.0), px(110.0), threshold);
+        assert_eq!((direction, anchor), (1, px(110.0)));
+
+        let (direction, anchor) = repo_tab_drag_direction(direction, anchor, px(102.0), threshold);
+        assert_eq!(
+            (direction, anchor),
+            (1, px(110.0)),
+            "minor pointer noise must not reverse a rightward reorder"
+        );
+
+        let (direction, anchor) = repo_tab_drag_direction(direction, anchor, px(98.0), threshold);
+        assert_eq!(
+            (direction, anchor),
+            (-1, px(98.0)),
+            "deliberate travel beyond the dead band must still reverse"
         );
     }
 

--- a/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
@@ -1077,7 +1077,11 @@ impl Render for RepoTabsBarView {
         let root_view = self.root_view.clone();
         let add_repo = div()
             .flex_none()
-            .h_full()
+            // Only the visible control row should intercept title-bar input.
+            // A full-height child here blocks window dragging in the blank
+            // chrome above the button when the tab row overflows.
+            .h(scaled_px(components::CONTROL_HEIGHT_PX))
+            .self_center()
             .flex()
             .items_center()
             .pl(scaled_px(2.0))

--- a/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
@@ -77,6 +77,38 @@ const REPO_TAB_DRAG_SCROLL_PX_PER_SEC: f32 = 700.0;
 /// Ceiling on the gap between two auto-scroll steps, so a stalled frame can't
 /// launch the strip across several tabs at once.
 const REPO_TAB_DRAG_SCROLL_MAX_STEP: Duration = Duration::from_millis(50);
+/// Shared label-row geometry. Keeping an explicit line box lets the text,
+/// status glyph, and close button all center on the same title-bar axis.
+const REPO_TAB_FONT_SIZE_PX: f32 = 15.0;
+const REPO_TAB_CONTENT_HEIGHT_PX: f32 = 18.0;
+const REPO_TAB_STATUS_SIZE_PX: f32 = 12.0;
+const REPO_TAB_LABEL_GAP_PX: f32 = 4.0;
+const REPO_TAB_MIN_SIDE_PADDING_PX: f32 = 6.0;
+const REPO_TAB_MAX_SIDE_PADDING_PX: f32 = 10.0;
+/// Padding reaches its minimum when each tab only has its minimum width, and
+/// its maximum when every tab could occupy the component's 180px width cap.
+const REPO_TAB_COMPACT_AVAILABLE_WIDTH_PX: f32 = 96.0;
+const REPO_TAB_ROOMY_AVAILABLE_WIDTH_PX: f32 = 180.0;
+
+fn repo_tab_horizontal_padding(
+    viewport_width: Pixels,
+    repo_count: usize,
+    ui_scale_percent: u32,
+) -> Pixels {
+    let scaled_px = |value| ui_scale::design_px_from_percent(value, ui_scale_percent);
+    let min_padding = f32::from(scaled_px(REPO_TAB_MIN_SIDE_PADDING_PX));
+    let max_padding = f32::from(scaled_px(REPO_TAB_MAX_SIDE_PADDING_PX));
+    if repo_count == 0 || viewport_width <= px(0.0) {
+        return px(max_padding);
+    }
+
+    let available_per_tab = f32::from(viewport_width) / repo_count as f32;
+    let compact_width = f32::from(scaled_px(REPO_TAB_COMPACT_AVAILABLE_WIDTH_PX));
+    let roomy_width = f32::from(scaled_px(REPO_TAB_ROOMY_AVAILABLE_WIDTH_PX));
+    let room =
+        ((available_per_tab - compact_width) / (roomy_width - compact_width)).clamp(0.0, 1.0);
+    px(min_padding + (max_padding - min_padding) * room)
+}
 
 struct RepoTabSlide {
     id: ElementId,
@@ -617,6 +649,12 @@ impl Render for RepoTabsBarView {
         self.reveal_pending_repo_tab(window);
         self.drive_repo_tab_drag_scroll(ui_scale_percent, window);
 
+        let repo_count = self.state.repos.len();
+        let tab_horizontal_padding = repo_tab_horizontal_padding(
+            self.tab_scroll.viewport().size.width,
+            repo_count,
+            ui_scale_percent,
+        );
         let mut bar = components::TabBar::new("repo_tab_bar").scroll(self.tab_scroll.clone());
         for (ix, repo) in self.state.repos.iter().enumerate() {
             let repo_id = repo.id;
@@ -632,6 +670,18 @@ impl Render for RepoTabsBarView {
             let context_menu_invoker: SharedString = format!("repo_tab_{}", repo_id.0).into();
             let context_menu_active =
                 self.active_context_menu_invoker.as_ref() == Some(&context_menu_invoker);
+            let next_context_menu_active = next_repo_id.is_some_and(|next_repo_id| {
+                self.active_context_menu_invoker
+                    .as_ref()
+                    .is_some_and(|invoker| {
+                        invoker.as_ref() == format!("repo_tab_{}", next_repo_id.0)
+                    })
+            });
+            let show_inactive_separator = !is_active
+                && !context_menu_active
+                && next_repo_id.is_some()
+                && next_repo_id != active
+                && !next_context_menu_active;
             let context_menu_invoker_for_right_click = context_menu_invoker.clone();
             let is_hovered = self.hovered_repo_tab == Some(repo_id);
             let label = path_display::repo_path_name(&repo.spec.workdir);
@@ -656,11 +706,6 @@ impl Render for RepoTabsBarView {
                 .flex()
                 .items_center()
                 .justify_center()
-                // The row centers on the label's line box, which sits slightly
-                // above the text's optical center (ascender space). Nudge the
-                // close glyph down so it aligns with the visible label text.
-                .relative()
-                .top(scaled_px(1.5))
                 .size(scaled_px(14.0))
                 .rounded(px(theme.radii.row))
                 .cursor_pointer()
@@ -678,7 +723,8 @@ impl Render for RepoTabsBarView {
                 .gitcomet_tooltip(theme, close_tooltip.clone());
 
             let mut tab = components::Tab::new(("repo_tab", repo_id.0))
-                .selected(is_active || context_menu_active);
+                .selected(is_active || context_menu_active)
+                .horizontal_padding(tab_horizontal_padding);
             if is_hovered {
                 tab = tab.end_slot(close_button);
             }
@@ -686,27 +732,29 @@ impl Render for RepoTabsBarView {
             let show_missing_warning = Self::repo_tab_shows_missing_warning(repo, show_spinner);
             let tab_label = div()
                 .flex()
+                .flex_1()
                 .items_center()
-                .gap(scaled_px(6.0))
+                .h(scaled_px(REPO_TAB_CONTENT_HEIGHT_PX))
+                .gap(scaled_px(REPO_TAB_LABEL_GAP_PX))
                 .min_w(px(0.0))
                 .child(
                     div()
-                        .w(scaled_px(12.0))
-                        .h(scaled_px(12.0))
+                        .size(scaled_px(REPO_TAB_STATUS_SIZE_PX))
                         .flex()
                         .items_center()
                         .justify_center()
                         .when(show_spinner, |d| {
-                            d.child(
-                                spinner(
-                                    ("repo_tab_busy_spinner", repo_id.0),
-                                    with_alpha(
-                                        theme.colors.text,
-                                        if theme.is_dark { 0.72 } else { 0.62 },
-                                    ),
+                            d.debug_selector(move || format!("repo_tab_busy_spinner_{}", repo_id.0))
+                                .child(
+                                    spinner(
+                                        ("repo_tab_busy_spinner", repo_id.0),
+                                        with_alpha(
+                                            theme.colors.text,
+                                            if theme.is_dark { 0.72 } else { 0.62 },
+                                        ),
+                                    )
+                                    .into_any_element(),
                                 )
-                                .into_any_element(),
-                            )
                         })
                         .when(show_missing_warning, |d| {
                             d.child(svg_icon(
@@ -719,9 +767,16 @@ impl Render for RepoTabsBarView {
                 .child(
                     // A name too long for the tab fades into the tab's own
                     // background rather than being cut mid-glyph.
-                    components::FadingText::new(div().text_sm().child(label), label_bg)
-                        .render(ui_scale_percent)
-                        .flex_1(),
+                    components::FadingText::new(
+                        div()
+                            .text_size(scaled_px(REPO_TAB_FONT_SIZE_PX))
+                            .line_height(scaled_px(REPO_TAB_CONTENT_HEIGHT_PX))
+                            .child(label),
+                        label_bg,
+                    )
+                    .render(ui_scale_percent)
+                    .debug_selector(move || format!("repo_tab_label_{}", repo_id.0))
+                    .flex_1(),
                 )
                 .when(self.open_terminal_repo_ids.contains(&repo_id), |d| {
                     d.child(
@@ -738,6 +793,24 @@ impl Render for RepoTabsBarView {
             let tab = tab
                 .child(tab_label)
                 .render(theme, ui_scale_percent)
+                .relative()
+                .when(show_inactive_separator, |tab| {
+                    tab.child(
+                        div()
+                            .debug_selector(move || {
+                                format!("repo_tab_separator_after_{}", repo_id.0)
+                            })
+                            .absolute()
+                            // Each tab has 3px horizontal margins. Paint in
+                            // their shared gap so the divider sits between the
+                            // two idle tab shapes rather than on either one.
+                            .right(scaled_px(-3.0))
+                            .top(scaled_px(7.0))
+                            .w(px(1.0))
+                            .h(scaled_px(16.0))
+                            .bg(theme.colors.border_variant),
+                    )
+                })
                 .debug_selector(move || format!("repo_tab_{}", repo_id.0))
                 .on_drag(
                     RepoTabDrag {
@@ -982,9 +1055,25 @@ impl Render for RepoTabsBarView {
                 },
             ));
 
-        bar.tab_end(add_repo)
+        let padding_scroll = self.tab_scroll.clone();
+        let bar = bar
+            .tab_end(add_repo)
             .filler(tab_strip_drag)
-            .render(theme, ui_scale_percent)
+            .render(theme, ui_scale_percent);
+        div()
+            .size_full()
+            .on_children_prepainted(move |_bounds, _window, cx| {
+                let next_padding = repo_tab_horizontal_padding(
+                    padding_scroll.viewport().size.width,
+                    repo_count,
+                    ui_scale_percent,
+                );
+                if (f32::from(next_padding) - f32::from(tab_horizontal_padding)).abs() > 0.25 {
+                    cx.refresh_windows();
+                }
+            })
+            .child(bar)
+            .id("repo_tabs_responsive_root")
             .can_drop(|dragged, _window, _cx| dragged.downcast_ref::<RepoTabDrag>().is_some())
             .on_drop(cx.listener(|this, drag: &RepoTabDrag, _w, cx| {
                 // Drop on the bar (but not on a specific tab) -> move to end.
@@ -1041,7 +1130,8 @@ fn repo_tab_insert_before_for_drop(
 #[cfg(test)]
 mod tests {
     use super::{
-        RepoTabsBarView, repo_tab_insert_before_for_drag_cursor, repo_tab_insert_before_for_drop,
+        RepoTabsBarView, repo_tab_horizontal_padding, repo_tab_insert_before_for_drag_cursor,
+        repo_tab_insert_before_for_drop,
     };
     use gitcomet_core::domain::RepoSpec;
     use gitcomet_state::model::{RepoId, RepoState};
@@ -1056,6 +1146,20 @@ mod tests {
                 workdir: PathBuf::from(path),
             },
         )
+    }
+
+    #[test]
+    fn repo_tab_padding_tracks_available_width_per_tab() {
+        assert_eq!(repo_tab_horizontal_padding(px(0.0), 3, 100), px(10.0));
+        assert_eq!(repo_tab_horizontal_padding(px(288.0), 3, 100), px(6.0));
+        assert_eq!(repo_tab_horizontal_padding(px(414.0), 3, 100), px(8.0));
+        assert_eq!(repo_tab_horizontal_padding(px(540.0), 3, 100), px(10.0));
+
+        assert!(
+            repo_tab_horizontal_padding(px(600.0), 8, 100)
+                < repo_tab_horizontal_padding(px(600.0), 3, 100),
+            "more tabs in the same viewport should use less side padding"
+        );
     }
 
     #[test]

--- a/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
@@ -14,11 +14,12 @@ pub(in super::super) struct RepoTabsBarView {
     open_terminal_repo_ids: HashSet<RepoId>,
 
     hovered_repo_tab: Option<RepoId>,
+    /// Left-pressed tab, tracked so its text fade matches the tab's active fill.
+    pressed_repo_tab: Option<RepoId>,
     active_context_menu_invoker: Option<SharedString>,
     repo_tab_spinner_delay: Option<RepoTabSpinnerDelayState>,
     repo_tab_spinner_delay_seq: u64,
     notify_fingerprint: u64,
-    title_drag_state: crate::view::chrome::TitleBarDragState,
     repo_tab_drag_visual: Option<RepoTabDragVisual>,
     tab_scroll: components::TabBarScroll,
     /// Active repo the strip last scrolled into view, so a repo the user
@@ -87,7 +88,7 @@ const REPO_TAB_MIN_SIDE_PADDING_PX: f32 = 6.0;
 const REPO_TAB_MAX_SIDE_PADDING_PX: f32 = 10.0;
 /// Padding reaches its minimum when each tab only has its minimum width, and
 /// its maximum when every tab could occupy the component's 180px width cap.
-const REPO_TAB_COMPACT_AVAILABLE_WIDTH_PX: f32 = 96.0;
+const REPO_TAB_COMPACT_AVAILABLE_WIDTH_PX: f32 = 100.0;
 const REPO_TAB_ROOMY_AVAILABLE_WIDTH_PX: f32 = 180.0;
 
 fn repo_tab_horizontal_padding(
@@ -302,6 +303,7 @@ impl RepoTabsBarView {
 
     fn close_repo_tab(&mut self, repo_id: RepoId, cx: &mut gpui::Context<Self>) {
         self.hovered_repo_tab = None;
+        self.pressed_repo_tab = None;
         if let Ok(true) = self.root_view.update(cx, |root, cx| {
             root.request_terminal_shutdown_action(TerminalShutdownAction::CloseRepo { repo_id }, cx)
         }) {
@@ -333,6 +335,12 @@ impl RepoTabsBarView {
             {
                 this.hovered_repo_tab = None;
             }
+            if this
+                .pressed_repo_tab
+                .is_some_and(|id| !this.state.repos.iter().any(|r| r.id == id))
+            {
+                this.pressed_repo_tab = None;
+            }
 
             if next_fingerprint != this.notify_fingerprint {
                 this.notify_fingerprint = next_fingerprint;
@@ -348,11 +356,11 @@ impl RepoTabsBarView {
             root_view,
             open_terminal_repo_ids: HashSet::default(),
             hovered_repo_tab: None,
+            pressed_repo_tab: None,
             active_context_menu_invoker: None,
             repo_tab_spinner_delay: None,
             repo_tab_spinner_delay_seq: 0,
             notify_fingerprint,
-            title_drag_state: crate::view::chrome::TitleBarDragState::default(),
             repo_tab_drag_visual: None,
             tab_scroll: components::TabBarScroll::new(),
             revealed_repo: None,
@@ -542,6 +550,11 @@ impl RepoTabsBarView {
         self.tab_scroll.viewport()
     }
 
+    #[cfg(test)]
+    pub(in crate::view) fn pressed_repo_tab_for_tests(&self) -> Option<RepoId> {
+        self.pressed_repo_tab
+    }
+
     fn active_repo_id(&self) -> Option<RepoId> {
         self.state.active_repo
     }
@@ -684,9 +697,12 @@ impl Render for RepoTabsBarView {
                 && !next_context_menu_active;
             let context_menu_invoker_for_right_click = context_menu_invoker.clone();
             let is_hovered = self.hovered_repo_tab == Some(repo_id);
+            let is_pressed = self.pressed_repo_tab == Some(repo_id);
             let label = path_display::repo_path_name(&repo.spec.workdir);
             let label_bg = if is_active || context_menu_active {
                 theme.colors.sidebar_bg
+            } else if is_pressed {
+                theme.colors.active
             } else if is_hovered {
                 hovered_tab_bg
             } else {
@@ -868,6 +884,7 @@ impl Render for RepoTabsBarView {
                 ))
                 .on_drop(cx.listener(move |this, _drag: &RepoTabDrag, _w, cx| {
                     this.hovered_repo_tab = None;
+                    this.pressed_repo_tab = None;
                     this.clear_repo_tab_drag_visual(cx);
                     cx.notify();
                 }))
@@ -879,6 +896,13 @@ impl Render for RepoTabsBarView {
                     }
                     cx.notify();
                 }))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _e: &MouseDownEvent, _w, cx| {
+                        this.pressed_repo_tab = Some(repo_id);
+                        cx.notify();
+                    }),
+                )
                 .on_mouse_down(
                     MouseButton::Right,
                     cx.listener(move |this, e: &MouseDownEvent, window, cx| {
@@ -957,108 +981,59 @@ impl Render for RepoTabsBarView {
                         });
                     })
                     .debug_selector(|| "add_repo_menu".to_string())
+                    .block_mouse_except_scroll()
                     .gitcomet_tooltip(theme, "Add repository".into()),
             );
 
-        // Browser-style: the empty strip after the tabs moves the window,
-        // toggles zoom on double click, and offers the window system menu.
-        let tab_strip_drag = div()
-            .id("repo_tab_strip_drag")
-            .debug_selector(|| "repo_tab_strip_drag".to_string())
-            .size_full()
-            .window_control_area(WindowControlArea::Drag)
-            .on_click(cx.listener(|this, e: &ClickEvent, window, cx| {
-                if !crate::view::chrome::should_handle_titlebar_double_click(
-                    e.click_count(),
-                    e.standard_click(),
-                ) {
+        // Keeps repository-tab drag reordering alive across the empty part of
+        // the strip. Ordinary pointer input falls through to the title bar's
+        // shared drag surface underneath.
+        let tab_strip_filler = div().size_full().on_drag_move(cx.listener(
+            |this, e: &gpui::DragMoveEvent<RepoTabDrag>, _window, cx| {
+                let (repo_id, cursor_offset_x, drag_center_x, dragged_tab_width) = {
+                    let drag = e.drag(cx);
+                    let drag_center_x = drag.center_x(e.event.position.x);
+                    let previous_center_x = drag.last_center_x.replace(drag_center_x);
+                    if drag_center_x > previous_center_x {
+                        drag.direction.set(1);
+                    } else if drag_center_x < previous_center_x {
+                        drag.direction.set(-1);
+                    }
+                    (
+                        drag.repo_id,
+                        drag.cursor_offset_x.get(),
+                        drag_center_x,
+                        drag.tab_width.get(),
+                    )
+                };
+                let visual = RepoTabDragVisual {
+                    repo_id,
+                    left: this.clamp_repo_tab_drag_left(
+                        e.event.position.x - cursor_offset_x,
+                        repo_id,
+                        dragged_tab_width,
+                    ),
+                };
+                if this.repo_tab_drag_visual != Some(visual) {
+                    this.repo_tab_drag_visual = Some(visual);
+                    cx.notify();
+                }
+
+                if drag_center_x < e.bounds.left() {
                     return;
                 }
-                this.title_drag_state.clear();
-                cx.stop_propagation();
-                crate::view::chrome::handle_titlebar_double_click(window);
-                cx.notify();
-            }))
-            .on_mouse_up(
-                MouseButton::Right,
-                cx.listener(|_this, e: &MouseUpEvent, window, cx| {
-                    crate::view::chrome::show_titlebar_secondary_menu(e.position, window, cx);
-                }),
-            )
-            .on_mouse_down(
-                MouseButton::Left,
-                cx.listener(|this, e: &MouseDownEvent, _w, cx| {
-                    this.title_drag_state.on_left_mouse_down(e.click_count);
-                    cx.notify();
-                }),
-            )
-            .on_mouse_up(
-                MouseButton::Left,
-                cx.listener(|this, _e, _w, cx| {
-                    this.title_drag_state.clear();
-                    this.clear_repo_tab_drag_visual(cx);
-                    cx.notify();
-                }),
-            )
-            .on_mouse_up_out(
-                MouseButton::Left,
-                cx.listener(|this, _e, _w, cx| {
-                    this.title_drag_state.clear();
-                    this.clear_repo_tab_drag_visual(cx);
-                    cx.notify();
-                }),
-            )
-            .on_mouse_move(cx.listener(|this, _e, window, _cx| {
-                if this.title_drag_state.take_move_request() {
-                    crate::app::begin_window_move(window);
-                }
-            }))
-            .on_drag_move(cx.listener(
-                |this, e: &gpui::DragMoveEvent<RepoTabDrag>, _window, cx| {
-                    let (repo_id, cursor_offset_x, drag_center_x, dragged_tab_width) = {
-                        let drag = e.drag(cx);
-                        let drag_center_x = drag.center_x(e.event.position.x);
-                        let previous_center_x = drag.last_center_x.replace(drag_center_x);
-                        if drag_center_x > previous_center_x {
-                            drag.direction.set(1);
-                        } else if drag_center_x < previous_center_x {
-                            drag.direction.set(-1);
-                        }
-                        (
-                            drag.repo_id,
-                            drag.cursor_offset_x.get(),
-                            drag_center_x,
-                            drag.tab_width.get(),
-                        )
-                    };
-                    let visual = RepoTabDragVisual {
-                        repo_id,
-                        left: this.clamp_repo_tab_drag_left(
-                            e.event.position.x - cursor_offset_x,
-                            repo_id,
-                            dragged_tab_width,
-                        ),
-                    };
-                    if this.repo_tab_drag_visual != Some(visual) {
-                        this.repo_tab_drag_visual = Some(visual);
-                        cx.notify();
-                    }
 
-                    if drag_center_x < e.bounds.left() {
-                        return;
-                    }
-
-                    this.store.dispatch(Msg::ReorderRepoTabs {
-                        repo_id,
-                        insert_before: None,
-                    });
-                },
-            ));
+                this.store.dispatch(Msg::ReorderRepoTabs {
+                    repo_id,
+                    insert_before: None,
+                });
+            },
+        ));
 
         let padding_scroll = self.tab_scroll.clone();
         let bar = bar
             .tab_end(add_repo)
-            .filler(tab_strip_drag)
+            .filler(tab_strip_filler)
             .render(theme, ui_scale_percent);
         div()
             .size_full()
@@ -1074,6 +1049,22 @@ impl Render for RepoTabsBarView {
             })
             .child(bar)
             .id("repo_tabs_responsive_root")
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, _e: &MouseUpEvent, _w, cx| {
+                    if this.pressed_repo_tab.take().is_some() {
+                        cx.notify();
+                    }
+                }),
+            )
+            .on_mouse_up_out(
+                MouseButton::Left,
+                cx.listener(|this, _e: &MouseUpEvent, _w, cx| {
+                    if this.pressed_repo_tab.take().is_some() {
+                        cx.notify();
+                    }
+                }),
+            )
             .can_drop(|dragged, _window, _cx| dragged.downcast_ref::<RepoTabDrag>().is_some())
             .on_drop(cx.listener(|this, drag: &RepoTabDrag, _w, cx| {
                 // Drop on the bar (but not on a specific tab) -> move to end.
@@ -1082,6 +1073,7 @@ impl Render for RepoTabsBarView {
                     insert_before: None,
                 });
                 this.hovered_repo_tab = None;
+                this.pressed_repo_tab = None;
                 this.clear_repo_tab_drag_visual(cx);
                 cx.notify();
             }))
@@ -1151,8 +1143,8 @@ mod tests {
     #[test]
     fn repo_tab_padding_tracks_available_width_per_tab() {
         assert_eq!(repo_tab_horizontal_padding(px(0.0), 3, 100), px(10.0));
-        assert_eq!(repo_tab_horizontal_padding(px(288.0), 3, 100), px(6.0));
-        assert_eq!(repo_tab_horizontal_padding(px(414.0), 3, 100), px(8.0));
+        assert_eq!(repo_tab_horizontal_padding(px(300.0), 3, 100), px(6.0));
+        assert_eq!(repo_tab_horizontal_padding(px(420.0), 3, 100), px(8.0));
         assert_eq!(repo_tab_horizontal_padding(px(540.0), 3, 100), px(10.0));
 
         assert!(

--- a/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/repo_tabs_bar.rs
@@ -82,33 +82,40 @@ const REPO_TAB_DRAG_SCROLL_MAX_STEP: Duration = Duration::from_millis(50);
 /// status glyph, and close button all center on the same title-bar axis.
 const REPO_TAB_FONT_SIZE_PX: f32 = 15.0;
 const REPO_TAB_CONTENT_HEIGHT_PX: f32 = 18.0;
-const REPO_TAB_STATUS_SIZE_PX: f32 = 12.0;
-const REPO_TAB_LABEL_GAP_PX: f32 = 4.0;
-const REPO_TAB_MIN_SIDE_PADDING_PX: f32 = 6.0;
-const REPO_TAB_MAX_SIDE_PADDING_PX: f32 = 10.0;
-/// Padding reaches its minimum when each tab only has its minimum width, and
-/// its maximum when every tab could occupy the component's 180px width cap.
-const REPO_TAB_COMPACT_AVAILABLE_WIDTH_PX: f32 = 100.0;
-const REPO_TAB_ROOMY_AVAILABLE_WIDTH_PX: f32 = 180.0;
+const REPO_TAB_STATUS_SIZE_PX: f32 = components::REPOSITORY_BADGE_SIZE_PX;
+const REPO_TAB_LABEL_GAP_PX: f32 = 6.0;
+const REPO_TAB_CLOSE_FADE_WIDTH_PX: f32 = 16.0;
+const REPO_TAB_SIDE_PADDING_PX: f32 = 10.0;
 
-fn repo_tab_horizontal_padding(
-    viewport_width: Pixels,
-    repo_count: usize,
-    ui_scale_percent: u32,
-) -> Pixels {
-    let scaled_px = |value| ui_scale::design_px_from_percent(value, ui_scale_percent);
-    let min_padding = f32::from(scaled_px(REPO_TAB_MIN_SIDE_PADDING_PX));
-    let max_padding = f32::from(scaled_px(REPO_TAB_MAX_SIDE_PADDING_PX));
-    if repo_count == 0 || viewport_width <= px(0.0) {
-        return px(max_padding);
+fn repo_tab_text_width(label: SharedString, font_size: Pixels, window: &mut Window) -> Pixels {
+    if label.is_empty() {
+        return px(0.0);
     }
+    let style = window.text_style();
+    let run = style.to_run(label.len());
+    window
+        .text_system()
+        .shape_line(label, font_size, &[run], None)
+        .width
+}
 
-    let available_per_tab = f32::from(viewport_width) / repo_count as f32;
-    let compact_width = f32::from(scaled_px(REPO_TAB_COMPACT_AVAILABLE_WIDTH_PX));
-    let roomy_width = f32::from(scaled_px(REPO_TAB_ROOMY_AVAILABLE_WIDTH_PX));
-    let room =
-        ((available_per_tab - compact_width) / (roomy_width - compact_width)).clamp(0.0, 1.0);
-    px(min_padding + (max_padding - min_padding) * room)
+fn repo_tab_close_button_fill(
+    theme: AppTheme,
+    background: gpui::Rgba,
+    pressed: bool,
+) -> gpui::Rgba {
+    let amount = match (theme.is_dark, pressed) {
+        (true, false) => 0.44,
+        (true, true) => 0.60,
+        (false, false) => 0.22,
+        (false, true) => 0.32,
+    };
+    let mut fill =
+        crate::theme::composite_over(background, with_alpha(theme.colors.shadow, amount));
+    // The hover plate must fully cover repository text beneath the overlaid
+    // close action rather than depend on stacked alpha compositing.
+    fill.a = 1.0;
+    fill
 }
 
 struct RepoTabSlide {
@@ -401,10 +408,9 @@ impl RepoTabsBarView {
     }
 
     /// Scrolls a newly activated tab into view. GPUI resolves the request
-    /// against the previously measured layout, which is a frame behind while
-    /// the strip is still settling (the scroll arrows appearing narrow it), so
-    /// the reveal is re-requested until the tab really is on screen — capped,
-    /// so a tab that can never satisfy it can't spin frames forever.
+    /// against the previously measured layout, so the reveal is re-requested
+    /// until the tab really is on screen — capped so a tab that can never
+    /// satisfy it cannot spin frames forever.
     fn reveal_pending_repo_tab(&mut self, window: &mut Window) {
         const MAX_REVEAL_ATTEMPTS: u8 = 3;
 
@@ -414,7 +420,6 @@ impl RepoTabsBarView {
         let Some(ix) = self.state.repos.iter().position(|r| r.id == repo_id) else {
             return;
         };
-
         if self.tab_scroll.is_measured() {
             if self.tab_scroll.tab_is_visible(ix) || attempts >= MAX_REVEAL_ATTEMPTS {
                 self.pending_reveal = None;
@@ -644,8 +649,9 @@ impl Render for RepoTabsBarView {
         let ui_scale_percent = ui_scale::current(cx).percent;
         let scaled_px = |value| ui_scale::design_px_from_percent(value, ui_scale_percent);
         let active = self.active_repo_id();
-        let spinner =
-            |id: (&'static str, u64), color: gpui::Rgba| svg_spinner(id, color, scaled_px(12.0));
+        let spinner = |id: (&'static str, u64), color: gpui::Rgba| {
+            svg_spinner(id, color, scaled_px(REPO_TAB_STATUS_SIZE_PX))
+        };
         // Tabs are transparent, so a label fading out has to land on whatever
         // is actually behind it: the bar for an idle tab, the content strip
         // for the active one.
@@ -662,12 +668,36 @@ impl Render for RepoTabsBarView {
         self.reveal_pending_repo_tab(window);
         self.drive_repo_tab_drag_scroll(ui_scale_percent, window);
 
-        let repo_count = self.state.repos.len();
-        let tab_horizontal_padding = repo_tab_horizontal_padding(
-            self.tab_scroll.viewport().size.width,
-            repo_count,
-            ui_scale_percent,
-        );
+        let tab_horizontal_padding = scaled_px(REPO_TAB_SIDE_PADDING_PX);
+        let repo_tab_labels = self
+            .state
+            .repos
+            .iter()
+            .map(|repo| path_display::repo_path_name(&repo.spec.workdir))
+            .collect::<Vec<_>>();
+        let natural_tab_widths = self
+            .state
+            .repos
+            .iter()
+            .zip(&repo_tab_labels)
+            .map(|(repo, label)| {
+                let text_width =
+                    repo_tab_text_width(label.clone(), scaled_px(REPO_TAB_FONT_SIZE_PX), window);
+                let terminal_width = if self.open_terminal_repo_ids.contains(&repo.id) {
+                    scaled_px(REPO_TAB_LABEL_GAP_PX + REPO_TAB_STATUS_SIZE_PX)
+                } else {
+                    px(0.0)
+                };
+                let content_width = scaled_px(REPO_TAB_STATUS_SIZE_PX + REPO_TAB_LABEL_GAP_PX)
+                    + text_width
+                    + terminal_width;
+                components::Tab::natural_width(
+                    content_width,
+                    tab_horizontal_padding,
+                    ui_scale_percent,
+                )
+            })
+            .collect::<Vec<_>>();
         let mut bar = components::TabBar::new("repo_tab_bar").scroll(self.tab_scroll.clone());
         for (ix, repo) in self.state.repos.iter().enumerate() {
             let repo_id = repo.id;
@@ -698,7 +728,8 @@ impl Render for RepoTabsBarView {
             let context_menu_invoker_for_right_click = context_menu_invoker.clone();
             let is_hovered = self.hovered_repo_tab == Some(repo_id);
             let is_pressed = self.pressed_repo_tab == Some(repo_id);
-            let label = path_display::repo_path_name(&repo.spec.workdir);
+            let label = repo_tab_labels[ix].clone();
+            let initials: SharedString = components::repository_initials(label.as_ref()).into();
             let label_bg = if is_active || context_menu_active {
                 theme.colors.sidebar_bg
             } else if is_pressed {
@@ -715,6 +746,8 @@ impl Render for RepoTabsBarView {
 
             let tooltip = Self::repo_tab_tooltip(repo);
             let close_tooltip: SharedString = "Close repository".into();
+            let close_hover_bg = repo_tab_close_button_fill(theme, label_bg, false);
+            let close_pressed_bg = repo_tab_close_button_fill(theme, label_bg, true);
 
             let close_button = div()
                 .id(("repo_tab_close", repo_id.0))
@@ -722,30 +755,51 @@ impl Render for RepoTabsBarView {
                 .flex()
                 .items_center()
                 .justify_center()
-                .size(scaled_px(14.0))
+                .size(scaled_px(REPO_TAB_STATUS_SIZE_PX))
                 .rounded(px(theme.radii.row))
+                // Fully cover any label ink beneath the button; the sibling
+                // ramp transitions into this exact background.
+                .bg(label_bg)
                 .cursor_pointer()
-                .hover(move |s| s.bg(with_alpha(theme.colors.danger, 0.18)))
-                .active(move |s| s.bg(with_alpha(theme.colors.danger, 0.26)))
+                .hover(move |s| s.bg(close_hover_bg))
+                .active(move |s| s.bg(close_pressed_bg))
                 .child(svg_icon(
                     "icons/repo_tab_close.svg",
                     theme.colors.danger,
-                    scaled_px(12.0),
+                    scaled_px(REPO_TAB_STATUS_SIZE_PX),
                 ))
                 .on_click(cx.listener(move |this, _e: &ClickEvent, _w, cx| {
                     cx.stop_propagation();
                     this.close_repo_tab(repo_id, cx);
                 }))
                 .gitcomet_tooltip(theme, close_tooltip.clone());
+            let close_overlay = div()
+                .flex()
+                .items_center()
+                .h(scaled_px(REPO_TAB_STATUS_SIZE_PX))
+                .child(
+                    components::trailing_fade(label_bg, scaled_px(REPO_TAB_CLOSE_FADE_WIDTH_PX))
+                        .debug_selector(move || format!("repo_tab_close_fade_{}", repo_id.0)),
+                )
+                .child(close_button);
 
             let mut tab = components::Tab::new(("repo_tab", repo_id.0))
                 .selected(is_active || context_menu_active)
-                .horizontal_padding(tab_horizontal_padding);
+                .horizontal_padding(tab_horizontal_padding)
+                .responsive_width(natural_tab_widths[ix]);
             if is_hovered {
-                tab = tab.end_slot(close_button);
+                tab = tab.end_slot(close_overlay);
             }
 
             let show_missing_warning = Self::repo_tab_shows_missing_warning(repo, show_spinner);
+            let show_initials = !show_spinner && !show_missing_warning;
+            let status_color =
+                with_alpha(theme.colors.text, if theme.is_dark { 0.72 } else { 0.62 });
+            let badge_color = if is_active {
+                theme.colors.accent
+            } else {
+                status_color
+            };
             let tab_label = div()
                 .flex()
                 .flex_1()
@@ -762,14 +816,8 @@ impl Render for RepoTabsBarView {
                         .when(show_spinner, |d| {
                             d.debug_selector(move || format!("repo_tab_busy_spinner_{}", repo_id.0))
                                 .child(
-                                    spinner(
-                                        ("repo_tab_busy_spinner", repo_id.0),
-                                        with_alpha(
-                                            theme.colors.text,
-                                            if theme.is_dark { 0.72 } else { 0.62 },
-                                        ),
-                                    )
-                                    .into_any_element(),
+                                    spinner(("repo_tab_busy_spinner", repo_id.0), badge_color)
+                                        .into_any_element(),
                                 )
                         })
                         .when(show_missing_warning, |d| {
@@ -778,6 +826,17 @@ impl Render for RepoTabsBarView {
                                 theme.colors.warning,
                                 scaled_px(12.0),
                             ))
+                        })
+                        .when(show_initials, |d| {
+                            d.child(
+                                components::repository_initials_box(
+                                    theme,
+                                    ui_scale_percent,
+                                    initials.clone(),
+                                    is_active,
+                                )
+                                .debug_selector(move || format!("repo_tab_initials_{}", repo_id.0)),
+                            )
                         }),
                 )
                 .child(
@@ -785,6 +844,7 @@ impl Render for RepoTabsBarView {
                     // background rather than being cut mid-glyph.
                     components::FadingText::new(
                         div()
+                            .debug_selector(move || format!("repo_tab_label_text_{}", repo_id.0))
                             .text_size(scaled_px(REPO_TAB_FONT_SIZE_PX))
                             .line_height(scaled_px(REPO_TAB_CONTENT_HEIGHT_PX))
                             .child(label),
@@ -801,7 +861,7 @@ impl Render for RepoTabsBarView {
                             .child(svg_icon(
                                 "icons/terminal.svg",
                                 theme.colors.accent,
-                                px(12.0),
+                                scaled_px(REPO_TAB_STATUS_SIZE_PX),
                             )),
                     )
                 });
@@ -988,8 +1048,8 @@ impl Render for RepoTabsBarView {
         // Keeps repository-tab drag reordering alive across the empty part of
         // the strip. Ordinary pointer input falls through to the title bar's
         // shared drag surface underneath.
-        let tab_strip_filler = div().size_full().on_drag_move(cx.listener(
-            |this, e: &gpui::DragMoveEvent<RepoTabDrag>, _window, cx| {
+        let tab_strip_drag_listener =
+            cx.listener(|this, e: &gpui::DragMoveEvent<RepoTabDrag>, _window, cx| {
                 let (repo_id, cursor_offset_x, drag_center_x, dragged_tab_width) = {
                     let drag = e.drag(cx);
                     let drag_center_x = drag.center_x(e.event.position.x);
@@ -1027,28 +1087,14 @@ impl Render for RepoTabsBarView {
                     repo_id,
                     insert_before: None,
                 });
-            },
-        ));
+            });
 
-        let padding_scroll = self.tab_scroll.clone();
-        let bar = bar
-            .tab_end(add_repo)
-            .filler(tab_strip_filler)
-            .render(theme, ui_scale_percent);
+        let bar = bar.tab_end(add_repo).render(theme, ui_scale_percent);
         div()
             .size_full()
-            .on_children_prepainted(move |_bounds, _window, cx| {
-                let next_padding = repo_tab_horizontal_padding(
-                    padding_scroll.viewport().size.width,
-                    repo_count,
-                    ui_scale_percent,
-                );
-                if (f32::from(next_padding) - f32::from(tab_horizontal_padding)).abs() > 0.25 {
-                    cx.refresh_windows();
-                }
-            })
             .child(bar)
             .id("repo_tabs_responsive_root")
+            .on_drag_move(tab_strip_drag_listener)
             .on_mouse_up(
                 MouseButton::Left,
                 cx.listener(|this, _e: &MouseUpEvent, _w, cx| {
@@ -1122,7 +1168,7 @@ fn repo_tab_insert_before_for_drop(
 #[cfg(test)]
 mod tests {
     use super::{
-        RepoTabsBarView, repo_tab_horizontal_padding, repo_tab_insert_before_for_drag_cursor,
+        RepoTabsBarView, repo_tab_close_button_fill, repo_tab_insert_before_for_drag_cursor,
         repo_tab_insert_before_for_drop,
     };
     use gitcomet_core::domain::RepoSpec;
@@ -1141,17 +1187,21 @@ mod tests {
     }
 
     #[test]
-    fn repo_tab_padding_tracks_available_width_per_tab() {
-        assert_eq!(repo_tab_horizontal_padding(px(0.0), 3, 100), px(10.0));
-        assert_eq!(repo_tab_horizontal_padding(px(300.0), 3, 100), px(6.0));
-        assert_eq!(repo_tab_horizontal_padding(px(420.0), 3, 100), px(8.0));
-        assert_eq!(repo_tab_horizontal_padding(px(540.0), 3, 100), px(10.0));
+    fn repo_tab_close_hover_uses_an_opaque_darker_fill() {
+        for theme in [
+            crate::theme::AppTheme::gitcomet_dark(),
+            crate::theme::AppTheme::gitcomet_light(),
+        ] {
+            let background = theme.colors.sidebar_bg;
+            let hover = repo_tab_close_button_fill(theme, background, false);
+            let pressed = repo_tab_close_button_fill(theme, background, true);
+            let brightness = |color: gpui::Rgba| color.r + color.g + color.b;
 
-        assert!(
-            repo_tab_horizontal_padding(px(600.0), 8, 100)
-                < repo_tab_horizontal_padding(px(600.0), 3, 100),
-            "more tabs in the same viewport should use less side padding"
-        );
+            assert_eq!(hover.a, 1.0, "hover background must be solid");
+            assert_eq!(pressed.a, 1.0, "pressed background must be solid");
+            assert!(brightness(hover) < brightness(background));
+            assert!(brightness(pressed) < brightness(hover));
+        }
     }
 
     #[test]

--- a/crates/gitcomet-ui-gpui/src/view/state_apply.rs
+++ b/crates/gitcomet-ui-gpui/src/view/state_apply.rs
@@ -12,7 +12,7 @@ impl GitCometView {
         let prev_banner_error = self.state.banner_error.clone();
         let prev_auth_prompt = self.state.auth_prompt.clone();
         let prev_submodule_trust_prompt = self.state.submodule_trust_prompt.clone();
-        let prev_submodule_trust_check = self.state.submodule_trust_check_pending.clone();
+        let prev_submodule_trust_check = self.state.submodule_trust_check_pending;
         let next_banner_error = next.banner_error.clone();
         let merge_view_active = active_merge_view_target(next.as_ref()).is_some();
         let mut follow_up_msgs = Vec::new();
@@ -189,7 +189,7 @@ impl GitCometView {
             // A newly-started check opens the spinner popover on the next render.
             if self.state.submodule_trust_check_pending.is_some() {
                 self.pending_submodule_trust_check =
-                    self.state.submodule_trust_check_pending.clone();
+                    self.state.submodule_trust_check_pending;
             } else if let Some(prev) = prev_submodule_trust_check.as_ref()
                 && self.state.submodule_trust_prompt.is_none()
             {

--- a/crates/gitcomet-ui-gpui/src/view/state_apply.rs
+++ b/crates/gitcomet-ui-gpui/src/view/state_apply.rs
@@ -188,8 +188,7 @@ impl GitCometView {
         if prev_submodule_trust_check != self.state.submodule_trust_check_pending {
             // A newly-started check opens the spinner popover on the next render.
             if self.state.submodule_trust_check_pending.is_some() {
-                self.pending_submodule_trust_check =
-                    self.state.submodule_trust_check_pending;
+                self.pending_submodule_trust_check = self.state.submodule_trust_check_pending;
             } else if let Some(prev) = prev_submodule_trust_check.as_ref()
                 && self.state.submodule_trust_prompt.is_none()
             {

--- a/crates/gitcomet-ui-gpui/src/view/test_support.rs
+++ b/crates/gitcomet-ui-gpui/src/view/test_support.rs
@@ -41,12 +41,20 @@ pub(crate) fn repo_tab_strip_viewport(view: &GitCometView, app: &App) -> gpui::B
     view.repo_tabs_bar.read(app).tab_strip_viewport_for_tests()
 }
 
+pub(crate) fn pressed_repo_tab(view: &GitCometView, app: &App) -> Option<RepoId> {
+    view.repo_tabs_bar.read(app).pressed_repo_tab_for_tests()
+}
+
 pub(crate) fn add_repo_menu_is_open(view: &GitCometView, app: &App) -> bool {
     matches!(popover_kind(view, app), Some(PopoverKind::AddRepoMenu))
 }
 
 pub(crate) fn app_menu_focus_handle(view: &GitCometView, app: &App) -> FocusHandle {
     view.title_bar.read(app).app_menu_focus_handle_for_test()
+}
+
+pub(crate) fn titlebar_drag_is_armed(view: &GitCometView, app: &App) -> bool {
+    view.title_bar.read(app).title_drag_armed_for_test()
 }
 
 pub(in crate::view) fn history_refs_hover_is_open(view: &GitCometView, app: &App) -> bool {

--- a/crates/gitcomet-ui-gpui/src/view/tests.rs
+++ b/crates/gitcomet-ui-gpui/src/view/tests.rs
@@ -3269,7 +3269,7 @@ fn loading_repo_tab_close_button_closes_repo(cx: &mut gpui::TestAppContext) {
     state.repos.push(RepoState::new_opening(
         repo_id,
         RepoSpec {
-            workdir: PathBuf::from("/tmp/loading-repo-tab-close-test"),
+            workdir: PathBuf::from("/tmp/repo"),
         },
     ));
     store_for_assert.replace_snapshot_for_test(Arc::new(state));
@@ -3282,13 +3282,48 @@ fn loading_repo_tab_close_button_closes_repo(cx: &mut gpui::TestAppContext) {
         .debug_bounds("repo_tab_1")
         .expect("expected loading repo tab to be rendered")
         .center();
+    let repo_tab_bounds = cx
+        .debug_bounds("repo_tab_1")
+        .expect("expected loading repo tab bounds");
+    assert_eq!(
+        repo_tab_bounds.size.width,
+        px(96.0),
+        "expected a short repository label to retain the 96px minimum tab width"
+    );
     cx.simulate_mouse_move(repo_tab_center, None, gpui::Modifiers::default());
     test_support::redraw(cx);
 
+    let label_center_y = cx
+        .debug_bounds("repo_tab_label_1")
+        .expect("expected loading repo tab label bounds")
+        .center()
+        .y;
+    let spinner_center_y = cx
+        .debug_bounds("repo_tab_busy_spinner_1")
+        .expect("expected loading repo tab spinner bounds")
+        .center()
+        .y;
     let close_center = cx
         .debug_bounds("repo_tab_close_1")
         .expect("expected loading repo tab close button to be rendered")
         .center();
+    let close_bounds = cx
+        .debug_bounds("repo_tab_close_1")
+        .expect("expected loading repo tab close button bounds");
+    let close_trailing_inset = repo_tab_bounds.right() - close_bounds.right();
+    assert!(
+        close_trailing_inset >= px(10.0) && close_trailing_inset <= px(12.0),
+        "expected close button at the end of the tab inside its trailing padding, got \
+         {close_trailing_inset:?}"
+    );
+    assert_eq!(
+        label_center_y, spinner_center_y,
+        "expected repository label and loading spinner to share a centerline"
+    );
+    assert_eq!(
+        label_center_y, close_center.y,
+        "expected repository label and close button to share a centerline"
+    );
     cx.simulate_mouse_move(close_center, None, gpui::Modifiers::default());
     cx.simulate_mouse_down(
         close_center,

--- a/crates/gitcomet-ui-gpui/src/view/tests.rs
+++ b/crates/gitcomet-ui-gpui/src/view/tests.rs
@@ -3287,8 +3287,8 @@ fn loading_repo_tab_close_button_closes_repo(cx: &mut gpui::TestAppContext) {
         .expect("expected loading repo tab bounds");
     assert_eq!(
         repo_tab_bounds.size.width,
-        px(96.0),
-        "expected a short repository label to retain the 96px minimum tab width"
+        px(100.0),
+        "expected a short repository label to retain the 100px minimum tab width"
     );
     cx.simulate_mouse_move(repo_tab_center, None, gpui::Modifiers::default());
     test_support::redraw(cx);
@@ -3338,6 +3338,47 @@ fn loading_repo_tab_close_button_closes_repo(cx: &mut gpui::TestAppContext) {
 
     wait_until("loading repo tab to close", || {
         store_for_assert.snapshot().repos.is_empty()
+    });
+}
+
+#[gpui::test]
+fn inactive_repo_tab_tracks_pressed_state_for_its_label_fade(cx: &mut gpui::TestAppContext) {
+    let _visual_guard = crate::test_support::lock_visual_test();
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let store_for_view = store.clone();
+    let (view, cx) = cx.add_window_view(move |window, cx| {
+        GitCometView::new(store_for_view, events, None, window, cx)
+    });
+    install_repo_tab_test_state(&store, &view, cx, RepoId(1));
+
+    let inactive_tab_center = cx
+        .debug_bounds("repo_tab_2")
+        .expect("expected inactive repository tab bounds")
+        .center();
+    cx.simulate_mouse_move(inactive_tab_center, None, gpui::Modifiers::default());
+    cx.simulate_mouse_down(
+        inactive_tab_center,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::default(),
+    );
+    test_support::redraw(cx);
+
+    cx.update(|_window, app| {
+        assert_eq!(
+            test_support::pressed_repo_tab(view.read(app), app),
+            Some(RepoId(2)),
+            "expected the label fade to resolve against the held tab's active background"
+        );
+    });
+
+    cx.simulate_mouse_up(
+        inactive_tab_center,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::default(),
+    );
+    test_support::redraw(cx);
+    cx.update(|_window, app| {
+        assert_eq!(test_support::pressed_repo_tab(view.read(app), app), None);
     });
 }
 

--- a/crates/gitcomet-ui-gpui/src/view/tests.rs
+++ b/crates/gitcomet-ui-gpui/src/view/tests.rs
@@ -3272,9 +3272,24 @@ fn loading_repo_tab_close_button_closes_repo(cx: &mut gpui::TestAppContext) {
             workdir: PathBuf::from("/tmp/repo"),
         },
     ));
+    let ready_repo_id = RepoId(2);
+    let mut ready_repo = RepoState::new_opening(
+        ready_repo_id,
+        RepoSpec {
+            workdir: PathBuf::from("/tmp/GitComet"),
+        },
+    );
+    ready_repo.open = Loadable::Ready(());
+    state.repos.push(ready_repo);
     store_for_assert.replace_snapshot_for_test(Arc::new(state));
     cx.update(|_window, app| {
         view.update(app, |this, cx| test_support::sync_store_snapshot(this, cx));
+        let repo_tabs_bar = view.read(app).repo_tabs_bar.clone();
+        repo_tabs_bar.update(app, |bar, cx| {
+            let mut open_terminal_repo_ids = HashSet::default();
+            open_terminal_repo_ids.insert(ready_repo_id);
+            bar.set_open_terminal_repo_ids(open_terminal_repo_ids, cx);
+        });
     });
     test_support::redraw(cx);
 
@@ -3285,24 +3300,44 @@ fn loading_repo_tab_close_button_closes_repo(cx: &mut gpui::TestAppContext) {
     let repo_tab_bounds = cx
         .debug_bounds("repo_tab_1")
         .expect("expected loading repo tab bounds");
+    let label_before_hover = cx
+        .debug_bounds("repo_tab_label_1")
+        .expect("expected loading repo tab label before hover");
+    assert_eq!(
+        cx.debug_bounds("repo_tab_close_1"),
+        None,
+        "close action should stay hidden until the repository tab is hovered"
+    );
+    assert_eq!(
+        cx.debug_bounds("repo_tab_close_fade_1"),
+        None,
+        "close fade should only exist together with the close action"
+    );
     assert_eq!(
         repo_tab_bounds.size.width,
-        px(100.0),
-        "expected a short repository label to retain the 100px minimum tab width"
+        px(102.0),
+        "expected a short repository label to fit the 18px status mark at the compact width"
     );
     cx.simulate_mouse_move(repo_tab_center, None, gpui::Modifiers::default());
     test_support::redraw(cx);
 
-    let label_center_y = cx
+    let label_bounds = cx
         .debug_bounds("repo_tab_label_1")
-        .expect("expected loading repo tab label bounds")
-        .center()
-        .y;
-    let spinner_center_y = cx
+        .expect("expected loading repo tab label bounds");
+    let label_center_y = label_bounds.center().y;
+    let spinner_bounds = cx
         .debug_bounds("repo_tab_busy_spinner_1")
-        .expect("expected loading repo tab spinner bounds")
-        .center()
-        .y;
+        .expect("expected loading repo tab spinner bounds");
+    let initials_bounds = cx
+        .debug_bounds("repo_tab_initials_2")
+        .expect("expected ready repo tab initials bounds");
+    let ready_label_bounds = cx
+        .debug_bounds("repo_tab_label_2")
+        .expect("expected ready repo tab label bounds");
+    let ready_label_center_y = ready_label_bounds.center().y;
+    let terminal_bounds = cx
+        .debug_bounds("repo_tab_terminal_2")
+        .expect("expected ready repo tab terminal icon bounds");
     let close_center = cx
         .debug_bounds("repo_tab_close_1")
         .expect("expected loading repo tab close button to be rendered")
@@ -3310,6 +3345,9 @@ fn loading_repo_tab_close_button_closes_repo(cx: &mut gpui::TestAppContext) {
     let close_bounds = cx
         .debug_bounds("repo_tab_close_1")
         .expect("expected loading repo tab close button bounds");
+    let close_fade_bounds = cx
+        .debug_bounds("repo_tab_close_fade_1")
+        .expect("expected a fade before the overlaid close button");
     let close_trailing_inset = repo_tab_bounds.right() - close_bounds.right();
     assert!(
         close_trailing_inset >= px(10.0) && close_trailing_inset <= px(12.0),
@@ -3317,12 +3355,78 @@ fn loading_repo_tab_close_button_closes_repo(cx: &mut gpui::TestAppContext) {
          {close_trailing_inset:?}"
     );
     assert_eq!(
-        label_center_y, spinner_center_y,
+        label_bounds.size.width, label_before_hover.size.width,
+        "showing the close action must not reserve or remove repository-label space"
+    );
+    assert!(
+        label_bounds.right() > close_bounds.left(),
+        "the close action should overlay the repository text instead of taking a flex slot"
+    );
+    assert_eq!(
+        close_fade_bounds.size.width,
+        px(16.0),
+        "expected the shared 16px fade ramp before the close action"
+    );
+    assert_eq!(
+        close_fade_bounds.right(),
+        close_bounds.left(),
+        "the fade ramp should meet the close button without a hard edge"
+    );
+    assert_eq!(
+        spinner_bounds.size, initials_bounds.size,
+        "expected loading spinner and repository initials to have identical dimensions"
+    );
+    assert_eq!(
+        spinner_bounds.size,
+        gpui::size(px(18.0), px(18.0)),
+        "expected repository status marks to match the shared 18px text line box"
+    );
+    assert_eq!(
+        close_bounds.size, spinner_bounds.size,
+        "expected the repository close button to use the shared 18px geometry"
+    );
+    assert_eq!(
+        terminal_bounds.size, spinner_bounds.size,
+        "expected the embedded terminal icon to use the shared 18px geometry"
+    );
+    assert_eq!(
+        label_bounds.left() - spinner_bounds.right(),
+        px(6.0),
+        "expected a 6px gap between the loading spinner and repository name"
+    );
+    assert_eq!(
+        ready_label_bounds.left() - initials_bounds.right(),
+        px(6.0),
+        "expected a 6px gap between the initials badge and repository name"
+    );
+    assert_eq!(
+        cx.debug_bounds("repo_tab_initials_1"),
+        None,
+        "expected loading repository initials to be replaced by the spinner"
+    );
+    assert_eq!(
+        cx.debug_bounds("repo_tab_busy_spinner_2"),
+        None,
+        "expected a ready repository to show initials instead of a spinner"
+    );
+    assert_eq!(
+        label_center_y,
+        spinner_bounds.center().y,
         "expected repository label and loading spinner to share a centerline"
     );
     assert_eq!(
         label_center_y, close_center.y,
         "expected repository label and close button to share a centerline"
+    );
+    assert_eq!(
+        ready_label_center_y,
+        initials_bounds.center().y,
+        "expected repository label and initials badge to share a centerline"
+    );
+    assert_eq!(
+        ready_label_center_y,
+        terminal_bounds.center().y,
+        "expected repository label and terminal icon to share a centerline"
     );
     cx.simulate_mouse_move(close_center, None, gpui::Modifiers::default());
     cx.simulate_mouse_down(
@@ -3337,7 +3441,11 @@ fn loading_repo_tab_close_button_closes_repo(cx: &mut gpui::TestAppContext) {
     );
 
     wait_until("loading repo tab to close", || {
-        store_for_assert.snapshot().repos.is_empty()
+        !store_for_assert
+            .snapshot()
+            .repos
+            .iter()
+            .any(|repo| repo.id == repo_id)
     });
 }
 
@@ -3394,18 +3502,28 @@ fn repo_tab_context_menu_renders_requested_actions(cx: &mut gpui::TestAppContext
     open_repo_tab_context_menu(cx, "repo_tab_2");
 
     assert_eq!(store.snapshot().active_repo, Some(RepoId(1)));
-    cx.debug_bounds("context_menu_active")
-        .expect("expected Active menu item");
+    cx.debug_bounds("context_menu_activate")
+        .expect("expected Activate menu item");
+    cx.debug_bounds("context_menu_open_repository_location")
+        .expect("expected Open repository location menu item");
     cx.debug_bounds("context_menu_close")
         .expect("expected Close menu item");
     cx.debug_bounds("context_menu_close_repositories_to_the_right")
         .expect("expected Close repositories to the right menu item");
     cx.debug_bounds("context_menu_close_other_repositories")
         .expect("expected Close other repositories menu item");
+    assert!(
+        cx.debug_bounds("app_popover")
+            .expect("expected repository tab context menu bounds")
+            .size
+            .width
+            >= px(360.0),
+        "expected repository tab context menu to use its wider layout"
+    );
 }
 
 #[gpui::test]
-fn repo_tab_context_menu_active_activates_selected_repo(cx: &mut gpui::TestAppContext) {
+fn repo_tab_context_menu_activate_activates_selected_repo(cx: &mut gpui::TestAppContext) {
     let _visual_guard = crate::test_support::lock_visual_test();
     let (store, events) = AppStore::new(Arc::new(TestBackend));
     let store_for_view = store.clone();
@@ -3414,9 +3532,9 @@ fn repo_tab_context_menu_active_activates_selected_repo(cx: &mut gpui::TestAppCo
 
     install_repo_tab_test_state(&store, &view, cx, RepoId(1));
     open_repo_tab_context_menu(cx, "repo_tab_2");
-    click_debug_selector(cx, "context_menu_active");
+    click_debug_selector(cx, "context_menu_activate");
 
-    wait_until("repo tab menu active action", || {
+    wait_until("repo tab menu activate action", || {
         store.snapshot().active_repo == Some(RepoId(2))
     });
 }
@@ -3493,7 +3611,7 @@ fn repo_tab_context_menu_close_other_repos_keeps_selected_repo(cx: &mut gpui::Te
 }
 
 #[gpui::test]
-fn repo_tab_context_menu_active_is_disabled_for_active_repo(cx: &mut gpui::TestAppContext) {
+fn repo_tab_context_menu_activate_is_disabled_for_active_repo(cx: &mut gpui::TestAppContext) {
     let _visual_guard = crate::test_support::lock_visual_test();
     let (store, events) = AppStore::new(Arc::new(TestBackend));
     let store_for_view = store.clone();
@@ -3502,11 +3620,11 @@ fn repo_tab_context_menu_active_is_disabled_for_active_repo(cx: &mut gpui::TestA
 
     install_repo_tab_test_state(&store, &view, cx, RepoId(2));
     open_repo_tab_context_menu(cx, "repo_tab_2");
-    click_debug_selector(cx, "context_menu_active");
+    click_debug_selector(cx, "context_menu_activate");
 
     assert_eq!(store.snapshot().active_repo, Some(RepoId(2)));
-    cx.debug_bounds("context_menu_active")
-        .expect("expected disabled Active item to leave the menu open");
+    cx.debug_bounds("context_menu_activate")
+        .expect("expected disabled Activate item to leave the menu open");
 }
 
 #[gpui::test]

--- a/crates/gitcomet/Cargo.toml
+++ b/crates/gitcomet/Cargo.toml
@@ -42,6 +42,9 @@ tempfile = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 wayland-client = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+signal-hook = { workspace = true }
+
 [target.'cfg(target_os = "windows")'.build-dependencies]
 embed-resource = "3"
 

--- a/crates/gitcomet/Cargo.toml
+++ b/crates/gitcomet/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [features]
 default = ["ui-gpui", "gix"]
 ui = ["ui-gpui"]
-ui-gpui-runtime = ["dep:gitcomet-ui-gpui"]
+ui-gpui-runtime = ["dep:gitcomet-ui-gpui", "dep:sysinfo"]
 ui-gpui = ["ui-gpui-runtime", "gitcomet-ui-gpui/syntax-all"]
 ui-gpui-syntax-common = [
     "ui-gpui-runtime",
@@ -37,6 +37,7 @@ mimalloc = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sysinfo = { workspace = true, optional = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/gitcomet/src/crashlog.rs
+++ b/crates/gitcomet/src/crashlog.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 static WRITING_CRASH_LOG: AtomicBool = AtomicBool::new(false);
 static SESSION_ACTIVE: AtomicBool = AtomicBool::new(false);
+static SESSION_LIFECYCLE: Mutex<()> = Mutex::new(());
 static WRITING_RUNTIME_ERROR_LOG: Mutex<()> = Mutex::new(());
 static CRASH_LOGGER: CrashLogger = CrashLogger;
 const CRASH_ISSUE_URL: &str = concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new");
@@ -39,6 +40,11 @@ struct AbnormalExitLog {
 pub fn install() {
     if log::set_logger(&CRASH_LOGGER).is_ok() {
         log::set_max_level(log::LevelFilter::Error);
+    }
+
+    #[cfg(unix)]
+    if let Err(err) = install_terminal_interrupt_handler() {
+        eprintln!("Failed to install GitComet terminal interrupt handler: {err}");
     }
 
     let previous = std::panic::take_hook();
@@ -80,7 +86,51 @@ fn should_record_runtime_error(target: &str, message: &str) -> bool {
     // removed from App. Its callback logs the failed handle lookup even though
     // teardown is proceeding normally. Treating that diagnostic as evidence of
     // a crash causes the next launch to report a false abnormal exit.
-    !(target == "gpui::window" && message.trim() == "window not found")
+    if target == "gpui::window" && message.trim() == "window not found" {
+        return false;
+    }
+
+    // Some EGL drivers emit this validation message through wgpu's debug
+    // callback while the application continues normally. It is not evidence
+    // that GitComet itself failed and can otherwise obscure a later exit's
+    // actual cause in the recovered report.
+    if target == "wgpu_hal::gles::egl"
+        && message.contains("eglCreateSyncKHR")
+        && message.contains("EGL_BAD_ATTRIBUTE")
+        && message.contains("EGL_SYNC_NATIVE_FENCE_FD_ANDROID")
+        && message.contains("EGL_SYNC_STATUS")
+    {
+        return false;
+    }
+
+    true
+}
+
+#[cfg(unix)]
+fn install_terminal_interrupt_handler() -> std::io::Result<()> {
+    use signal_hook::consts::signal::SIGINT;
+    use signal_hook::iterator::Signals;
+
+    let mut signals = Signals::new([SIGINT])?;
+    std::thread::Builder::new()
+        .name("gitcomet-sigint".to_string())
+        .spawn(move || {
+            if signals.forever().next().is_some() {
+                // SIGINT is the user's explicit request to stop a terminal
+                // launch. Retire only this process's active recovery marker,
+                // then preserve the conventional shell exit status (130).
+                let _lifecycle = SESSION_LIFECYCLE
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if SESSION_ACTIVE.swap(false, Ordering::SeqCst)
+                    && let Some(dir) = crash_dir()
+                {
+                    let _ = finish_session_in_dir(&dir);
+                }
+                std::process::exit(128 + SIGINT);
+            }
+        })?;
+    Ok(())
 }
 
 fn write_runtime_error_log(record: &log::Record<'_>) {
@@ -154,10 +204,18 @@ fn write_runtime_error_log_in_dir(
 }
 
 /// Records entry to the UI event loop. A stale marker lets the next launch
-/// report native aborts and signals without attempting I/O in a signal handler.
+/// report native aborts and unexpected signals. Terminal SIGINT is handled on
+/// a dedicated thread and removes the marker before exiting.
 pub fn begin_session() -> std::io::Result<()> {
     let dir = crash_dir().ok_or_else(crash_directory_unavailable_error)?;
-    begin_session_in_dir(&dir)?;
+    let _lifecycle = SESSION_LIFECYCLE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Err(err) = begin_session_in_dir(&dir) {
+        SESSION_ACTIVE.store(false, Ordering::SeqCst);
+        let _ = finish_session_in_dir(&dir);
+        return Err(err);
+    }
     SESSION_ACTIVE.store(true, Ordering::SeqCst);
     Ok(())
 }
@@ -199,9 +257,13 @@ fn begin_session_in_dir(dir: &Path) -> std::io::Result<()> {
 
 /// Clears the current session marker after the UI event loop returns normally.
 pub fn finish_session() -> std::io::Result<()> {
-    SESSION_ACTIVE.store(false, Ordering::SeqCst);
     let dir = crash_dir().ok_or_else(crash_directory_unavailable_error)?;
-    finish_session_in_dir(&dir)
+    let _lifecycle = SESSION_LIFECYCLE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let result = finish_session_in_dir(&dir);
+    SESSION_ACTIVE.store(false, Ordering::SeqCst);
+    result
 }
 
 fn finish_session_in_dir(dir: &Path) -> std::io::Result<()> {
@@ -1122,6 +1184,16 @@ mod tests {
     }
 
     #[test]
+    fn ignores_non_fatal_egl_native_fence_validation_error() {
+        assert!(!should_record_runtime_error(
+            "wgpu_hal::gles::egl",
+            "EGL 'eglCreateSyncKHR' code 0x3004: EGL_BAD_ATTRIBUTE error: In \
+             eglCreateSyncKHR: EGL_SYNC_NATIVE_FENCE_FD_ANDROID specified valid fd butEGL_SYNC_STATUS \
+             is also being set"
+        ));
+    }
+
+    #[test]
     fn retains_other_runtime_errors() {
         assert!(should_record_runtime_error(
             "gpui::window",
@@ -1607,6 +1679,41 @@ new frame
         assert!(!marker.exists());
         assert!(!last_operation.exists());
         assert!(!runtime_error.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminal_interrupt_clears_active_session_state() {
+        const CHILD_PROCESS: &str = "GITCOMET_SIGINT_CLEANUP_TEST_CHILD";
+
+        if std::env::var_os(CHILD_PROCESS).is_some() {
+            install_terminal_interrupt_handler().expect("install SIGINT handler");
+            begin_session().expect("begin child session");
+            let dir = crash_dir().expect("child crash directory");
+            std::fs::write(last_operation_path(&dir), "copy_source=test\n")
+                .expect("write child operation diagnostics");
+            std::fs::write(runtime_error_path(&dir), "message=test runtime error\n")
+                .expect("write child runtime diagnostics");
+            signal_hook::low_level::raise(signal_hook::consts::signal::SIGINT)
+                .expect("raise SIGINT");
+            loop {
+                std::thread::park();
+            }
+        }
+
+        let state_root = tempdir().expect("temporary state root");
+        let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
+            .arg("terminal_interrupt_clears_active_session_state")
+            .env(CHILD_PROCESS, "1")
+            .env("XDG_STATE_HOME", state_root.path())
+            .status()
+            .expect("run SIGINT cleanup child");
+
+        assert_eq!(status.code(), Some(130));
+        let dir = state_root.path().join("gitcomet").join("crashes");
+        assert!(!session_marker_path(&dir).exists());
+        assert!(!last_operation_path(&dir).exists());
+        assert!(!runtime_error_path(&dir).exists());
     }
 
     #[test]

--- a/crates/gitcomet/src/crashlog.rs
+++ b/crates/gitcomet/src/crashlog.rs
@@ -15,9 +15,9 @@ const CRASH_ISSUE_URL: &str = concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new
 const CRASH_ISSUE_TEMPLATE: &str = "crash_report.md";
 const PENDING_REPORT_FILE: &str = "pending-report-path.txt";
 const STARTUP_REPORT_FILE: &str = "pending-startup-report.log";
-const SESSION_MARKER_FILE: &str = "session-in-progress.log";
-const LAST_OPERATION_FILE: &str = "last-operation.log";
-const RUNTIME_ERROR_FILE: &str = "last-runtime-error.log";
+const SESSION_MARKER_FILE_PREFIX: &str = "session-in-progress";
+const LAST_OPERATION_FILE_PREFIX: &str = "last-operation";
+const RUNTIME_ERROR_FILE_PREFIX: &str = "last-runtime-error";
 const MAX_TITLE_CHARS: usize = 96;
 const MAX_BACKTRACE_CHARS: usize = 2_400;
 #[cfg(windows)]
@@ -328,10 +328,18 @@ fn record_session_failure_in_dir_with_diagnostics(
 
 pub fn take_startup_report() -> Option<StartupCrashReport> {
     let dir = crash_dir()?;
-    take_startup_report_from_crash_dir(&dir)
+    take_startup_report_from_crash_dir_with_process_check(&dir, process_is_running)
 }
 
+#[cfg(test)]
 fn take_startup_report_from_crash_dir(dir: &Path) -> Option<StartupCrashReport> {
+    take_startup_report_from_crash_dir_with_process_check(dir, |_| false)
+}
+
+fn take_startup_report_from_crash_dir_with_process_check(
+    dir: &Path,
+    process_is_running: impl FnMut(u32) -> bool,
+) -> Option<StartupCrashReport> {
     let report_path = startup_report_path(dir);
     let mut report_log = match std::fs::read_to_string(&report_path) {
         Ok(report_log) => report_log,
@@ -344,17 +352,7 @@ fn take_startup_report_from_crash_dir(dir: &Path) -> Option<StartupCrashReport> 
             return None;
         }
     };
-    let session_log = read_abnormal_exit_log(
-        &session_marker_path(dir),
-        &last_operation_path(dir),
-        &runtime_error_path(dir),
-    )
-    .map(|contents| AbnormalExitLog {
-        marker_path: session_marker_path(dir),
-        last_operation_path: last_operation_path(dir),
-        runtime_error_path: runtime_error_path(dir),
-        contents,
-    });
+    let session_logs = stale_abnormal_exit_logs(dir, process_is_running);
     let pending_path = pending_report_path(dir);
     let (panic_log, pending_panic_read_failed) = match read_pending_panic_log(&pending_path) {
         Ok(panic_log) => (panic_log, false),
@@ -370,12 +368,12 @@ fn take_startup_report_from_crash_dir(dir: &Path) -> Option<StartupCrashReport> 
         let _ = std::fs::remove_file(&pending_path);
     }
 
-    if session_log.is_none() && panic_log.is_none() {
+    if session_logs.is_empty() && panic_log.is_none() {
         return (!report_log.trim().is_empty())
             .then(|| build_startup_report(report_path, &report_log));
     }
 
-    if let Some(session_log) = &session_log {
+    for session_log in &session_logs {
         append_report_log(&mut report_log, &session_log.contents);
     }
     // Preserve the existing panic-over-session priority when both reports are
@@ -391,7 +389,7 @@ fn take_startup_report_from_crash_dir(dir: &Path) -> Option<StartupCrashReport> 
             return None;
         }
     };
-    if let Some(session_log) = &session_log {
+    for session_log in &session_logs {
         if let Err(err) = remove_file_if_exists(&session_log.marker_path) {
             eprintln!(
                 "Failed to clear recovered GitComet session marker {}: {err}",
@@ -422,6 +420,59 @@ fn take_startup_report_from_crash_dir(dir: &Path) -> Option<StartupCrashReport> 
         }
     }
     Some(build_startup_report(report_path, &report_log))
+}
+
+fn stale_abnormal_exit_logs(
+    dir: &Path,
+    mut process_is_running: impl FnMut(u32) -> bool,
+) -> Vec<AbnormalExitLog> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(err) => {
+            eprintln!(
+                "Failed to enumerate GitComet session markers in {}: {err}",
+                dir.display()
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut markers = entries
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            session_marker_pid(&path).map(|pid| (pid, path))
+        })
+        .collect::<Vec<_>>();
+    markers.sort_unstable_by_key(|(pid, _)| *pid);
+
+    markers
+        .into_iter()
+        .filter(|(pid, _)| !process_is_running(*pid))
+        .filter_map(|(pid, marker_path)| {
+            let last_operation_path = last_operation_path_for_pid(dir, pid);
+            let runtime_error_path = runtime_error_path_for_pid(dir, pid);
+            read_abnormal_exit_log(&marker_path, &last_operation_path, &runtime_error_path).map(
+                |contents| AbnormalExitLog {
+                    marker_path,
+                    last_operation_path,
+                    runtime_error_path,
+                    contents,
+                },
+            )
+        })
+        .collect()
+}
+
+fn process_is_running(pid: u32) -> bool {
+    let pid = sysinfo::Pid::from_u32(pid);
+    let mut system = sysinfo::System::new();
+    system.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[pid]),
+        true,
+        sysinfo::ProcessRefreshKind::nothing(),
+    );
+    system.process(pid).is_some()
 }
 
 fn read_abnormal_exit_log(
@@ -675,15 +726,41 @@ fn startup_report_path(dir: &Path) -> PathBuf {
 }
 
 fn session_marker_path(dir: &Path) -> PathBuf {
-    dir.join(SESSION_MARKER_FILE)
+    session_marker_path_for_pid(dir, std::process::id())
 }
 
 fn last_operation_path(dir: &Path) -> PathBuf {
-    dir.join(LAST_OPERATION_FILE)
+    last_operation_path_for_pid(dir, std::process::id())
 }
 
 fn runtime_error_path(dir: &Path) -> PathBuf {
-    dir.join(RUNTIME_ERROR_FILE)
+    runtime_error_path_for_pid(dir, std::process::id())
+}
+
+fn session_marker_path_for_pid(dir: &Path, pid: u32) -> PathBuf {
+    process_diagnostic_path(dir, SESSION_MARKER_FILE_PREFIX, pid)
+}
+
+fn last_operation_path_for_pid(dir: &Path, pid: u32) -> PathBuf {
+    process_diagnostic_path(dir, LAST_OPERATION_FILE_PREFIX, pid)
+}
+
+fn runtime_error_path_for_pid(dir: &Path, pid: u32) -> PathBuf {
+    process_diagnostic_path(dir, RUNTIME_ERROR_FILE_PREFIX, pid)
+}
+
+fn process_diagnostic_path(dir: &Path, prefix: &str, pid: u32) -> PathBuf {
+    dir.join(format!("{prefix}-{pid}.log"))
+}
+
+fn session_marker_pid(path: &Path) -> Option<u32> {
+    let filename = path.file_name()?.to_str()?;
+    filename
+        .strip_prefix(SESSION_MARKER_FILE_PREFIX)?
+        .strip_prefix('-')?
+        .strip_suffix(".log")?
+        .parse()
+        .ok()
 }
 
 fn env_value(name: &str) -> String {
@@ -1647,7 +1724,7 @@ new frame
     }
 
     #[test]
-    fn startup_recovery_consumes_the_previous_session_marker() {
+    fn startup_recovery_consumes_a_stale_session_marker() {
         let dir = tempdir().expect("temp dir");
         let marker = session_marker_path(dir.path());
         std::fs::write(&marker, "message=GitComet did not exit cleanly\n")
@@ -1658,7 +1735,62 @@ new frame
         assert!(report.summary.contains("did not exit cleanly"));
         assert!(
             !marker.exists(),
-            "recovery should not use PID liveness checks"
+            "stale recovery state should be removed after it is snapshotted"
+        );
+    }
+
+    #[test]
+    fn startup_recovery_ignores_live_process_markers() {
+        let dir = tempdir().expect("temp dir");
+        let live_pid = 41;
+        let stale_pid = 42;
+        let live_marker = session_marker_path_for_pid(dir.path(), live_pid);
+        let live_operation = last_operation_path_for_pid(dir.path(), live_pid);
+        let live_runtime_error = runtime_error_path_for_pid(dir.path(), live_pid);
+        let stale_marker = session_marker_path_for_pid(dir.path(), stale_pid);
+        let stale_operation = last_operation_path_for_pid(dir.path(), stale_pid);
+
+        std::fs::write(&live_marker, "message=live GitComet session\n").expect("write live marker");
+        std::fs::write(&live_operation, "copy_source=live-instance\n")
+            .expect("write live operation diagnostics");
+        std::fs::write(&live_runtime_error, "message=live runtime error\n")
+            .expect("write live runtime diagnostics");
+        std::fs::write(&stale_marker, "message=stale GitComet session\n")
+            .expect("write stale marker");
+        std::fs::write(&stale_operation, "copy_source=stale-instance\n")
+            .expect("write stale operation diagnostics");
+
+        let report = take_startup_report_from_crash_dir_with_process_check(dir.path(), |pid| {
+            pid == live_pid
+        })
+        .expect("the stale marker should produce a report");
+
+        let persisted =
+            std::fs::read_to_string(report.crash_log_path).expect("read startup report");
+        assert!(persisted.contains("stale GitComet session"));
+        assert!(persisted.contains("copy_source=stale-instance"));
+        assert!(!persisted.contains("live GitComet session"));
+        assert!(live_marker.exists());
+        assert!(live_operation.exists());
+        assert!(live_runtime_error.exists());
+        assert!(!stale_marker.exists());
+        assert!(!stale_operation.exists());
+    }
+
+    #[test]
+    fn session_diagnostic_paths_include_the_owning_pid() {
+        let dir = Path::new("/tmp/gitcomet-crash-path-test");
+        assert_eq!(
+            session_marker_path_for_pid(dir, 123),
+            dir.join("session-in-progress-123.log")
+        );
+        assert_eq!(
+            last_operation_path_for_pid(dir, 123),
+            dir.join("last-operation-123.log")
+        );
+        assert_eq!(
+            runtime_error_path_for_pid(dir, 123),
+            dir.join("last-runtime-error-123.log")
         );
     }
 
@@ -1702,18 +1834,21 @@ new frame
         }
 
         let state_root = tempdir().expect("temporary state root");
-        let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
-            .arg("terminal_interrupt_clears_active_session_state")
-            .env(CHILD_PROCESS, "1")
-            .env("XDG_STATE_HOME", state_root.path())
-            .status()
-            .expect("run SIGINT cleanup child");
+        let mut child =
+            std::process::Command::new(std::env::current_exe().expect("test executable"))
+                .arg("terminal_interrupt_clears_active_session_state")
+                .env(CHILD_PROCESS, "1")
+                .env("XDG_STATE_HOME", state_root.path())
+                .spawn()
+                .expect("run SIGINT cleanup child");
+        let child_pid = child.id();
+        let status = child.wait().expect("wait for SIGINT cleanup child");
 
         assert_eq!(status.code(), Some(130));
         let dir = state_root.path().join("gitcomet").join("crashes");
-        assert!(!session_marker_path(&dir).exists());
-        assert!(!last_operation_path(&dir).exists());
-        assert!(!runtime_error_path(&dir).exists());
+        assert!(!session_marker_path_for_pid(&dir, child_pid).exists());
+        assert!(!last_operation_path_for_pid(&dir, child_pid).exists());
+        assert!(!runtime_error_path_for_pid(&dir, child_pid).exists());
     }
 
     #[test]

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -23,7 +23,7 @@ These shortcuts apply in the normal GitComet window.
 | Open a new window | `Cmd-N`, `Cmd-Shift-N` | `Ctrl-N`, `Ctrl-Shift-N` | |
 | Open Settings | `Cmd-,` | `Ctrl-,` | |
 | Open a repository | `Cmd-O` | `Ctrl-O` | |
-| Open recent repositories | `Cmd-Shift-O`, `Option-Cmd-O` | `Ctrl-Shift-O` | |
+| Toggle open and recently closed repositories | `Ctrl-Shift-A`, `Cmd-Shift-O`, `Option-Cmd-O` | `Ctrl-Shift-A`, `Ctrl-Shift-O` | In an embedded terminal on Windows/Linux, `Ctrl-Shift-A` keeps its terminal “Select All” behavior. |
 | Open active repository in external code editor | `Cmd-Shift-E` | `Ctrl-Shift-E` | Only active when an external code editor is configured. |
 | Close the active repository tab, or close the window if no repo tab can close | `Cmd-W` | `Ctrl-W` | |
 | Close the active window | `Cmd-Shift-W` | `Ctrl-Shift-W` | |


### PR DESCRIPTION
Repository tabs now looks following:

<img width="1799" height="507" alt="image" src="https://github.com/user-attachments/assets/763674ef-1c0a-4f4c-b716-81e83cd9fa96" />


- Added selected sort text to recent repositories picker. 
- Removed Application and Patches header titles from application menu
- Added Open Repository Location to repository tab right menu
- Style changes
- Added CTRL SHIFT A shortcut to toggle recent repositories picker menu
