### PR TITLE
fix the issue where annotation panel refresh changes on window move or resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,9 +622,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bindgen"
@@ -4159,9 +4159,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -5834,9 +5834,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7394,7 +7394,7 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "data-url",
  "fontdb 0.24.0",
  "harfrust 0.12.0",

--- a/crates/gitcomet-state/src/model.rs
+++ b/crates/gitcomet-state/src/model.rs
@@ -671,6 +671,9 @@ pub struct HistoryState {
     pub blame_path: Option<PathBuf>,
     pub blame_source: Option<BlameSource>,
     pub blame: Loadable<Shared<Vec<BlameLine>>>,
+    /// Annotations to keep painting while blame reloads for the same target, so
+    /// the annotation column does not blank out on every refresh.
+    pub retained_blame_while_loading: Option<Shared<Vec<BlameLine>>>,
     pub selected_commit: Option<CommitId>,
     pub selected_commit_rev: u64,
     pub commit_details: Loadable<Shared<CommitDetails>>,
@@ -698,6 +701,7 @@ impl Default for HistoryState {
             blame_path: None,
             blame_source: None,
             blame: Loadable::NotLoaded,
+            retained_blame_while_loading: None,
             selected_commit: None,
             selected_commit_rev: 0,
             commit_details: Loadable::NotLoaded,
@@ -1392,6 +1396,24 @@ impl RepoState {
         if let Loadable::Ready(page) = &self.log {
             self.history_state.retained_log_while_loading = Some(Arc::clone(page));
         }
+    }
+
+    /// Hold on to the currently loaded annotations so the blame column keeps
+    /// painting them while the same target reloads, instead of blanking out.
+    /// Only valid while `blame_path`/`blame_source` still describe them —
+    /// callers that re-target blame must call [`Self::clear_retained_blame`].
+    pub(crate) fn retain_blame_while_loading(&mut self) {
+        if self.history_state.retained_blame_while_loading.is_some() {
+            return;
+        }
+
+        if let Loadable::Ready(lines) = &self.history_state.blame {
+            self.history_state.retained_blame_while_loading = Some(Arc::clone(lines));
+        }
+    }
+
+    pub(crate) fn clear_retained_blame(&mut self) {
+        self.history_state.retained_blame_while_loading = None;
     }
 
     pub(crate) fn set_log_loading_more(&mut self, v: bool) {

--- a/crates/gitcomet-state/src/store/reducer/actions_emit_effects.rs
+++ b/crates/gitcomet-state/src/store/reducer/actions_emit_effects.rs
@@ -759,15 +759,21 @@ pub(super) fn drop_stash(repo_id: RepoId, index: usize) -> Vec<Effect> {
     vec![Effect::DropStash { repo_id, index }]
 }
 
-/// Drop any loaded blame after a working-tree mutation (stage/unstage/apply
-/// patch/commit). The blame annotation column is derived from the same content
-/// the diff shows, which is being reloaded; leaving blame `Ready` would make
-/// `request_blame_for_current_target` treat the target as already attempted and
-/// keep painting stale attribution and staged/unstaged labels. `blame_path` and
-/// `blame_source` are intentionally preserved so the view reloads the same
+/// Drop any loaded blame once the content it describes is known to be stale —
+/// after a working-tree mutation (stage/unstage/apply patch/commit), after a
+/// reload whose result actually differed (`diff_loaded`/`diff_file_loaded`), or
+/// after a git-state event that may have moved HEAD. The blame annotation column
+/// is derived from the same content the diff shows; leaving blame `Ready` would
+/// make `request_blame_for_current_target` treat the target as already attempted
+/// and keep painting stale attribution and staged/unstaged labels. `blame_path`
+/// and `blame_source` are intentionally preserved so the view reloads the same
 /// target's blame against the new content.
 pub(super) fn invalidate_loaded_blame(repo_state: &mut RepoState) {
     if !matches!(repo_state.history_state.blame, Loadable::NotLoaded) {
+        // Keep the outgoing annotations available to the view so the column
+        // stays painted across the reload; the target is unchanged, so they
+        // still describe the right file.
+        repo_state.retain_blame_while_loading();
         repo_state.history_state.blame = Loadable::NotLoaded;
     }
 }

--- a/crates/gitcomet-state/src/store/reducer/diff_selection.rs
+++ b/crates/gitcomet-state/src/store/reducer/diff_selection.rs
@@ -1,3 +1,4 @@
+use super::actions_emit_effects::invalidate_loaded_blame;
 use super::util::{
     SelectedConflictTarget, SelectedDiffLoadPlan, apply_selected_diff_load_plan_state,
     diff_target_preview_flags, selected_conflict_target, selected_diff_load_plan,
@@ -590,15 +591,28 @@ pub(super) fn diff_loaded(
         if !current_plan.load_patch_diff {
             return Vec::new();
         }
-        repo_state.diff_state.diff_rev = repo_state.diff_state.diff_rev.wrapping_add(1);
-        repo_state.diff_state.diff = match result {
-            Ok(v) => Loadable::Ready(Arc::new(v)),
+        match result {
+            // A refresh that found no change must not churn the UI: keep the
+            // existing `Arc` so pointer-identity fingerprints stay put, leave
+            // the revs alone, and leave blame painted. `Loading`/`Error`/
+            // `NotLoaded` → `Ready` always falls through to the bump below, so
+            // a freshly selected diff is unaffected.
+            Ok(v) if matches!(&repo_state.diff_state.diff, Loadable::Ready(cur) if **cur == v) => {}
+            Ok(v) => {
+                repo_state.diff_state.diff_rev = repo_state.diff_state.diff_rev.wrapping_add(1);
+                repo_state.diff_state.diff = Loadable::Ready(Arc::new(v));
+                repo_state.bump_diff_state_rev();
+                // The annotation column is derived from the content the diff
+                // shows, so blame is stale exactly when that content changed.
+                invalidate_loaded_blame(repo_state);
+            }
             Err(e) => {
                 super::util::push_diagnostic(repo_state, DiagnosticKind::Error, e.to_string());
-                Loadable::Error(e.to_string())
+                repo_state.diff_state.diff_rev = repo_state.diff_state.diff_rev.wrapping_add(1);
+                repo_state.diff_state.diff = Loadable::Error(e.to_string());
+                repo_state.bump_diff_state_rev();
             }
-        };
-        repo_state.bump_diff_state_rev();
+        }
     }
     Vec::new()
 }
@@ -619,15 +633,29 @@ pub(super) fn diff_file_loaded(
         if !current_plan.load_file_text {
             return Vec::new();
         }
-        repo_state.diff_state.diff_file_rev = repo_state.diff_state.diff_file_rev.wrapping_add(1);
-        repo_state.diff_state.diff_file = match result {
-            Ok(v) => Loadable::Ready(v.map(Arc::new)),
+        // Same content-driven guard as `diff_loaded`. Required, not merely
+        // symmetric: in content-preview mode `load_patch_diff` is false and
+        // `diff_loaded` returns early above, so `diff_file` is the only signal
+        // that the shown content changed.
+        match result {
+            Ok(v)
+                if matches!(&repo_state.diff_state.diff_file, Loadable::Ready(cur)
+                    if cur.as_deref() == v.as_ref()) => {}
+            Ok(v) => {
+                repo_state.diff_state.diff_file_rev =
+                    repo_state.diff_state.diff_file_rev.wrapping_add(1);
+                repo_state.diff_state.diff_file = Loadable::Ready(v.map(Arc::new));
+                repo_state.bump_diff_state_rev();
+                invalidate_loaded_blame(repo_state);
+            }
             Err(e) => {
                 super::util::push_diagnostic(repo_state, DiagnosticKind::Error, e.to_string());
-                Loadable::Error(e.to_string())
+                repo_state.diff_state.diff_file_rev =
+                    repo_state.diff_state.diff_file_rev.wrapping_add(1);
+                repo_state.diff_state.diff_file = Loadable::Error(e.to_string());
+                repo_state.bump_diff_state_rev();
             }
-        };
-        repo_state.bump_diff_state_rev();
+        }
     }
     Vec::new()
 }

--- a/crates/gitcomet-state/src/store/reducer/effects.rs
+++ b/crates/gitcomet-state/src/store/reducer/effects.rs
@@ -50,8 +50,15 @@ pub(super) fn blame_loaded(
         && repo_state.history_state.blame_path.as_ref() == Some(&path)
         && repo_state.history_state.blame_source.as_ref() == Some(&source)
     {
+        let retained = repo_state.history_state.retained_blame_while_loading.take();
         repo_state.history_state.blame = match result {
-            Ok(v) => Loadable::Ready(Arc::new(v)),
+            // Reuse the retained allocation when the reload produced identical
+            // annotations, so the view's `Arc`-identity fingerprints and the
+            // memoized blame time range stay valid and nothing repaints.
+            Ok(v) => Loadable::Ready(match retained {
+                Some(prev) if *prev == v => prev,
+                _ => Arc::new(v),
+            }),
             Err(e) => {
                 push_diagnostic(repo_state, DiagnosticKind::Error, e.to_string());
                 Loadable::Error(e.to_string())
@@ -729,6 +736,26 @@ pub(super) fn load_blame(
     let Some(repo_state) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
         return Vec::new();
     };
+    // The view dispatches this from `MainPaneView::render` against an
+    // asynchronously pushed `AppState` snapshot, and `AppStore::dispatch` is a
+    // channel send, so several frames can ask for the same blame before the
+    // `Loading` snapshot reaches the view. Without this guard each of those
+    // frames forks another `git blame --line-porcelain` for the same file.
+    // `blame_path` + `blame_source` identify the request exactly, which a
+    // repo-wide `RepoLoadsInFlight` bit could not.
+    let same_target = repo_state.history_state.blame_path.as_ref() == Some(&path)
+        && repo_state.history_state.blame_source.as_ref() == Some(&source);
+    if same_target && repo_state.history_state.blame.is_loading() {
+        return Vec::new();
+    }
+    if same_target {
+        // Reloading the same file: keep the current annotations painted until
+        // the new ones land.
+        repo_state.retain_blame_while_loading();
+    } else {
+        // Re-targeting: anything held over describes a different file.
+        repo_state.clear_retained_blame();
+    }
     repo_state.history_state.blame_path = Some(path.clone());
     repo_state.history_state.blame_source = Some(source.clone());
     repo_state.history_state.blame = Loadable::Loading;
@@ -3616,6 +3643,173 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, Effect::LoadSelectedDiff { .. }))
         );
+    }
+
+    fn blame_line(line: &str) -> gitcomet_core::services::BlameLine {
+        gitcomet_core::services::BlameLine {
+            commit_id: Arc::from("1111111111111111111111111111111111111111"),
+            author: Arc::from("Ada"),
+            author_time_unix: Some(1_700_000_000),
+            summary: Arc::from("initial"),
+            body: None,
+            line: line.to_string(),
+            prior_exists: true,
+            source_path: None,
+            prior_commit: None,
+        }
+    }
+
+    #[test]
+    fn load_blame_dedupes_same_target_while_loading() {
+        // `MainPaneView::render` dispatches from an asynchronously pushed state
+        // snapshot, so a render burst (e.g. during a window resize) can ask for
+        // the same blame many times before the `Loading` snapshot arrives. Each
+        // duplicate would fork another `git blame` subprocess.
+        let repo_id = RepoId(1);
+        let mut state = new_state_with_repo(repo_id);
+        let path = PathBuf::from("src/lib.rs");
+        let source = gitcomet_core::domain::BlameSource::WorkingTree(DiffArea::Unstaged);
+
+        let effects = load_blame(&mut state, repo_id, path.clone(), source.clone());
+        assert_eq!(effects.len(), 1);
+        assert!(load_blame(&mut state, repo_id, path.clone(), source.clone()).is_empty());
+        assert!(load_blame(&mut state, repo_id, path, source).is_empty());
+    }
+
+    #[test]
+    fn load_blame_reloads_when_target_changes_while_loading() {
+        let repo_id = RepoId(1);
+        let mut state = new_state_with_repo(repo_id);
+        let source = gitcomet_core::domain::BlameSource::WorkingTree(DiffArea::Unstaged);
+
+        load_blame(
+            &mut state,
+            repo_id,
+            PathBuf::from("src/lib.rs"),
+            source.clone(),
+        );
+        let other = PathBuf::from("src/main.rs");
+        let effects = load_blame(&mut state, repo_id, other.clone(), source);
+        assert_eq!(effects.len(), 1);
+        assert_eq!(
+            repo_mut(&mut state, repo_id)
+                .history_state
+                .blame_path
+                .as_ref(),
+            Some(&other)
+        );
+    }
+
+    #[test]
+    fn load_blame_retains_ready_annotations_for_the_same_target() {
+        let repo_id = RepoId(1);
+        let mut state = new_state_with_repo(repo_id);
+        let path = PathBuf::from("src/lib.rs");
+        let source = gitcomet_core::domain::BlameSource::WorkingTree(DiffArea::Unstaged);
+        let lines = Arc::new(vec![blame_line("let x = 1;")]);
+        {
+            let repo = repo_mut(&mut state, repo_id);
+            repo.history_state.blame_path = Some(path.clone());
+            repo.history_state.blame_source = Some(source.clone());
+            repo.history_state.blame = Loadable::Ready(Arc::clone(&lines));
+        }
+
+        load_blame(&mut state, repo_id, path, source);
+
+        let repo = repo_mut(&mut state, repo_id);
+        assert!(repo.history_state.blame.is_loading());
+        assert!(
+            repo.history_state
+                .retained_blame_while_loading
+                .as_ref()
+                .is_some_and(|held| Arc::ptr_eq(held, &lines)),
+            "the annotation column must keep painting while the same target reloads"
+        );
+    }
+
+    #[test]
+    fn load_blame_drops_retained_annotations_when_retargeting() {
+        let repo_id = RepoId(1);
+        let mut state = new_state_with_repo(repo_id);
+        let source = gitcomet_core::domain::BlameSource::WorkingTree(DiffArea::Unstaged);
+        {
+            let repo = repo_mut(&mut state, repo_id);
+            repo.history_state.blame_path = Some(PathBuf::from("src/lib.rs"));
+            repo.history_state.blame_source = Some(source.clone());
+            repo.history_state.blame = Loadable::Ready(Arc::new(vec![blame_line("let x = 1;")]));
+        }
+
+        load_blame(&mut state, repo_id, PathBuf::from("src/main.rs"), source);
+
+        assert!(
+            repo_mut(&mut state, repo_id)
+                .history_state
+                .retained_blame_while_loading
+                .is_none(),
+            "annotations for a different file must never be painted"
+        );
+    }
+
+    #[test]
+    fn blame_loaded_reuses_the_retained_allocation_when_unchanged() {
+        // An identical reload must not produce a new `Arc`: the view keys its
+        // notify fingerprint and its memoized blame time range on Arc identity.
+        let repo_id = RepoId(1);
+        let mut state = new_state_with_repo(repo_id);
+        let path = PathBuf::from("src/lib.rs");
+        let source = gitcomet_core::domain::BlameSource::WorkingTree(DiffArea::Unstaged);
+        let lines = Arc::new(vec![blame_line("let x = 1;")]);
+        {
+            let repo = repo_mut(&mut state, repo_id);
+            repo.history_state.blame_path = Some(path.clone());
+            repo.history_state.blame_source = Some(source.clone());
+            repo.history_state.blame = Loadable::Ready(Arc::clone(&lines));
+        }
+        load_blame(&mut state, repo_id, path.clone(), source.clone());
+
+        blame_loaded(
+            &mut state,
+            repo_id,
+            path,
+            source,
+            Ok(vec![blame_line("let x = 1;")]),
+        );
+
+        let repo = repo_mut(&mut state, repo_id);
+        assert!(
+            matches!(&repo.history_state.blame, Loadable::Ready(got) if Arc::ptr_eq(got, &lines))
+        );
+        assert!(repo.history_state.retained_blame_while_loading.is_none());
+    }
+
+    #[test]
+    fn blame_loaded_replaces_the_retained_allocation_when_changed() {
+        let repo_id = RepoId(1);
+        let mut state = new_state_with_repo(repo_id);
+        let path = PathBuf::from("src/lib.rs");
+        let source = gitcomet_core::domain::BlameSource::WorkingTree(DiffArea::Unstaged);
+        let lines = Arc::new(vec![blame_line("let x = 1;")]);
+        {
+            let repo = repo_mut(&mut state, repo_id);
+            repo.history_state.blame_path = Some(path.clone());
+            repo.history_state.blame_source = Some(source.clone());
+            repo.history_state.blame = Loadable::Ready(Arc::clone(&lines));
+        }
+        load_blame(&mut state, repo_id, path.clone(), source.clone());
+
+        blame_loaded(
+            &mut state,
+            repo_id,
+            path,
+            source,
+            Ok(vec![blame_line("let x = 2;")]),
+        );
+
+        let repo = repo_mut(&mut state, repo_id);
+        assert!(
+            matches!(&repo.history_state.blame, Loadable::Ready(got) if !Arc::ptr_eq(got, &lines))
+        );
+        assert!(repo.history_state.retained_blame_while_loading.is_none());
     }
 
     #[test]

--- a/crates/gitcomet-state/src/store/reducer/external_and_history.rs
+++ b/crates/gitcomet-state/src/store/reducer/external_and_history.rs
@@ -84,6 +84,7 @@ pub(super) fn reload_repo(state: &mut AppState, repo_id: crate::model::RepoId) -
     repo_state.history_state.blame_path = None;
     repo_state.history_state.blame_source = None;
     repo_state.history_state.blame = Loadable::NotLoaded;
+    repo_state.clear_retained_blame();
     repo_state.set_worktrees(Loadable::NotLoaded);
     repo_state.set_submodules(Loadable::NotLoaded);
     repo_state.clear_head_dependent_cached_state();
@@ -174,12 +175,17 @@ pub(super) fn repo_externally_changed(
         && let Some(target) = repo_state.diff_state.diff_target.clone()
         && matches!(target, DiffTarget::WorkingTree { .. })
     {
-        // The working-tree content changed underneath us and the diff is being
-        // reloaded; the annotation column is derived from that same content, so
-        // drop loaded blame too. `blame_path`/`blame_source` are preserved, so
-        // `request_blame_for_current_target` reloads the same target's blame
-        // against the new content instead of painting stale attribution.
-        invalidate_loaded_blame(repo_state);
+        // A moved HEAD (external commit / checkout / rebase) can leave the patch
+        // byte-identical while every line's attribution changes ("Not Committed
+        // Yet" → a real commit), and nothing downstream can detect that, so drop
+        // blame up front for git-state events. A pure worktree/index event leaves
+        // blame painted; `diff_loaded`/`diff_file_loaded` then invalidate it only
+        // if the reloaded content actually differs, so a refresh that finds no
+        // change does not re-run `git blame`. `blame_path`/`blame_source` are
+        // preserved either way, so the view reloads the same target.
+        if change.git_state {
+            invalidate_loaded_blame(repo_state);
+        }
         if let Some(conflict_target) = selected_conflict_target(repo_state, &target) {
             match conflict_target {
                 SelectedConflictTarget::Current => {

--- a/crates/gitcomet-state/src/store/reducer/repo_management.rs
+++ b/crates/gitcomet-state/src/store/reducer/repo_management.rs
@@ -1082,6 +1082,7 @@ pub(super) fn repo_opened_ok(
             repo_state.history_state.blame_path = None;
             repo_state.history_state.blame_source = None;
             repo_state.history_state.blame = Loadable::NotLoaded;
+            repo_state.clear_retained_blame();
             repo_state.set_worktrees(Loadable::NotLoaded);
             repo_state.set_submodules(Loadable::NotLoaded);
             repo_state.set_selected_commit(None);

--- a/crates/gitcomet-state/src/store/repo_monitor.rs
+++ b/crates/gitcomet-state/src/store/repo_monitor.rs
@@ -1,8 +1,8 @@
 use crate::model::RepoId;
 use crate::msg::{Msg, RepoExternalChange, RepoWatchDegradedReason};
 use gix::index::entry::Mode as GitIndexMode;
-use notify::event::{AccessKind, AccessMode};
-use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use notify::event::{AccessKind, AccessMode, EventKindMask};
+use notify::{Config as NotifyConfig, RecommendedWatcher, RecursiveMode, Watcher};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::any::Any;
 use std::fs;
@@ -661,13 +661,16 @@ fn build_workdir_watcher(
     monitor_tx: &mpsc::Sender<MonitorMsg>,
     monitor_enabled: &Arc<AtomicBool>,
 ) -> Option<(RecommendedWatcher, WatchSetupOutcome)> {
-    let watcher = notify::recommended_watcher({
-        let monitor_tx = monitor_tx.clone();
-        let monitor_enabled = Arc::clone(monitor_enabled);
-        move |res| {
-            send_watcher_event_or_log(repo_id, &monitor_tx, res, monitor_enabled.as_ref());
-        }
-    });
+    let watcher = RecommendedWatcher::new(
+        {
+            let monitor_tx = monitor_tx.clone();
+            let monitor_enabled = Arc::clone(monitor_enabled);
+            move |res| {
+                send_watcher_event_or_log(repo_id, &monitor_tx, res, monitor_enabled.as_ref());
+            }
+        },
+        NotifyConfig::default().with_event_kinds(WATCHED_EVENT_KINDS),
+    );
 
     let mut watcher: RecommendedWatcher = match watcher {
         Ok(w) => w,
@@ -1676,10 +1679,24 @@ fn is_git_tags_path(workdir: &Path, git_dir: Option<&Path>, path: &Path) -> bool
     false
 }
 
+/// Which event kinds the kernel is asked to deliver.
+///
+/// `notify::Config::default()` is `EventKindMask::ALL`, which on Linux adds
+/// `IN_OPEN` and `IN_CLOSE_NOWRITE` to the inotify mask. `should_ignore_event_kind`
+/// discards those — but only after the kernel has queued each one and woken the
+/// monitor thread. A repo this app is actively reading (status, diffs, `git blame`)
+/// makes its own reads generate them, so they routinely account for well over 99%
+/// of all delivered events. Ask for only the kinds `classify_repo_event` can act
+/// on; `ACCESS_CLOSE` (`IN_CLOSE_WRITE`) is the one access kind that signals a
+/// completed write, and `should_ignore_event_kind` still keeps exactly that one.
+const WATCHED_EVENT_KINDS: EventKindMask = EventKindMask::CORE.union(EventKindMask::ACCESS_CLOSE);
+
 fn should_ignore_event_kind(event: &notify::Event) -> bool {
     match &event.kind {
         // Reading repo state should not cause a refresh loop; ignore access events except
-        // close-after-write which indicates a write has completed.
+        // close-after-write which indicates a write has completed. Backends that
+        // honour `WATCHED_EVENT_KINDS` no longer deliver the ignored kinds at all;
+        // this stays as the portable backstop.
         notify::EventKind::Access(AccessKind::Close(AccessMode::Write)) => false,
         notify::EventKind::Access(_) => true,
         _ => false,
@@ -2301,6 +2318,71 @@ mod tests {
         assert!(
             !saw_target,
             "modifications under the gitignored target/ must not be watched"
+        );
+    }
+
+    #[test]
+    fn watched_event_kinds_exclude_read_access_but_keep_close_write() {
+        assert!(!WATCHED_EVENT_KINDS.intersects(EventKindMask::ACCESS_OPEN));
+        assert!(!WATCHED_EVENT_KINDS.intersects(EventKindMask::ACCESS_CLOSE_NOWRITE));
+        // `should_ignore_event_kind` keeps close-after-write, so it must still be requested.
+        assert!(WATCHED_EVENT_KINDS.contains(EventKindMask::ACCESS_CLOSE));
+        // Everything `classify_repo_event` acts on.
+        assert!(WATCHED_EVENT_KINDS.contains(EventKindMask::CORE));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn watcher_does_not_deliver_events_for_reads_of_watched_files() {
+        // Regression: the default notify config asks inotify for IN_OPEN and
+        // IN_CLOSE_NOWRITE, so every file this app reads while producing a status,
+        // diff or blame bounced straight back as an event the monitor then threw
+        // away. On an active repo that was >99% of all delivered events — tens of
+        // thousands per minute of pure thread-wakeup and allocation churn.
+        let dir = unique_temp_dir("gitcomet-monitor-read-noise");
+        let workdir = dir.path().join("repo");
+        fs::create_dir_all(&workdir).expect("create workdir");
+        let file = workdir.join("tracked.txt");
+        fs::write(&file, b"before").expect("seed file");
+
+        let (tx, rx) = mpsc::channel::<notify::Event>();
+        let mut watcher = RecommendedWatcher::new(
+            move |res: notify::Result<notify::Event>| {
+                if let Ok(event) = res {
+                    let _ = tx.send(event);
+                }
+            },
+            NotifyConfig::default().with_event_kinds(WATCHED_EVENT_KINDS),
+        )
+        .expect("create watcher");
+        watcher
+            .watch(&workdir, RecursiveMode::NonRecursive)
+            .expect("watch workdir");
+
+        for _ in 0..50 {
+            assert_eq!(fs::read(&file).expect("read file"), b"before");
+        }
+        std::thread::sleep(Duration::from_secs(1));
+        let read_events: Vec<_> = rx.try_iter().collect();
+        assert!(
+            read_events.is_empty(),
+            "reading watched files must not deliver any event, got {read_events:?}"
+        );
+
+        // The watch is still live: a real write must still arrive.
+        fs::write(&file, b"after").expect("modify file");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut saw_write = false;
+        while !saw_write && Instant::now() < deadline {
+            match rx.recv_timeout(Duration::from_millis(200)) {
+                Ok(event) => saw_write = event.paths.iter().any(|p| p == &file),
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+        assert!(
+            saw_write,
+            "a write to a watched file must still be delivered"
         );
     }
 

--- a/crates/gitcomet-state/src/store/tests/diff_selection.rs
+++ b/crates/gitcomet-state/src/store/tests/diff_selection.rs
@@ -1755,6 +1755,255 @@ fn diff_loaded_ok_sets_ready_when_target_matches() {
     assert!(repo_state.diagnostics.is_empty());
 }
 
+/// A repo with a working-tree diff and blame both loaded, ready to be fed a
+/// `DiffLoaded` / `DiffFileLoaded` result.
+fn state_with_loaded_diff_and_blame(
+    diff: gitcomet_core::domain::Diff,
+) -> (
+    AppState,
+    DiffTarget,
+    Arc<Vec<gitcomet_core::services::BlameLine>>,
+) {
+    let mut state = AppState::default();
+    let mut repo_state = RepoState::new_opening(
+        RepoId(1),
+        RepoSpec {
+            workdir: PathBuf::from("/tmp/repo"),
+        },
+    );
+    let target = diff.target.clone();
+    repo_state.diff_state.diff_target = Some(target.clone());
+    repo_state.diff_state.diff = Loadable::Ready(Arc::new(diff));
+    let blame = Arc::new(vec![gitcomet_core::services::BlameLine {
+        commit_id: Arc::from("1111111111111111111111111111111111111111"),
+        author: Arc::from("Ada"),
+        author_time_unix: Some(1_700_000_000),
+        summary: Arc::from("initial"),
+        body: None,
+        line: "let x = 1;".to_string(),
+        prior_exists: true,
+        source_path: None,
+        prior_commit: None,
+    }]);
+    repo_state.history_state.blame_path = Some(PathBuf::from("src/lib.rs"));
+    repo_state.history_state.blame_source = Some(gitcomet_core::domain::BlameSource::WorkingTree(
+        gitcomet_core::domain::DiffArea::Unstaged,
+    ));
+    repo_state.history_state.blame = Loadable::Ready(Arc::clone(&blame));
+    state.repos.push(repo_state);
+    state.active_repo = Some(RepoId(1));
+    (state, target, blame)
+}
+
+fn unstaged_diff(line: &str) -> gitcomet_core::domain::Diff {
+    gitcomet_core::domain::Diff {
+        target: DiffTarget::WorkingTree {
+            path: PathBuf::from("src/lib.rs"),
+            area: gitcomet_core::domain::DiffArea::Unstaged,
+        },
+        lines: vec![gitcomet_core::domain::DiffLine {
+            kind: gitcomet_core::domain::DiffLineKind::Context,
+            text: line.into(),
+        }],
+    }
+}
+
+#[test]
+fn diff_loaded_identical_content_skips_rev_bumps_and_keeps_blame() {
+    // A refresh that found no change must not churn the UI: window focus (and,
+    // before the fix, every window drag) reloads the working-tree diff, and
+    // bumping the revs would blank and re-run the expensive blame.
+    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let id_alloc = AtomicU64::new(1);
+    let (mut state, target, blame) = state_with_loaded_diff_and_blame(unstaged_diff("let x = 1;"));
+    let diff_rev = state.repos[0].diff_state.diff_rev;
+    let diff_state_rev = state.repos[0].diff_state.diff_state_rev;
+    let previous = match &state.repos[0].diff_state.diff {
+        Loadable::Ready(diff) => Arc::clone(diff),
+        other => panic!("expected a loaded diff, got {other:?}"),
+    };
+
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::DiffLoaded {
+            repo_id: RepoId(1),
+            target: target.clone(),
+            result: Ok(unstaged_diff("let x = 1;")),
+        }),
+    );
+
+    let repo_state = &state.repos[0];
+    assert_eq!(repo_state.diff_state.diff_rev, diff_rev);
+    assert_eq!(repo_state.diff_state.diff_state_rev, diff_state_rev);
+    assert!(
+        matches!(&repo_state.diff_state.diff, Loadable::Ready(diff) if Arc::ptr_eq(diff, &previous)),
+        "an unchanged reload must keep the existing Arc so identity fingerprints stay put"
+    );
+    assert!(
+        matches!(&repo_state.history_state.blame, Loadable::Ready(lines) if Arc::ptr_eq(lines, &blame)),
+        "blame must survive a reload that found no change"
+    );
+}
+
+#[test]
+fn diff_loaded_changed_content_bumps_revs_and_invalidates_blame() {
+    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let id_alloc = AtomicU64::new(1);
+    let (mut state, target, blame) = state_with_loaded_diff_and_blame(unstaged_diff("let x = 1;"));
+    let diff_rev = state.repos[0].diff_state.diff_rev;
+    let diff_state_rev = state.repos[0].diff_state.diff_state_rev;
+
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::DiffLoaded {
+            repo_id: RepoId(1),
+            target,
+            result: Ok(unstaged_diff("let x = 2;")),
+        }),
+    );
+
+    let repo_state = &state.repos[0];
+    assert_eq!(repo_state.diff_state.diff_rev, diff_rev.wrapping_add(1));
+    assert_eq!(
+        repo_state.diff_state.diff_state_rev,
+        diff_state_rev.wrapping_add(1)
+    );
+    assert!(
+        matches!(repo_state.history_state.blame, Loadable::NotLoaded),
+        "blame is derived from the diff content, so changed content invalidates it"
+    );
+    // The target is preserved so the view reloads the same file's blame, and the
+    // outgoing annotations stay painted meanwhile.
+    assert_eq!(
+        repo_state.history_state.blame_path.as_deref(),
+        Some(std::path::Path::new("src/lib.rs"))
+    );
+    assert!(
+        repo_state
+            .history_state
+            .retained_blame_while_loading
+            .as_ref()
+            .is_some_and(|held| Arc::ptr_eq(held, &blame))
+    );
+}
+
+#[test]
+fn diff_loaded_error_after_ready_still_bumps_revs() {
+    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let id_alloc = AtomicU64::new(1);
+    let (mut state, target, _) = state_with_loaded_diff_and_blame(unstaged_diff("let x = 1;"));
+    let diff_state_rev = state.repos[0].diff_state.diff_state_rev;
+
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::DiffLoaded {
+            repo_id: RepoId(1),
+            target,
+            result: Err(Error::new(ErrorKind::Backend("boom".to_string()))),
+        }),
+    );
+
+    let repo_state = &state.repos[0];
+    assert!(matches!(repo_state.diff_state.diff, Loadable::Error(_)));
+    assert_eq!(
+        repo_state.diff_state.diff_state_rev,
+        diff_state_rev.wrapping_add(1)
+    );
+    assert!(!repo_state.diagnostics.is_empty());
+}
+
+fn file_diff_text(line: &str) -> gitcomet_core::domain::FileDiffText {
+    gitcomet_core::domain::FileDiffText::new(
+        PathBuf::from("icon.svg"),
+        None,
+        Some(line.to_string()),
+    )
+}
+
+/// A repo showing a file-text view (`load_file_text`, not `load_patch_diff`)
+/// with blame loaded — the shape that makes `diff_file` the only content signal.
+fn state_with_loaded_file_text_and_blame(
+    text: gitcomet_core::domain::FileDiffText,
+) -> (
+    AppState,
+    DiffTarget,
+    Arc<Vec<gitcomet_core::services::BlameLine>>,
+) {
+    let target = DiffTarget::WorkingTree {
+        path: PathBuf::from("icon.svg"),
+        area: DiffArea::Unstaged,
+    };
+    let (mut state, _, blame) = state_with_loaded_diff_and_blame(gitcomet_core::domain::Diff {
+        target: target.clone(),
+        lines: vec![],
+    });
+    state.repos[0].diff_state.diff = Loadable::NotLoaded;
+    state.repos[0].diff_state.diff_file = Loadable::Ready(Some(Arc::new(text)));
+    (state, target, blame)
+}
+
+#[test]
+fn diff_file_loaded_identical_content_skips_rev_bumps_and_keeps_blame() {
+    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let id_alloc = AtomicU64::new(1);
+    let (mut state, target, blame) = state_with_loaded_file_text_and_blame(file_diff_text("a"));
+    let diff_file_rev = state.repos[0].diff_state.diff_file_rev;
+    let diff_state_rev = state.repos[0].diff_state.diff_state_rev;
+
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::DiffFileLoaded {
+            repo_id: RepoId(1),
+            target,
+            result: Ok(Some(file_diff_text("a"))),
+        }),
+    );
+
+    let repo_state = &state.repos[0];
+    assert_eq!(repo_state.diff_state.diff_file_rev, diff_file_rev);
+    assert_eq!(repo_state.diff_state.diff_state_rev, diff_state_rev);
+    assert!(
+        matches!(&repo_state.history_state.blame, Loadable::Ready(lines) if Arc::ptr_eq(lines, &blame))
+    );
+}
+
+#[test]
+fn diff_file_loaded_changed_content_bumps_revs_and_invalidates_blame() {
+    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let id_alloc = AtomicU64::new(1);
+    let (mut state, target, _) = state_with_loaded_file_text_and_blame(file_diff_text("a"));
+    let diff_file_rev = state.repos[0].diff_state.diff_file_rev;
+
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::DiffFileLoaded {
+            repo_id: RepoId(1),
+            target,
+            result: Ok(Some(file_diff_text("b"))),
+        }),
+    );
+
+    let repo_state = &state.repos[0];
+    assert_eq!(
+        repo_state.diff_state.diff_file_rev,
+        diff_file_rev.wrapping_add(1)
+    );
+    assert!(matches!(
+        repo_state.history_state.blame,
+        Loadable::NotLoaded
+    ));
+}
+
 #[test]
 fn diff_file_loaded_and_image_loaded_cover_success_and_error_paths() {
     let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();

--- a/crates/gitcomet-state/src/store/tests/external_and_history.rs
+++ b/crates/gitcomet-state/src/store/tests/external_and_history.rs
@@ -1076,14 +1076,7 @@ fn reload_repo_sets_sections_loading_and_emits_refresh_effects() {
     );
 }
 
-#[test]
-fn repo_externally_changed_invalidates_loaded_blame() {
-    // Regression: an external edit/stage reloads the working-tree diff, and the
-    // blame annotation column is derived from that same content. Leaving blame
-    // `Ready` would make `request_blame_for_current_target` treat the target as
-    // already attempted and keep painting stale attribution over the new lines.
-    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
-    let id_alloc = AtomicU64::new(1);
+fn state_with_blamed_unstaged_diff() -> (AppState, RepoId) {
     let mut state = AppState::default();
     let repo_id = RepoId(1);
     state.repos.push(RepoState::new_opening(
@@ -1115,6 +1108,18 @@ fn repo_externally_changed_invalidates_loaded_blame() {
             prior_commit: None,
         },
     ]));
+    (state, repo_id)
+}
+
+#[test]
+fn repo_externally_changed_worktree_keeps_blame_until_content_changes() {
+    // A worktree/index event reloads the diff, but the reload may well find the
+    // same bytes (a window-focus refresh, a touch, a save that changed nothing).
+    // Blame is expensive — it shells out to `git blame` — so it must survive
+    // until `diff_loaded`/`diff_file_loaded` sees the content actually differ.
+    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let id_alloc = AtomicU64::new(1);
+    let (mut state, repo_id) = state_with_blamed_unstaged_diff();
 
     let effects = reduce(
         &mut repos,
@@ -1126,17 +1131,63 @@ fn repo_externally_changed_invalidates_loaded_blame() {
         },
     );
 
-    // The working-tree diff reloads against the new content...
+    // The working-tree diff still reloads against the (possibly new) content...
     assert!(
         effects
             .iter()
             .any(|e| matches!(e, Effect::LoadDiff { repo_id: id, .. } if *id == repo_id)),
         "external worktree change must reload the diff"
     );
-    // ...and blame is dropped so it reloads too, with the target preserved.
+    // ...but the annotations stay painted until that reload proves them stale.
+    assert!(
+        matches!(state.repos[0].history_state.blame, Loadable::Ready(_)),
+        "a worktree event alone must not invalidate blame"
+    );
+}
+
+#[test]
+fn repo_externally_changed_git_state_invalidates_loaded_blame() {
+    // A moved HEAD (external commit / checkout / rebase) can leave the patch
+    // byte-identical while every line's attribution changes, and no downstream
+    // content comparison can detect that — so git-state events drop blame up
+    // front, preserving the target so it reloads for the same file.
+    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let id_alloc = AtomicU64::new(1);
+    let (mut state, repo_id) = state_with_blamed_unstaged_diff();
+    let previous = match &state.repos[0].history_state.blame {
+        Loadable::Ready(lines) => Arc::clone(lines),
+        other => panic!("expected a loaded blame, got {other:?}"),
+    };
+
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::RepoExternallyChanged {
+            repo_id,
+            change: crate::msg::RepoExternalChange::all(),
+        },
+    );
+
+    assert!(
+        effects
+            .iter()
+            .any(|e| matches!(e, Effect::LoadDiff { repo_id: id, .. } if *id == repo_id)),
+        "a git-state change must reload the diff"
+    );
     assert!(
         matches!(state.repos[0].history_state.blame, Loadable::NotLoaded),
-        "blame must be invalidated when the working-tree diff reloads externally"
+        "blame must be invalidated when refs may have moved"
+    );
+    // The outgoing annotations are held over so the column does not blank while
+    // the reload runs.
+    assert!(
+        state.repos[0]
+            .history_state
+            .retained_blame_while_loading
+            .as_ref()
+            .is_some_and(|held| Arc::ptr_eq(held, &previous)),
+        "the previous annotations must be retained while blame reloads"
     );
     assert_eq!(
         state.repos[0].history_state.blame_path.as_deref(),

--- a/crates/gitcomet-ui-gpui/assets/open_source_licenses.tsv
+++ b/crates/gitcomet-ui-gpui/assets/open_source_licenses.tsv
@@ -59,7 +59,7 @@ av1-grain	0.2.5	BSD-2-Clause
 avif-serialize	0.8.9	BSD-3-Clause
 backtrace	0.3.76	MIT OR Apache-2.0
 base64	0.22.1	MIT OR Apache-2.0
-base64	0.23.0	MIT OR Apache-2.0
+base64	0.23.1	MIT OR Apache-2.0
 bindgen	0.72.1	BSD-3-Clause
 bisync	0.3.0	MIT OR Apache-2.0
 bisync_macros	0.2.3	MIT OR Apache-2.0
@@ -352,7 +352,7 @@ jobserver	0.1.35	MIT OR Apache-2.0
 js-sys	0.3.103	MIT OR Apache-2.0
 khronos-egl	6.0.0	MIT/Apache-2.0
 khronos_api	3.1.0	Apache-2.0
-kqueue	1.2.0	MIT
+kqueue	1.2.1	MIT
 kqueue-sys	1.1.2	MIT
 kurbo	0.13.1	Apache-2.0 OR MIT
 lazy_static	1.5.0	MIT OR Apache-2.0
@@ -523,7 +523,7 @@ ref-cast	1.0.26	MIT OR Apache-2.0
 ref-cast-impl	1.0.26	MIT OR Apache-2.0
 refineable	0.1.0	Apache-2.0
 regex	1.13.1	MIT OR Apache-2.0
-regex-automata	0.4.16	MIT OR Apache-2.0
+regex-automata	0.4.18	MIT OR Apache-2.0
 regex-syntax	0.8.11	MIT OR Apache-2.0
 renderdoc-sys	1.1.0	MIT OR Apache-2.0
 resvg	0.47.0	Apache-2.0 OR MIT

--- a/crates/gitcomet-ui-gpui/src/app.rs
+++ b/crates/gitcomet-ui-gpui/src/app.rs
@@ -30,9 +30,11 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use schemars::JsonSchema;
 #[cfg(target_os = "macos")]
 use serde::Deserialize;
+use std::cell::Cell;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::time::{Duration, Instant};
 
 const WINDOW_MIN_WIDTH_PX: f32 = 820.0;
 const WINDOW_MIN_HEIGHT_PX: f32 = 560.0;
@@ -332,8 +334,38 @@ fn window_hwnd(window: &Window) -> Option<isize> {
     Some(handle.hwnd.get())
 }
 
+thread_local! {
+    /// When we last asked the compositor/window manager for an interactive move
+    /// or resize grab.
+    static LAST_WINDOW_GRAB_AT: Cell<Option<Instant>> = const { Cell::new(None) };
+}
+
+/// Record that we just requested an interactive move/resize grab.
+///
+/// The grab is executed by the compositor/WM, which takes the input focus for
+/// the duration of the drag. GPUI surfaces that as a plain window deactivate →
+/// activate pair — on Wayland via `wl_keyboard` Leave/Enter, on X11 via
+/// FocusOut/FocusIn (which are not filtered on `mode`, so NotifyGrab and
+/// NotifyUngrab arrive too) — indistinguishable from the user alt-tabbing away
+/// and back. This marker lets the activation observer ignore its own echo
+/// instead of treating it as a return to the app and refreshing the repo.
+pub(crate) fn note_window_grab_started() {
+    LAST_WINDOW_GRAB_AT.with(|cell| cell.set(Some(Instant::now())));
+}
+
+/// Whether a grab was requested no more than `max_age` ago. Always consumes the
+/// marker, so a grab the compositor silently dropped cannot arm suppression for
+/// an unrelated activation minutes later.
+pub(crate) fn take_window_grab_started_within(now: Instant, max_age: Duration) -> bool {
+    LAST_WINDOW_GRAB_AT.with(|cell| match cell.take() {
+        Some(at) => now.saturating_duration_since(at) <= max_age,
+        None => false,
+    })
+}
+
 #[cfg(target_os = "windows")]
 pub(crate) fn begin_window_move(window: &Window) {
+    note_window_grab_started();
     if let Some(hwnd) = window_hwnd(window)
         && gitcomet_win32_window_utils::begin_window_move(hwnd)
     {
@@ -345,7 +377,13 @@ pub(crate) fn begin_window_move(window: &Window) {
 
 #[cfg(not(target_os = "windows"))]
 pub(crate) fn begin_window_move(window: &Window) {
+    note_window_grab_started();
     window.start_window_move();
+}
+
+pub(crate) fn begin_window_resize(window: &Window, edge: gpui::ResizeEdge) {
+    note_window_grab_started();
+    window.start_window_resize(edge);
 }
 
 #[cfg(target_os = "windows")]

--- a/crates/gitcomet-ui-gpui/src/view/mod.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod.rs
@@ -44,6 +44,17 @@ use std::time::{Duration, Instant};
 
 const REPO_ACTIVATION_THROTTLE: Duration = Duration::from_secs(5);
 
+/// How long after requesting an interactive move/resize grab a deactivation is
+/// still attributed to that grab. Compositors hand over focus within a frame;
+/// generous enough for a loaded system, short enough that a genuine alt-tab
+/// right after a drag is not mistaken for the grab.
+const WINDOW_GRAB_DEACTIVATE_GRACE: Duration = Duration::from_millis(1_500);
+
+/// Upper bound on how long a drag may hold the grab before the re-activation is
+/// no longer treated as its echo. Only a safety valve: arming already requires a
+/// fresh grab plus a deactivation within [`WINDOW_GRAB_DEACTIVATE_GRACE`].
+const WINDOW_GRAB_REACTIVATE_GRACE: Duration = Duration::from_secs(120);
+
 actions!(
     text_input_diff_navigation,
     [
@@ -89,6 +100,17 @@ pub(crate) fn is_diff_shortcut_candidate(keystroke: &gpui::Keystroke) -> bool {
             && !mods.function
             && matches!(key, "a" | "c" | "e" | "s" | "d" | "h" | "u"))
         || (matches!(key, "a" | "b" | "c" | "d") && no_command_modifiers)
+}
+
+/// Whether this activation is the tail of a move/resize grab we started, and so
+/// must not be treated as the user returning to the app. Always consumes the
+/// marker; a drag that outlives [`WINDOW_GRAB_REACTIVATE_GRACE`] falls back to
+/// refreshing, which is the conservative direction.
+fn consume_window_grab_activation(suppressed_at: &mut Option<Instant>, now: Instant) -> bool {
+    match suppressed_at.take() {
+        Some(at) => now.saturating_duration_since(at) <= WINDOW_GRAB_REACTIVATE_GRACE,
+        None => false,
+    }
 }
 
 fn repo_activation_msg(
@@ -1505,26 +1527,37 @@ impl GitCometView {
         });
 
         let activation_subscription = cx.observe_window_activation(window, |this, window, cx| {
+            let now = Instant::now();
             if !window.is_window_active() {
                 // Capture the focused element before the platform blur() fires and clears it.
                 // This is the restore target when opening the palette via a global hotkey while
                 // this window is in the background.
                 this.pre_palette_focus = window.focused(cx);
+                // A deactivation right after we asked for a move/resize grab is
+                // the compositor taking focus for the drag, not the user leaving
+                // the app. Remember it so the matching re-activation does not
+                // refresh the repo.
+                this.window_grab_activation_suppressed_at =
+                    crate::app::take_window_grab_started_within(now, WINDOW_GRAB_DEACTIVATE_GRACE)
+                        .then_some(now);
                 return;
             }
+            let self_initiated_grab =
+                consume_window_grab_activation(&mut this.window_grab_activation_suppressed_at, now);
             let runtime = refresh_git_runtime();
             if runtime != this.state.git_runtime {
                 this.store
                     .dispatch(Msg::SetGitRuntimeState(runtime.clone()));
             }
-            if !runtime.is_available() {
+            // Suppressed activations skip `repo_activation_msg` entirely, so its
+            // throttle map is not stamped and a genuine alt-tab immediately after
+            // a drag still refreshes.
+            if !runtime.is_available() || self_initiated_grab {
                 return;
             }
-            if let Some(msg) = repo_activation_msg(
-                &this.state,
-                &mut this.last_repo_activation_dispatch_at,
-                Instant::now(),
-            ) {
+            if let Some(msg) =
+                repo_activation_msg(&this.state, &mut this.last_repo_activation_dispatch_at, now)
+            {
                 this.store.dispatch(msg);
             }
         });
@@ -1710,6 +1743,7 @@ impl GitCometView {
             ui_window_size_last_seen: size(px(0.0), px(0.0)),
             ui_settings_persist_seq: 0,
             last_repo_activation_dispatch_at: HashMap::default(),
+            window_grab_activation_suppressed_at: None,
             date_time_format,
             timezone,
             show_timezone,
@@ -1730,7 +1764,6 @@ impl GitCometView {
             diff_whitespace_mode,
             diff_view_mode,
             annotate_enabled,
-            diff_view_mode_before_annotate: None,
             diff_reveal_whitespace_chars,
             diff_word_wrap,
             diff_show_line_numbers,
@@ -2054,11 +2087,6 @@ impl GitCometView {
             return;
         }
 
-        // An explicit mode change while blame is on overrides the automatic
-        // Split → Inline switch, so don't restore the stashed mode later.
-        if self.annotate_enabled {
-            self.diff_view_mode_before_annotate = None;
-        }
         self.diff_view_mode = next;
         self.main_pane
             .update(cx, |pane, cx| pane.set_diff_view_mode(next, cx));
@@ -2075,21 +2103,12 @@ impl GitCometView {
         }
 
         self.annotate_enabled = next;
+        // Blame is an annotation column, not a view mode: it renders in the left
+        // column in Split (see `rows::diff`, `annotation_active() && is_left`)
+        // just as it does in Inline, and the wrap widths already account for it
+        // in both. Toggling it must leave the selected mode alone.
         self.main_pane
             .update(cx, |pane, cx| pane.set_annotate_enabled(next, cx));
-        // The blame gutter and split panes don't fit side by side at typical
-        // widths — run blame in the inline view and restore the previous mode
-        // when it's toggled off (unless the user changed modes meanwhile).
-        if next {
-            if self.diff_view_mode == DiffViewMode::Split {
-                self.set_diff_view_mode(DiffViewMode::Inline, cx);
-                self.diff_view_mode_before_annotate = Some(DiffViewMode::Split);
-            }
-        } else if let Some(previous) = self.diff_view_mode_before_annotate.take()
-            && self.diff_view_mode == DiffViewMode::Inline
-        {
-            self.set_diff_view_mode(previous, cx);
-        }
         self.schedule_ui_settings_persist(cx);
     }
 
@@ -3921,7 +3940,7 @@ impl Render for GitCometView {
                     };
 
                     cx.stop_propagation();
-                    window.start_window_resize(edge);
+                    crate::app::begin_window_resize(window, edge);
                 }),
             );
         } else if self.hover_resize_edge.is_some() {

--- a/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
@@ -4614,6 +4614,9 @@ pub struct GitCometView {
     pub(super) ui_window_size_last_seen: Size<Pixels>,
     pub(super) ui_settings_persist_seq: u64,
     pub(super) last_repo_activation_dispatch_at: HashMap<RepoId, Instant>,
+    /// Set when a deactivation was caused by a move/resize grab we requested, so
+    /// the matching re-activation does not trigger a repo refresh.
+    pub(super) window_grab_activation_suppressed_at: Option<Instant>,
 
     pub(super) date_time_format: DateTimeFormat,
     pub(super) timezone: Timezone,
@@ -4635,9 +4638,6 @@ pub struct GitCometView {
     pub(super) diff_whitespace_mode: DiffWhitespaceMode,
     pub(super) diff_view_mode: DiffViewMode,
     pub(super) annotate_enabled: bool,
-    /// View mode stashed when enabling blame forced Split → Inline; restored
-    /// on toggle-off unless the user changed modes in the meantime.
-    pub(super) diff_view_mode_before_annotate: Option<DiffViewMode>,
     pub(super) diff_reveal_whitespace_chars: bool,
     pub(super) diff_word_wrap: bool,
     pub(super) diff_show_line_numbers: bool,

--- a/crates/gitcomet-ui-gpui/src/view/panels/main/diff_view.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/main/diff_view.rs
@@ -673,8 +673,7 @@ impl MainPaneView {
                     if conflict_resolver_active {
                         handled = false;
                     } else if self.active_conflict_target().is_some() {
-                        self.diff_view = DiffViewMode::Split;
-                        self.clear_diff_text_style_caches();
+                        self.set_diff_view_mode(DiffViewMode::Split, cx);
                         handled = true;
                         let root_view = self.root_view.clone();
                         cx.defer(move |cx| {
@@ -694,8 +693,7 @@ impl MainPaneView {
                         } else {
                             DiffViewMode::Split
                         };
-                        self.diff_view = new_mode;
-                        self.clear_diff_text_style_caches();
+                        self.set_diff_view_mode(new_mode, cx);
                         handled = true;
                         let root_view = self.root_view.clone();
                         let mode = new_mode;
@@ -2155,11 +2153,7 @@ impl MainPaneView {
                     .selected(self.diff_view == DiffViewMode::Inline)
                     .selected_bg(view_toggle_selected_bg)
                     .on_click(theme, cx, |this, _e, window, cx| {
-                        this.diff_view = DiffViewMode::Inline;
-                        this.clear_diff_text_style_caches();
-                        if this.diff_search_has_query() {
-                            this.diff_search_recompute_matches_preserving_current();
-                        }
+                        this.set_diff_view_mode(DiffViewMode::Inline, cx);
                         this.restore_diff_panel_focus_after_toolbar_action(window, cx);
                         let root_view = this.root_view.clone();
                         cx.defer(move |cx| {
@@ -2188,11 +2182,7 @@ impl MainPaneView {
                     .selected(self.diff_view == DiffViewMode::Split)
                     .selected_bg(view_toggle_selected_bg)
                     .on_click(theme, cx, |this, _e, window, cx| {
-                        this.diff_view = DiffViewMode::Split;
-                        this.clear_diff_text_style_caches();
-                        if this.diff_search_has_query() {
-                            this.diff_search_recompute_matches_preserving_current();
-                        }
+                        this.set_diff_view_mode(DiffViewMode::Split, cx);
                         this.restore_diff_panel_focus_after_toolbar_action(window, cx);
                         let root_view = this.root_view.clone();
                         cx.defer(move |cx| {

--- a/crates/gitcomet-ui-gpui/src/view/panels/tests/file_diff.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/tests/file_diff.rs
@@ -17054,3 +17054,254 @@ fn yaml_same_content_rev_refresh_invalidates_cached_heuristic_file_diff_rows(
         );
     }
 }
+
+/// Opens an unstaged text diff so the diff toolbar (Inline/Split + Blame)
+/// renders, and puts the pane in `mode`.
+fn push_unstaged_text_diff_for_blame_toggle(
+    cx: &mut gpui::VisualTestContext,
+    view: &gpui::Entity<super::super::GitCometView>,
+    repo_id: gitcomet_state::model::RepoId,
+    fixture_name: &str,
+    mode: DiffViewMode,
+) {
+    let workdir = std::env::temp_dir().join(format!(
+        "gitcomet_ui_test_{}_{fixture_name}",
+        std::process::id()
+    ));
+    let path = PathBuf::from("src/lib.rs");
+    let target = gitcomet_core::domain::DiffTarget::WorkingTree {
+        path: path.clone(),
+        area: gitcomet_core::domain::DiffArea::Unstaged,
+    };
+
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            let mut repo = opening_repo_state(repo_id, &workdir);
+            set_test_file_status(
+                &mut repo,
+                path.clone(),
+                gitcomet_core::domain::FileStatusKind::Modified,
+                gitcomet_core::domain::DiffArea::Unstaged,
+            );
+            repo.diff_state.diff_target = Some(target.clone());
+            repo.diff_state.diff =
+                gitcomet_state::model::Loadable::Ready(Arc::new(gitcomet_core::domain::Diff {
+                    target: target.clone(),
+                    lines: vec![
+                        gitcomet_core::domain::DiffLine {
+                            kind: gitcomet_core::domain::DiffLineKind::Context,
+                            text: "fn main() {".into(),
+                        },
+                        gitcomet_core::domain::DiffLine {
+                            kind: gitcomet_core::domain::DiffLineKind::Add,
+                            text: "    let x = 1;".into(),
+                        },
+                        gitcomet_core::domain::DiffLine {
+                            kind: gitcomet_core::domain::DiffLineKind::Context,
+                            text: "}".into(),
+                        },
+                    ],
+                }));
+
+            push_test_state(this, app_state_with_repo(repo, repo_id), cx);
+        });
+    });
+
+    // Go through the root setter so the root and the pane agree, exactly as the
+    // toolbar buttons and the session restore do.
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            this.set_diff_view_mode(mode, cx);
+        });
+    });
+    draw_and_drain_test_window(cx);
+}
+
+fn click_blame_toggle(cx: &mut gpui::VisualTestContext) {
+    let bounds = cx
+        .debug_bounds("diff_annotate")
+        .expect("the diff toolbar should render the blame toggle");
+    cx.simulate_click(bounds.center(), gpui::Modifiers::default());
+    cx.run_until_parked();
+    draw_and_drain_test_window(cx);
+}
+
+/// Regression: enabling blame used to force Split → Inline (and restore it on
+/// toggle-off). Blame is an annotation column, not a view mode — the split left
+/// column renders it just as the inline view does — so the selected mode must
+/// survive the toggle in both directions.
+#[gpui::test]
+fn blame_toggle_keeps_split_view(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+    let repo_id = gitcomet_state::model::RepoId(281);
+
+    push_unstaged_text_diff_for_blame_toggle(
+        cx,
+        &view,
+        repo_id,
+        "blame_toggle_split",
+        DiffViewMode::Split,
+    );
+
+    click_blame_toggle(cx);
+    cx.update(|_window, app| {
+        let root = view.read(app);
+        let pane = root.main_pane.read(app);
+        assert!(pane.annotate_enabled, "clicking blame should enable it");
+        assert_eq!(
+            pane.diff_view,
+            DiffViewMode::Split,
+            "enabling blame must not switch the diff view to Inline"
+        );
+        assert_eq!(root.diff_view_mode, DiffViewMode::Split);
+    });
+
+    click_blame_toggle(cx);
+    cx.update(|_window, app| {
+        let root = view.read(app);
+        let pane = root.main_pane.read(app);
+        assert!(!pane.annotate_enabled);
+        assert_eq!(
+            pane.diff_view,
+            DiffViewMode::Split,
+            "disabling blame must not change the diff view either"
+        );
+        assert_eq!(root.diff_view_mode, DiffViewMode::Split);
+    });
+}
+
+#[gpui::test]
+fn blame_toggle_keeps_inline_view(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+    let repo_id = gitcomet_state::model::RepoId(282);
+
+    push_unstaged_text_diff_for_blame_toggle(
+        cx,
+        &view,
+        repo_id,
+        "blame_toggle_inline",
+        DiffViewMode::Inline,
+    );
+
+    click_blame_toggle(cx);
+    cx.update(|_window, app| {
+        let root = view.read(app);
+        let pane = root.main_pane.read(app);
+        assert!(pane.annotate_enabled);
+        assert_eq!(pane.diff_view, DiffViewMode::Inline);
+        assert_eq!(root.diff_view_mode, DiffViewMode::Inline);
+    });
+}
+
+/// The annotation column narrows the left split column, so the shared split
+/// wrap width must shrink when blame is on — the guarantee that made forcing
+/// Inline unnecessary in the first place.
+#[gpui::test]
+fn split_annotate_reserves_the_annotation_column(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+    let repo_id = gitcomet_state::model::RepoId(283);
+
+    push_unstaged_text_diff_for_blame_toggle(
+        cx,
+        &view,
+        repo_id,
+        "blame_split_columns",
+        DiffViewMode::Split,
+    );
+
+    let (_, split_without_blame) = cx.update(|window, app| {
+        let main_pane = view.read(app).main_pane.clone();
+        main_pane.update(app, |pane, cx| pane.diff_wrap_columns(window, cx))
+    });
+
+    click_blame_toggle(cx);
+
+    let (_, split_with_blame) = cx.update(|window, app| {
+        let main_pane = view.read(app).main_pane.clone();
+        main_pane.update(app, |pane, cx| {
+            assert!(
+                pane.annotation_active(),
+                "an unstaged working-tree diff supports blame, so the column is active"
+            );
+            pane.diff_wrap_columns(window, cx)
+        })
+    });
+
+    assert!(
+        split_with_blame < split_without_blame,
+        "the annotation column must narrow the split wrap width \
+         (with blame: {split_with_blame}, without: {split_without_blame})"
+    );
+}
+
+/// The command palette and the Settings window route mode changes through
+/// `GitCometView::set_diff_view_mode` rather than the toolbar buttons, so the
+/// styled-segment cache clear has to live in the pane setter: inline keys those
+/// segments by `row_ix` while split keys them by `row_ix * 2` / `row_ix * 2 + 1`
+/// against the same epochs, so a stale entry can paint the wrong row.
+#[gpui::test]
+fn toggle_diff_view_command_clears_styled_segment_caches(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+    let repo_id = gitcomet_state::model::RepoId(284);
+
+    push_unstaged_text_diff_for_blame_toggle(
+        cx,
+        &view,
+        repo_id,
+        "toggle_diff_view_cache",
+        DiffViewMode::Inline,
+    );
+
+    // Seed the inline key space directly: which rows a draw happens to cache
+    // depends on syntax availability and streaming heuristics, and the contract
+    // under test is only that a mode change drops whatever is cached.
+    let cached = cx.update(|_window, app| {
+        let main_pane = view.read(app).main_pane.clone();
+        main_pane.update(app, |pane, _cx| {
+            for key in 0..3 {
+                pane.diff_text_segments_cache_set(
+                    key,
+                    0,
+                    crate::view::diff_text_model::CachedDiffStyledText {
+                        text: "let x = 1;".into(),
+                        highlights: Arc::from(Vec::new()),
+                        highlights_hash: 0,
+                        text_hash: 0,
+                    },
+                );
+            }
+            pane.diff_text_segments_cache.iter().flatten().count()
+        })
+    });
+    assert_eq!(cached, 3);
+
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            this.execute_command("toggle-diff-view", None, cx);
+        });
+    });
+    cx.run_until_parked();
+
+    cx.update(|_window, app| {
+        let root = view.read(app);
+        let pane = root.main_pane.read(app);
+        assert_eq!(pane.diff_view, DiffViewMode::Split);
+        assert_eq!(
+            pane.diff_text_segments_cache.iter().flatten().count(),
+            0,
+            "switching modes outside the toolbar must still clear the aliasing cache"
+        );
+    });
+}

--- a/crates/gitcomet-ui-gpui/src/view/panes/main/core_impl.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panes/main/core_impl.rs
@@ -3475,6 +3475,14 @@ impl MainPaneView {
         }
 
         self.diff_view = next;
+        // Inline keys styled segments by `row_ix` while split keys them by
+        // `row_ix * 2` / `row_ix * 2 + 1` (`file_diff_split_cache_key`) against
+        // the same `split_left`/`split_right` epochs, so the two key spaces
+        // alias. Clear on every mode change, not just the toolbar/hotkey ones.
+        self.clear_diff_text_style_caches();
+        if self.diff_search_has_query() {
+            self.diff_search_recompute_matches_preserving_current();
+        }
         cx.notify();
     }
 
@@ -3514,6 +3522,24 @@ impl MainPaneView {
                 .rendered_diff_target()
                 .and_then(blame_path_rev_for_target)
                 .is_some()
+    }
+
+    /// Whether the loaded (or retained) blame describes the diff target being
+    /// rendered right now. `blame_path`/`blame_source` follow the store snapshot,
+    /// which lags the dispatch by at least a frame, so just after a file switch
+    /// they still name the previous file — its annotations must not be painted
+    /// over the new one's rows.
+    pub(in crate::view) fn blame_matches_rendered_target(&self) -> bool {
+        let Some((path, source)) = self
+            .rendered_diff_target()
+            .and_then(blame_path_rev_for_target)
+        else {
+            return false;
+        };
+        self.active_repo().is_some_and(|repo| {
+            repo.history_state.blame_path.as_deref() == Some(path.as_path())
+                && repo.history_state.blame_source.as_ref() == Some(&source)
+        })
     }
 
     /// Record the hovered blame annotation sub-area and drive the shared tooltip
@@ -5093,7 +5119,7 @@ impl MainPaneView {
         }
     }
 
-    fn diff_wrap_columns(
+    pub(in crate::view) fn diff_wrap_columns(
         &self,
         window: &mut gpui::Window,
         cx: &mut gpui::Context<Self>,

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff.rs
@@ -797,13 +797,23 @@ fn build_row_blame_paint_tracked(
 impl MainPaneView {
     /// Build a blame render context when annotate is enabled and blame for the
     /// current target is loaded; otherwise `None`.
+    ///
+    /// While the same target reloads, falls back to the annotations retained by
+    /// the store (`retained_blame_while_loading`) so the column keeps its
+    /// contents instead of blanking on every refresh. The retained value is
+    /// dropped when blame re-targets, so it always describes `blame_path`.
     pub(super) fn blame_render_ctx(&mut self) -> Option<BlameRenderCtx> {
-        if !self.annotation_active() {
+        if !self.annotation_active() || !self.blame_matches_rendered_target() {
             return None;
         }
         let repo = self.active_repo()?;
-        let gitcomet_state::model::Loadable::Ready(lines) = &repo.history_state.blame else {
-            return None;
+        let lines = match &repo.history_state.blame {
+            gitcomet_state::model::Loadable::Ready(lines) => lines,
+            gitcomet_state::model::Loadable::NotLoaded
+            | gitcomet_state::model::Loadable::Loading => {
+                repo.history_state.retained_blame_while_loading.as_ref()?
+            }
+            gitcomet_state::model::Loadable::Error(_) => return None,
         };
         let path: std::sync::Arc<std::path::Path> =
             std::sync::Arc::from(repo.history_state.blame_path.as_deref()?);

--- a/crates/gitcomet-ui-gpui/src/view/settings_window.rs
+++ b/crates/gitcomet-ui-gpui/src/view/settings_window.rs
@@ -5266,7 +5266,7 @@ impl Render for SettingsWindowView {
                     };
 
                     cx.stop_propagation();
-                    window.start_window_resize(edge);
+                    crate::app::begin_window_resize(window, edge);
                 }),
             );
         } else {

--- a/crates/gitcomet-ui-gpui/src/view/tests.rs
+++ b/crates/gitcomet-ui-gpui/src/view/tests.rs
@@ -547,6 +547,73 @@ fn window_activation_dispatch_is_throttled_per_repo() {
 }
 
 #[test]
+fn window_grab_suppresses_the_activation_it_caused() {
+    // Dragging the title bar or a resize edge hands focus to the compositor for
+    // the duration of the grab, which GPUI reports as a deactivate → activate
+    // pair. Treating that as a return to the app refreshed the whole repo on
+    // every window move/resize.
+    let now = Instant::now();
+    crate::app::note_window_grab_started();
+
+    let armed = crate::app::take_window_grab_started_within(now, WINDOW_GRAB_DEACTIVATE_GRACE);
+    assert!(armed, "a fresh grab must claim the deactivation it caused");
+
+    let mut suppressed_at = Some(now);
+    assert!(consume_window_grab_activation(
+        &mut suppressed_at,
+        now + Duration::from_secs(5)
+    ));
+    assert!(
+        suppressed_at.is_none(),
+        "the marker must be consumed so it cannot suppress twice"
+    );
+}
+
+#[test]
+fn stale_window_grab_does_not_suppress_a_later_activation() {
+    // A grab the compositor ignored (bad serial, unsupported protocol) must not
+    // leave suppression armed for an unrelated alt-tab minutes later.
+    let now = Instant::now();
+    crate::app::note_window_grab_started();
+
+    assert!(!crate::app::take_window_grab_started_within(
+        now + WINDOW_GRAB_DEACTIVATE_GRACE + Duration::from_millis(1),
+        WINDOW_GRAB_DEACTIVATE_GRACE,
+    ));
+    assert!(
+        !crate::app::take_window_grab_started_within(now, WINDOW_GRAB_DEACTIVATE_GRACE),
+        "the stale marker must have been cleared, not left armed"
+    );
+}
+
+#[test]
+fn window_grab_suppression_expires_for_a_very_late_activation() {
+    let now = Instant::now();
+    let mut suppressed_at = Some(now);
+    assert!(!consume_window_grab_activation(
+        &mut suppressed_at,
+        now + WINDOW_GRAB_REACTIVATE_GRACE + Duration::from_secs(1),
+    ));
+}
+
+#[test]
+fn unsuppressed_activation_still_dispatches_repo_activated() {
+    // Suppression is opt-in, and a suppressed activation must not stamp the
+    // throttle map — a genuine alt-tab right after a drag still refreshes.
+    let repo_id = RepoId(1);
+    let state = view_state_with_active_ready_repo(repo_id);
+    let mut last_activation_dispatch = HashMap::default();
+    let now = Instant::now();
+
+    let mut suppressed_at = None;
+    assert!(!consume_window_grab_activation(&mut suppressed_at, now));
+    assert!(matches!(
+        repo_activation_msg(&state, &mut last_activation_dispatch, now),
+        Some(Msg::RepoActivated { repo_id: got }) if got == repo_id
+    ));
+}
+
+#[test]
 fn toast_total_lifetime_includes_fade_in_and_out() {
     let ttl = Duration::from_secs(6);
     assert_eq!(


### PR DESCRIPTION
- fix the issue where annotation panel refresh changes on window move or resize.
- Reduced the number of events required to process in repo_monitor by using kernel level filtering