### PR TITLE
fix(windows): use system sort executable for MSVC linker setup

### DIFF
--- a/scripts/windows/msvc-linker.cmd
+++ b/scripts/windows/msvc-linker.cmd
@@ -50,7 +50,7 @@ if not exist "%MSVC_TOOLS%" (
 )
 
 set "MSVC_VER="
-for /f "delims=" %%I in ('dir /b /ad "%MSVC_TOOLS%" ^| sort /r') do (
+for /f "delims=" %%I in ('dir /b /ad "%MSVC_TOOLS%" ^| "%SystemRoot%\System32\sort.exe" /r') do (
   set "MSVC_VER=%%I"
   goto :msvc_version_found
 )
@@ -89,7 +89,7 @@ if not exist "%KITS_LIB%" (
 )
 
 set "SDK_VER="
-for /f "delims=" %%I in ('dir /b /ad "%KITS_LIB%" ^| sort /r') do (
+for /f "delims=" %%I in ('dir /b /ad "%KITS_LIB%" ^| "%SystemRoot%\System32\sort.exe" /r') do (
   if exist "%KITS_LIB%\%%I\um\%SDK_ARCH%\kernel32.lib" (
     set "SDK_VER=%%I"
     goto :sdk_found


### PR DESCRIPTION
### Summary

Fix the MSVC linker setup script on Windows by explicitly invoking the system `sort.exe` executable when determining the latest MSVC and Windows SDK versions.

### Changes

* Use `%SystemRoot%\System32\sort.exe` instead of relying on `sort` from `PATH`.
* Apply the fix to both MSVC toolchain and Windows SDK version detection.

### Why

This prevents potential conflicts with other `sort` executables available in the environment and ensures the Windows linker setup consistently uses the native system utility.

### Testing

* Verified the changes in `scripts/windows/msvc-linker.cmd`.
* No functional changes beyond making `sort.exe` resolution explicit.
