### PR TITLE
Add Rebase Onto command to command palette

### DIFF
--- a/crates/gitcomet-ui-gpui/src/view/command_palette.rs
+++ b/crates/gitcomet-ui-gpui/src/view/command_palette.rs
@@ -80,6 +80,14 @@ pub(crate) const COMMANDS: &[CommandEntry] = &[
         requires_repo: true,
     },
     CommandEntry {
+        id: "rebase",
+        label: "Rebase Onto",
+        shortcut: Shortcut::None,
+        category: "Branch",
+        keywords: "rebase onto history rewrite",
+        requires_repo: true,
+    },
+    CommandEntry {
         id: "pull",
         label: "Pull",
         shortcut: Shortcut::None,
@@ -419,7 +427,6 @@ pub(crate) const COMMANDS: &[CommandEntry] = &[
     // TODO: "checkout-remote-branch" - Checkout Remote Branch
     // TODO: "delete-remote-branch"   - Delete Remote Branch
     // TODO: "merge"                  - Merge Branch/Ref
-    // TODO: "rebase"                 - Rebase Onto
     // TODO: "delete-tag"             - Delete Tag
     // TODO: "remove-remote"          - Remove Remote
     // TODO: "edit-remote-url"        - Edit Remote URL
@@ -1179,6 +1186,16 @@ mod tests {
         assert!(
             filtered_commands(false, "rename branch").is_empty(),
             "Rename Branch requires an active repository"
+        );
+    }
+
+    #[test]
+    fn rebase_onto_is_available_for_repository_commands() {
+        let matches = filtered_commands(true, "rebase onto");
+        assert_eq!(matches.first().map(|command| command.id), Some("rebase"));
+        assert!(
+            filtered_commands(false, "rebase onto").is_empty(),
+            "Rebase Onto requires an active repository"
         );
     }
 }

--- a/crates/gitcomet-ui-gpui/src/view/mod.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod.rs
@@ -975,7 +975,15 @@ impl GitCometView {
                 // TODO: Implement merge branch/ref
             }
             "rebase" => {
-                // TODO: Implement rebase onto
+                if let Some(window) = window {
+                    self.open_popover_centered(
+                        PopoverKind::BranchPicker {
+                            purpose: BranchPickerPurpose::RebaseOnto,
+                        },
+                        window,
+                        cx,
+                    );
+                }
             }
             "create-tag" => {
                 if let Some(repo_id) = self.active_repo_id()

--- a/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
@@ -3489,6 +3489,7 @@ pub(super) struct TerminalMenuContext {
 pub(super) enum BranchPickerPurpose {
     Checkout,
     Delete,
+    RebaseOnto,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -2260,6 +2260,15 @@ impl PopoverHost {
                 self.store.dispatch(Msg::DeleteBranch { repo_id, name });
                 self.close_popover(cx);
             }
+            Some(PopoverKind::BranchPicker {
+                purpose: BranchPickerPurpose::RebaseOnto,
+            }) => {
+                self.open_popover_centered(
+                    PopoverKind::RebaseOntoConfirm { repo_id, onto: name },
+                    window,
+                    cx,
+                );
+            }
             _ => {
                 self.store.dispatch(Msg::CheckoutBranch { repo_id, name });
                 self.close_popover(cx);

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -2264,7 +2264,10 @@ impl PopoverHost {
                 purpose: BranchPickerPurpose::RebaseOnto,
             }) => {
                 self.open_popover_centered(
-                    PopoverKind::RebaseOntoConfirm { repo_id, onto: name },
+                    PopoverKind::RebaseOntoConfirm {
+                        repo_id,
+                        onto: name,
+                    },
                     window,
                     cx,
                 );

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_picker.rs
@@ -48,8 +48,7 @@ pub(super) fn panel(this: &mut PopoverHost, cx: &mut gpui::Context<PopoverHost>)
                         .filter_map(|b| {
                             // The current branch cannot be rebased onto itself;
                             // deleting it is impossible too.
-                            if (is_delete || is_rebase_onto)
-                                && head_branch == Some(b.name.as_str())
+                            if (is_delete || is_rebase_onto) && head_branch == Some(b.name.as_str())
                             {
                                 None
                             } else {

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_picker.rs
@@ -12,8 +12,16 @@ pub(super) fn panel(this: &mut PopoverHost, cx: &mut gpui::Context<PopoverHost>)
             purpose: BranchPickerPurpose::Delete
         })
     );
+    let is_rebase_onto = matches!(
+        this.popover,
+        Some(PopoverKind::BranchPicker {
+            purpose: BranchPickerPurpose::RebaseOnto
+        })
+    );
     let title = if is_delete {
         "Delete Branch"
+    } else if is_rebase_onto {
+        "Rebase Onto"
     } else {
         "Checkout Branch"
     };
@@ -38,7 +46,11 @@ pub(super) fn panel(this: &mut PopoverHost, cx: &mut gpui::Context<PopoverHost>)
                     let branch_names = branches
                         .iter()
                         .filter_map(|b| {
-                            if is_delete && head_branch == Some(b.name.as_str()) {
+                            // The current branch cannot be rebased onto itself;
+                            // deleting it is impossible too.
+                            if (is_delete || is_rebase_onto)
+                                && head_branch == Some(b.name.as_str())
+                            {
                                 None
                             } else {
                                 Some(b.name.clone())

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/search_inputs.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/search_inputs.rs
@@ -187,8 +187,7 @@ impl PopoverHost {
                     let hide_current_branch = matches!(
                         this.popover,
                         Some(PopoverKind::BranchPicker {
-                            purpose:
-                                BranchPickerPurpose::Delete | BranchPickerPurpose::RebaseOnto
+                            purpose: BranchPickerPurpose::Delete | BranchPickerPurpose::RebaseOnto
                         })
                     );
                     let with_refs = branch_picker_offers_refs(this);

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/search_inputs.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/search_inputs.rs
@@ -182,10 +182,13 @@ impl PopoverHost {
                 |this| this.inline_branch_picker_active(),
                 |this| &mut this.branch_picker_selected_index,
                 |this, query, _cx| {
-                    let is_delete = matches!(
+                    // The current branch is not offered as a rebase target (it
+                    // cannot be rebased onto itself) and cannot be deleted.
+                    let hide_current_branch = matches!(
                         this.popover,
                         Some(PopoverKind::BranchPicker {
-                            purpose: BranchPickerPurpose::Delete
+                            purpose:
+                                BranchPickerPurpose::Delete | BranchPickerPurpose::RebaseOnto
                         })
                     );
                     let with_refs = branch_picker_offers_refs(this);
@@ -200,7 +203,7 @@ impl PopoverHost {
                     let mut names: Vec<String> = branches
                         .iter()
                         .filter_map(|b| {
-                            if is_delete && head_branch == Some(b.name.as_str()) {
+                            if hide_current_branch && head_branch == Some(b.name.as_str()) {
                                 None
                             } else {
                                 Some(b.name.clone())

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/picker.rs
@@ -1,5 +1,6 @@
 use super::branch::create_tracking_store;
 use super::*;
+use gitcomet_core::domain::{Branch, CommitId};
 
 #[gpui::test]
 fn repo_picker_escape_closes(cx: &mut gpui::TestAppContext) {
@@ -462,4 +463,73 @@ fn popover_feeds_pointer_positions_to_the_tooltip_host(cx: &mut gpui::TestAppCon
         anchor, row_center,
         "expected the tooltip anchor to follow the pointer inside the popover"
     );
+}
+
+#[gpui::test]
+fn rebase_onto_picker_excludes_current_branch_and_opens_confirm(cx: &mut gpui::TestAppContext) {
+    let (store, events, _repo, _workdir) = create_tracking_store("rebase-onto-picker");
+    let repo_id = store.snapshot().active_repo.expect("expected active repo");
+    store.dispatch(Msg::Internal(gitcomet_state::msg::InternalMsg::BranchesLoaded {
+        repo_id,
+        result: Ok(vec![
+            Branch {
+                name: "main".to_string(),
+                target: CommitId("HEAD".into()),
+                upstream: None,
+                divergence: None,
+            },
+            Branch {
+                name: "feature".to_string(),
+                target: CommitId("HEAD".into()),
+                upstream: None,
+                divergence: None,
+            },
+        ]),
+    }));
+    let store_for_view = store.clone();
+    let (view, cx) = cx
+        .add_window_view(|window, cx| GitCometView::new(store_for_view, events, None, window, cx));
+
+    cx.update(|window, app| {
+        crate::app::bind_text_input_keys_for_test(app);
+        let _ = window.draw(app);
+        view.update(app, |this, cx| {
+            this.popover_host.update(cx, |host, cx| {
+                host.open_popover_at(
+                    PopoverKind::BranchPicker {
+                        purpose: BranchPickerPurpose::RebaseOnto,
+                    },
+                    gpui::point(gpui::px(120.0), gpui::px(72.0)),
+                    window,
+                    cx,
+                );
+                let search = host
+                    .branch_picker_search_input
+                    .as_ref()
+                    .expect("branch picker search input");
+                let focus = search.read_with(cx, |input, _| input.focus_handle());
+                window.focus(&focus, cx);
+            });
+        });
+    });
+    cx.update(|window, app| {
+        let _ = window.draw(app);
+    });
+
+    // The current branch (main) must not be offered as a rebase target, so
+    // the first picker item is "feature"; selecting it asks for confirmation
+    // instead of checking it out.
+    cx.simulate_keystrokes("down enter");
+    cx.run_until_parked();
+
+    cx.update(|_window, app| {
+        let host = view.read(app).popover_host.read(app);
+        match &host.popover {
+            Some(PopoverKind::RebaseOntoConfirm { repo_id: rid, onto }) => {
+                assert_eq!(*rid, repo_id);
+                assert_eq!(onto, "feature");
+            }
+            other => panic!("expected RebaseOntoConfirm popover, got {other:?}"),
+        }
+    });
 }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/picker.rs
@@ -469,23 +469,25 @@ fn popover_feeds_pointer_positions_to_the_tooltip_host(cx: &mut gpui::TestAppCon
 fn rebase_onto_picker_excludes_current_branch_and_opens_confirm(cx: &mut gpui::TestAppContext) {
     let (store, events, _repo, _workdir) = create_tracking_store("rebase-onto-picker");
     let repo_id = store.snapshot().active_repo.expect("expected active repo");
-    store.dispatch(Msg::Internal(gitcomet_state::msg::InternalMsg::BranchesLoaded {
-        repo_id,
-        result: Ok(vec![
-            Branch {
-                name: "main".to_string(),
-                target: CommitId("HEAD".into()),
-                upstream: None,
-                divergence: None,
-            },
-            Branch {
-                name: "feature".to_string(),
-                target: CommitId("HEAD".into()),
-                upstream: None,
-                divergence: None,
-            },
-        ]),
-    }));
+    store.dispatch(Msg::Internal(
+        gitcomet_state::msg::InternalMsg::BranchesLoaded {
+            repo_id,
+            result: Ok(vec![
+                Branch {
+                    name: "main".to_string(),
+                    target: CommitId("HEAD".into()),
+                    upstream: None,
+                    divergence: None,
+                },
+                Branch {
+                    name: "feature".to_string(),
+                    target: CommitId("HEAD".into()),
+                    upstream: None,
+                    divergence: None,
+                },
+            ]),
+        },
+    ));
     let store_for_view = store.clone();
     let (view, cx) = cx
         .add_window_view(|window, cx| GitCometView::new(store_for_view, events, None, window, cx));


### PR DESCRIPTION
The palette entry opens a branch picker (current branch excluded as a target); selecting a branch opens the existing RebaseOntoConfirm dialog instead of checking out.