### PR TITLE
Fix an issue where scroll bar was not visible in file edit mode. Fix …

### DIFF
--- a/crates/gitcomet-state/src/model.rs
+++ b/crates/gitcomet-state/src/model.rs
@@ -901,6 +901,11 @@ pub struct DiffState {
     /// only for a `WorkingTree` target — editing is always of the file on disk.
     /// Set by `OpenFileEditor`, cleared by `ExitDiffEditMode`.
     pub edit_mode: bool,
+    /// The view that opened the editor. Editing always retargets the working
+    /// tree, so both the original target and whether it was a diff or a
+    /// full-content preview have to be retained explicitly for Save/Discard to
+    /// return to the right place.
+    pub edit_return_view: Option<FileEditReturnView>,
     pub diff_target_rev: u64,
     pub diff_state_rev: u64,
     /// A reload of the *same* target is in flight and the content still on
@@ -931,6 +936,7 @@ impl Default for DiffState {
             diff_target: None,
             content_preview: false,
             edit_mode: false,
+            edit_return_view: None,
             diff_target_rev: 0,
             diff_state_rev: 0,
             diff_reload_in_flight: false,
@@ -947,6 +953,13 @@ impl Default for DiffState {
             diff_file_image: Loadable::NotLoaded,
         }
     }
+}
+
+/// Main-pane destination restored when an editable working-tree buffer closes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FileEditReturnView {
+    pub target: DiffTarget,
+    pub content_preview: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/gitcomet-state/src/msg/message.rs
+++ b/crates/gitcomet-state/src/msg/message.rs
@@ -377,9 +377,9 @@ pub enum Msg {
         repo_id: RepoId,
         path: PathBuf,
     },
-    /// Leave the editor, keeping the file on screen as a read-only content
-    /// view. *Entering* the editor always goes through `OpenFileEditor`, which
-    /// re-targets the working tree — there is no "turn it on here" counterpart.
+    /// Leave the editor, restoring the diff or read-only content preview that
+    /// opened it. *Entering* always goes through `OpenFileEditor`, which
+    /// re-targets the working tree while retaining that return destination.
     ExitDiffEditMode {
         repo_id: RepoId,
     },

--- a/crates/gitcomet-state/src/store/reducer/diff_selection.rs
+++ b/crates/gitcomet-state/src/store/reducer/diff_selection.rs
@@ -6,7 +6,7 @@ use super::util::{
     start_current_conflict_target_reload,
 };
 use crate::model::{
-    AppState, ConflictFileLoadMode, DiagnosticKind, InlineSubmoduleDiffEntry,
+    AppState, ConflictFileLoadMode, DiagnosticKind, FileEditReturnView, InlineSubmoduleDiffEntry,
     InlineSubmoduleDiffSection, InlineSubmoduleDiffState, Loadable, RepoId, RepoState,
     ViewHistoryEntry,
 };
@@ -241,6 +241,22 @@ pub(super) fn open_file_editor(
     repo_id: RepoId,
     path: std::path::PathBuf,
 ) -> Vec<Effect> {
+    let return_view = state
+        .repos
+        .iter()
+        .find(|repo| repo.id == repo_id)
+        .and_then(|repo| {
+            if repo.diff_state.edit_mode {
+                return repo.diff_state.edit_return_view.clone();
+            }
+            repo.diff_state
+                .diff_target
+                .clone()
+                .map(|target| FileEditReturnView {
+                    target,
+                    content_preview: repo.diff_state.content_preview,
+                })
+        });
     let target = DiffTarget::WorkingTree {
         path: path.clone(),
         area: DiffArea::Unstaged,
@@ -253,16 +269,17 @@ pub(super) fn open_file_editor(
     }
     let mut effects = SelectDiffEffects::new();
     fill_select_diff_inline(state, repo_id, target, ContentViewMode::Edit, &mut effects);
+    if let Some(repo_state) = state.repos.iter_mut().find(|repo| repo.id == repo_id) {
+        repo_state.diff_state.edit_return_view = return_view;
+    }
     effects.into_vec()
 }
 
-/// Leave the editor, without reloading the file.
+/// Leave the editor and reload the view that was behind it.
 ///
-/// Lands on the read-only content view of the same file rather than on whatever
-/// the pane showed before the editor opened: the editor is a mode of the
-/// file-content view, and the diff stays one click (or one viewer-nav step)
-/// away. There is no enable counterpart — entering always goes through
-/// [`open_file_editor`], which re-targets the working tree.
+/// Restores the diff or read-only content preview that opened the editor. When
+/// there is no recorded origin (for example a restored legacy session), it
+/// falls back to the read-only working-tree preview of the edited file.
 pub(super) fn exit_diff_edit_mode(state: &mut AppState, repo_id: RepoId) -> Vec<Effect> {
     let Some(repo_state) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
         return Vec::new();
@@ -270,9 +287,40 @@ pub(super) fn exit_diff_edit_mode(state: &mut AppState, repo_id: RepoId) -> Vec<
     if !repo_state.diff_state.edit_mode {
         return Vec::new();
     }
-    repo_state.diff_state.edit_mode = false;
-    repo_state.bump_diff_state_rev();
-    Vec::new()
+    let return_view = repo_state.diff_state.edit_return_view.take();
+    let fallback_target = repo_state.diff_state.diff_target.clone();
+
+    let (target, mode) = match return_view {
+        Some(return_view) => (
+            Some(return_view.target),
+            if return_view.content_preview {
+                ContentViewMode::Preview
+            } else {
+                ContentViewMode::Diff
+            },
+        ),
+        None => (fallback_target, ContentViewMode::Preview),
+    };
+    let Some(target) = target else {
+        let Some(repo_state) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+            return Vec::new();
+        };
+        repo_state.diff_state.edit_mode = false;
+        repo_state.diff_state.content_preview = true;
+        repo_state.bump_diff_state_rev();
+        return Vec::new();
+    };
+
+    if mode == ContentViewMode::Preview
+        && let Some(entry) = view_history_entry_for_target(&target)
+        && let Some(repo_state) = state.repos.iter_mut().find(|repo| repo.id == repo_id)
+    {
+        repo_state.view_history.seek_or_record(entry);
+    }
+
+    let mut effects = SelectDiffEffects::new();
+    fill_select_diff_inline(state, repo_id, target, mode, &mut effects);
+    effects.into_vec()
 }
 
 /// Map a `(source, path)` content view to its `DiffTarget`. Returns `None` for
@@ -488,6 +536,9 @@ pub(super) fn fill_select_diff_inline(
     clear_inline_submodule_diff_state(repo_state);
     repo_state.diff_state.content_preview = content_preview;
     repo_state.diff_state.edit_mode = mode == ContentViewMode::Edit;
+    if mode != ContentViewMode::Edit {
+        repo_state.diff_state.edit_return_view = None;
+    }
 
     if !content_preview && let Some(conflict_target) = selected_conflict_target(repo_state, &target)
     {
@@ -540,6 +591,8 @@ pub(super) fn select_conflict_diff(
 
     clear_inline_submodule_diff_state(repo_state);
     repo_state.diff_state.content_preview = false;
+    repo_state.diff_state.edit_mode = false;
+    repo_state.diff_state.edit_return_view = None;
 
     let target = DiffTarget::WorkingTree {
         path: path.clone(),
@@ -563,6 +616,8 @@ pub(super) fn clear_diff_selection(state: &mut AppState, repo_id: RepoId) -> Vec
 
     clear_inline_submodule_diff_state(repo_state);
     repo_state.diff_state.content_preview = false;
+    repo_state.diff_state.edit_mode = false;
+    repo_state.diff_state.edit_return_view = None;
 
     repo_state.set_diff_target(None);
     repo_state.diff_state.diff = Loadable::NotLoaded;

--- a/crates/gitcomet-state/src/store/tests/diff_selection.rs
+++ b/crates/gitcomet-state/src/store/tests/diff_selection.rs
@@ -2565,6 +2565,92 @@ fn exiting_edit_mode_keeps_the_file_on_screen() {
 }
 
 #[test]
+fn exiting_edit_mode_restores_the_originating_diff_or_content_preview() {
+    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let id_alloc = AtomicU64::new(2);
+    let mut state = AppState::default();
+    let repo_id = RepoId(1);
+    state.repos.push(RepoState::new_opening(
+        repo_id,
+        RepoSpec {
+            workdir: PathBuf::from("/tmp/repo"),
+        },
+    ));
+    state.active_repo = Some(repo_id);
+
+    let path = PathBuf::from("src/main.rs");
+    let commit_id = CommitId("deadbeef".into());
+    let commit_target = DiffTarget::Commit {
+        commit_id: commit_id.clone(),
+        path: Some(path.clone()),
+    };
+
+    // A diff remains a diff, including its historical target, after editing
+    // the working-tree copy.
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::SelectDiff {
+            repo_id,
+            target: commit_target.clone(),
+        },
+    );
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::OpenFileEditor {
+            repo_id,
+            path: path.clone(),
+        },
+    );
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::ExitDiffEditMode { repo_id },
+    );
+    assert_eq!(state.repos[0].diff_state.diff_target, Some(commit_target));
+    assert!(!state.repos[0].diff_state.content_preview);
+    assert!(!state.repos[0].diff_state.edit_mode);
+
+    // A full-content preview returns to that preview and its original commit,
+    // rather than being forced into the working-tree preview.
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::OpenFileContent {
+            repo_id,
+            source: FileSource::Commit(commit_id.clone()),
+            path: path.clone(),
+        },
+    );
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::OpenFileEditor { repo_id, path },
+    );
+    reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::ExitDiffEditMode { repo_id },
+    );
+    assert_eq!(
+        state.repos[0].diff_state.diff_target,
+        Some(DiffTarget::Commit {
+            commit_id,
+            path: Some(PathBuf::from("src/main.rs")),
+        })
+    );
+    assert!(state.repos[0].diff_state.content_preview);
+    assert!(!state.repos[0].diff_state.edit_mode);
+}
+
+#[test]
 fn global_nav_realigns_viewer_history_onto_restored_file_view() {
     // Regression: a global (mouse) navigation that lands on a file-content view
     // must reposition the in-viewer file-version history (`view_history`) onto

--- a/crates/gitcomet-ui-gpui/src/kit/text_input/editing.rs
+++ b/crates/gitcomet-ui-gpui/src/kit/text_input/editing.rs
@@ -435,6 +435,9 @@ impl TextInput {
         self.selection.reversed = false;
         self.selection.undo_stack.clear();
         self.selection.redo_stack.clear();
+        self.interaction.is_selecting = false;
+        self.interaction.mouse_selection_anchor = None;
+        self.interaction.pending_mouse_selection_anchor = None;
         self.interaction.cursor_blink_visible = true;
         self.layout.scroll_x = px(0.0);
         self.invalidate_layout_caches();
@@ -2336,6 +2339,8 @@ impl TextInput {
         self.interaction.vertical_motion_x = None;
         self.interaction.cursor_blink_visible = true;
         self.interaction.is_selecting = false;
+        self.interaction.mouse_selection_anchor = None;
+        self.interaction.pending_mouse_selection_anchor = None;
         self.invalidate_layout_caches();
         if self.multiline && self.soft_wrap {
             self.request_wrap_recompute();
@@ -2627,17 +2632,28 @@ impl TextInput {
         cx.stop_propagation();
         window.focus(&self.focus_handle, cx);
         self.interaction.cursor_blink_visible = true;
-        let index = self.index_for_mouse_position(event.position);
+        let index = self.try_index_for_mouse_position(event.position);
         self.interaction.vertical_motion_x = None;
 
         if event.modifiers.shift {
             self.interaction.is_selecting = true;
-            self.select_to(index, cx);
+            self.interaction.mouse_selection_anchor = Some(if self.selection.reversed {
+                self.selection.range.end
+            } else {
+                self.selection.range.start
+            });
+            self.interaction.pending_mouse_selection_anchor = None;
+            if let Some(index) = index {
+                self.select_mouse_to_index(index, cx);
+            }
             return;
         }
 
         if event.click_count >= 2 {
             self.interaction.is_selecting = false;
+            self.interaction.mouse_selection_anchor = None;
+            self.interaction.pending_mouse_selection_anchor = None;
+            let index = index.unwrap_or_else(|| self.cursor_offset());
             let range = self.token_range_for_offset(index);
             if range.is_empty() {
                 self.move_to(index, cx);
@@ -2648,7 +2664,16 @@ impl TextInput {
             }
         } else {
             self.interaction.is_selecting = true;
-            self.move_to(index, cx)
+            self.interaction.mouse_selection_anchor = index;
+            self.interaction.pending_mouse_selection_anchor =
+                index.is_none().then_some(event.position);
+            match index {
+                Some(index) => self.move_to(index, cx),
+                // Clear any old highlight without inventing byte zero as the
+                // new anchor. The initiating pointer position is resolved by
+                // the first move after the next layout has painted.
+                None => self.move_to(self.cursor_offset(), cx),
+            }
         }
     }
 
@@ -2659,6 +2684,8 @@ impl TextInput {
         _cx: &mut Context<Self>,
     ) {
         self.interaction.is_selecting = false;
+        self.interaction.mouse_selection_anchor = None;
+        self.interaction.pending_mouse_selection_anchor = None;
     }
 
     pub(super) fn on_mouse_move(
@@ -2668,8 +2695,7 @@ impl TextInput {
         cx: &mut Context<Self>,
     ) {
         if self.interaction.is_selecting {
-            let index = self.index_for_mouse_position(event.position);
-            self.select_to(index, cx);
+            self.update_mouse_selection(event.position, cx);
         }
     }
 
@@ -2734,6 +2760,8 @@ impl TextInput {
         window.focus(&self.focus_handle, cx);
         self.interaction.cursor_blink_visible = true;
         self.interaction.is_selecting = false;
+        self.interaction.mouse_selection_anchor = None;
+        self.interaction.pending_mouse_selection_anchor = None;
         self.interaction.vertical_motion_x = None;
 
         let index = self.index_for_mouse_position(event.position);
@@ -2966,9 +2994,9 @@ impl TextInput {
             .child(select_all_row)
     }
 
-    pub(super) fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {
+    fn try_index_for_mouse_position(&self, position: Point<Pixels>) -> Option<usize> {
         if self.content.is_empty() {
-            return 0;
+            return Some(0);
         }
 
         let (Some(bounds), Some(layout), Some(starts)) = (
@@ -2976,14 +3004,14 @@ impl TextInput {
             self.layout.last.as_ref(),
             self.layout.line_starts.as_ref(),
         ) else {
-            return 0;
+            return None;
         };
 
         if position.y < bounds.top() {
-            return 0;
+            return Some(0);
         }
         if position.y > bounds.bottom() {
-            return self.content.len();
+            return Some(self.content.len());
         }
 
         let line_height = if self.layout.line_height.is_zero() {
@@ -2992,7 +3020,7 @@ impl TextInput {
             self.layout.line_height
         };
 
-        match layout {
+        Some(match layout {
             TextInputLayout::Plain(lines) => {
                 let ratio = f32::from(position.y - bounds.top()) / f32::from(line_height);
                 let mut line_ix = ratio.floor() as isize;
@@ -3030,7 +3058,54 @@ impl TextInput {
                 let doc_ix = starts.get(line_ix).copied().unwrap_or(0) + local;
                 doc_ix.min(self.content.len())
             }
+        })
+    }
+
+    pub(super) fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {
+        // Public hit-test callers need a total answer. Mouse drag initiation
+        // uses the optional form above so a briefly invalid layout never turns
+        // into a bogus byte-zero anchor.
+        self.try_index_for_mouse_position(position)
+            .unwrap_or_else(|| self.cursor_offset())
+    }
+
+    pub(super) fn update_mouse_selection(
+        &mut self,
+        position: Point<Pixels>,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(index) = self.try_index_for_mouse_position(position) else {
+            return;
+        };
+        if self.interaction.mouse_selection_anchor.is_none() {
+            let Some(anchor_position) = self.interaction.pending_mouse_selection_anchor else {
+                return;
+            };
+            let Some(anchor) = self.try_index_for_mouse_position(anchor_position) else {
+                return;
+            };
+            self.interaction.mouse_selection_anchor = Some(anchor);
+            self.interaction.pending_mouse_selection_anchor = None;
         }
+        self.select_mouse_to_index(index, cx);
+    }
+
+    fn select_mouse_to_index(&mut self, index: usize, cx: &mut Context<Self>) {
+        let Some(anchor) = self.interaction.mouse_selection_anchor else {
+            return;
+        };
+        let anchor = self.clamp_to_char_boundary(anchor);
+        let index = self.clamp_to_char_boundary(index);
+        let next = anchor.min(index)..anchor.max(index);
+        let reversed = index < anchor;
+        if self.selection.range == next && self.selection.reversed == reversed {
+            return;
+        }
+        self.selection.range = next;
+        self.selection.reversed = reversed;
+        self.interaction.vertical_motion_x = None;
+        self.interaction.cursor_blink_visible = true;
+        cx.notify();
     }
 
     pub(super) fn index_for_position(&self, position: Point<Pixels>) -> usize {

--- a/crates/gitcomet-ui-gpui/src/kit/text_input/element.rs
+++ b/crates/gitcomet-ui-gpui/src/kit/text_input/element.rs
@@ -793,7 +793,7 @@ impl Element for TextElement {
             window.on_mouse_event(move |event: &MouseMoveEvent, _phase, _window, cx| {
                 input.update(cx, |input, cx| {
                     if input.interaction.is_selecting {
-                        input.select_to(input.index_for_mouse_position(event.position), cx);
+                        input.update_mouse_selection(event.position, cx);
                     }
                 });
             });
@@ -805,6 +805,8 @@ impl Element for TextElement {
                 }
                 input.update(cx, |input, _cx| {
                     input.interaction.is_selecting = false;
+                    input.interaction.mouse_selection_anchor = None;
+                    input.interaction.pending_mouse_selection_anchor = None;
                 });
             });
         }

--- a/crates/gitcomet-ui-gpui/src/kit/text_input/state.rs
+++ b/crates/gitcomet-ui-gpui/src/kit/text_input/state.rs
@@ -767,6 +767,15 @@ impl SelectionState {
 
 pub(super) struct InteractionState {
     pub(super) is_selecting: bool,
+    /// Fixed document endpoint for the mouse drag in progress. Keyboard
+    /// selections can infer their anchor from `range` + `reversed`, but a mouse
+    /// drag must not let repeated move handlers or a direction change move it.
+    pub(super) mouse_selection_anchor: Option<usize>,
+    /// Window position of the initiating press while the text layout is
+    /// temporarily unavailable. A text replacement invalidates layout before
+    /// the next paint; resolving that press to byte 0 caused a one-frame
+    /// selection from the top of the document.
+    pub(super) pending_mouse_selection_anchor: Option<Point<Pixels>>,
     pub(super) suppress_right_click: bool,
     pub(super) context_menu: Option<TextInputContextMenuState>,
     pub(super) vertical_motion_x: Option<Pixels>,
@@ -796,6 +805,8 @@ impl InteractionState {
     pub(super) fn new() -> Self {
         Self {
             is_selecting: false,
+            mouse_selection_anchor: None,
+            pending_mouse_selection_anchor: None,
             suppress_right_click: false,
             context_menu: None,
             vertical_motion_x: None,

--- a/crates/gitcomet-ui-gpui/src/kit/text_input/tests.rs
+++ b/crates/gitcomet-ui-gpui/src/kit/text_input/tests.rs
@@ -429,6 +429,87 @@ impl Render for ScrolledPlainInputView {
 }
 
 #[gpui::test]
+fn mouse_drag_resolves_its_press_after_an_invalidated_layout(cx: &mut gpui::TestAppContext) {
+    let (input, cx) = cx.add_window_view(|window, cx| {
+        TextInput::new(
+            TextInputOptions {
+                multiline: false,
+                ..Default::default()
+            },
+            window,
+            cx,
+        )
+    });
+
+    cx.update(|window, app| {
+        input.update(app, |input, cx| {
+            input.set_text("alpha beta gamma", cx);
+        });
+        let _ = window.draw(app);
+    });
+
+    let (anchor_position, target_position) = cx.update(|_window, app| {
+        let input = input.read(app);
+        let bounds = input.layout.bounds.expect("text input bounds");
+        let y = bounds.center().y;
+        let position_for_offset = |wanted| {
+            (0..f32::from(bounds.size.width).ceil() as usize)
+                .map(|x| point(bounds.left() + px(x as f32), y))
+                .find(|position| input.index_for_mouse_position(*position) == wanted)
+                .unwrap_or_else(|| panic!("a hit position for offset {wanted}"))
+        };
+        (position_for_offset(6), position_for_offset(10))
+    });
+
+    // Replace the text and press before the next paint. The old implementation
+    // resolved this temporarily layout-less press as byte zero.
+    cx.update(|window, app| {
+        input.update(app, |input, cx| {
+            input.set_text("alpha beta gamma delta", cx);
+            assert!(input.layout.last.is_none());
+            input.on_mouse_down(
+                &MouseDownEvent {
+                    position: anchor_position,
+                    modifiers: gpui::Modifiers::default(),
+                    button: MouseButton::Left,
+                    click_count: 1,
+                    first_mouse: false,
+                },
+                window,
+                cx,
+            );
+            assert_eq!(
+                input.selection.range,
+                input.text().len()..input.text().len(),
+                "the unavailable layout must not invent a selection from byte zero"
+            );
+        });
+        let _ = window.draw(app);
+    });
+
+    let expected = cx.update(|_window, app| {
+        let input = input.read(app);
+        let anchor = input.index_for_mouse_position(anchor_position);
+        let target = input.index_for_mouse_position(target_position);
+        anchor.min(target)..anchor.max(target)
+    });
+    assert!(expected.start > 0);
+    cx.simulate_mouse_move(
+        target_position,
+        Some(MouseButton::Left),
+        gpui::Modifiers::default(),
+    );
+    cx.update(|_window, app| {
+        assert_eq!(input.read(app).selection.range, expected);
+    });
+    cx.simulate_mouse_up(
+        target_position,
+        MouseButton::Left,
+        gpui::Modifiers::default(),
+    );
+}
+
+#[gpui::test]
 fn plain_multiline_layout_shapes_only_the_viewport_of_a_large_document(
     cx: &mut gpui::TestAppContext,
 ) {

--- a/crates/gitcomet-ui-gpui/src/view/panels/main/diff_view.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/main/diff_view.rs
@@ -261,9 +261,9 @@ impl MainPaneView {
         let mut handled = false;
 
         // While the editable buffer has focus every keystroke belongs to it, with
-        // one exception: Ctrl/Cmd+S saves. Outside the editor that chord stages
-        // the file, and both meanings can coexist precisely because they are
-        // separated by focus.
+        // one exception: Ctrl/Cmd+S saves and returns to the originating view.
+        // Outside the editor that chord stages the file, and both meanings can
+        // coexist precisely because they are separated by focus.
         if self
             .file_editor_input
             .read(cx)
@@ -276,7 +276,7 @@ impl MainPaneView {
                 && !mods.function
                 && key == "s"
             {
-                self.save_file_editor_buffer(cx);
+                self.save_file_editor_buffer_and_exit(window, cx);
                 return true;
             }
             if key == "escape" && !mods.control && !mods.alt && !mods.platform && !mods.function {
@@ -1393,7 +1393,7 @@ impl MainPaneView {
         cx.notify();
     }
 
-    /// Throw the buffer away and leave the editor for the read-only view.
+    /// Throw the buffer away and restore the view that opened the editor.
     ///
     /// Discarding is the user saying they are done with this edit, so it exits
     /// the way Escape and the Edit toggle do rather than leaving them parked in
@@ -1414,6 +1414,30 @@ impl MainPaneView {
         cx.notify();
     }
 
+    /// Save the editable buffer and restore the view that opened it.
+    pub(in crate::view) fn save_file_editor_buffer_and_exit(
+        &mut self,
+        window: &mut Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        // The toolbar button is disabled in these states, but the keyboard
+        // shortcut can still arrive. A no-op save must not unexpectedly act as
+        // an editor-close shortcut.
+        if self.file_editor_loading
+            || !self.file_editor_is_dirty()
+            || self.file_editor_key.is_none()
+        {
+            return;
+        }
+        self.save_file_editor_buffer(cx);
+        let Some(repo_id) = self.active_repo_id() else {
+            return;
+        };
+        self.store.dispatch(Msg::ExitDiffEditMode { repo_id });
+        self.restore_diff_panel_focus_after_toolbar_action(window, cx);
+        cx.notify();
+    }
+
     /// The explicit "Save" button, shown while editing with auto-save off.
     fn file_editor_save_button(
         &self,
@@ -1423,14 +1447,14 @@ impl MainPaneView {
         components::Button::new("file_editor_save", "Save")
             .style(components::ButtonStyle::Outlined)
             .disabled(!self.file_editor_is_dirty())
-            .on_click(theme, cx, |this, _e, _window, cx| {
-                this.save_file_editor_buffer(cx);
+            .on_click(theme, cx, |this, _e, window, cx| {
+                this.save_file_editor_buffer_and_exit(window, cx);
             })
             .debug_selector(|| "file_editor_save".to_string())
             .gitcomet_tooltip(
                 theme,
                 format!(
-                    "Save the file ({})",
+                    "Save the file and return ({})",
                     crate::view::shortcut_labels::secondary_shortcut("S")
                 )
                 .into(),
@@ -1461,7 +1485,7 @@ impl MainPaneView {
             .gitcomet_tooltip(
                 theme,
                 if dirty {
-                    "Throw away the unsaved changes and return to the file view".into()
+                    "Throw away the unsaved changes and return to the previous view".into()
                 } else {
                     SharedString::from("No unsaved changes")
                 },

--- a/crates/gitcomet-ui-gpui/src/view/panels/tests/file_editor.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/tests/file_editor.rs
@@ -321,7 +321,7 @@ fn provider_binding_key_changes_only_when_something_changed() {
 }
 
 #[gpui::test]
-async fn alt_e_toggles_the_editor_and_ctrl_s_saves_while_it_has_focus(
+async fn alt_e_toggles_the_editor_and_ctrl_s_saves_and_exits_while_it_has_focus(
     cx: &mut gpui::TestAppContext,
 ) {
     let _visual_guard = lock_visual_test();
@@ -390,6 +390,16 @@ async fn alt_e_toggles_the_editor_and_ctrl_s_saves_while_it_has_focus(
     assert!(
         cx.update(|_window, app| !main_pane.read(app).file_editor_is_dirty()),
         "the buffer settles once saved"
+    );
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            crate::view::test_support::sync_store_snapshot(this, cx)
+        });
+    });
+    cx.run_until_parked();
+    assert!(
+        cx.update(|_window, app| !main_pane.read(app).is_file_editor_active()),
+        "saving from the editor returns to the view that opened it"
     );
 
     let _ = std::fs::remove_dir_all(&workdir);
@@ -780,6 +790,50 @@ async fn word_wrap_reaches_the_buffer(cx: &mut gpui::TestAppContext) {
                 .file_editor_input
                 .read(app)
                 .soft_wrap()
+        );
+    });
+
+    let _ = std::fs::remove_dir_all(&workdir);
+}
+
+#[gpui::test]
+async fn file_editor_mounts_a_vertical_scrollbar(cx: &mut gpui::TestAppContext) {
+    let _visual_guard = lock_visual_test();
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_id = gitcomet_state::model::RepoId(975);
+    let workdir = unique_workdir("file_editor_scrollbar");
+    let file_rel = std::path::PathBuf::from("long.rs");
+    let contents = (0..400)
+        .map(|line| format!("fn line_{line}() {{}}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(workdir.join(&file_rel), contents).expect("write fixture");
+
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            push_test_state(this, editor_state(repo_id, &workdir, &file_rel), cx);
+            this.main_pane
+                .update(cx, |pane, cx| pane.ensure_file_editor_loaded(cx));
+        });
+    });
+    cx.run_until_parked();
+    cx.update(|window, app| {
+        let _ = window.draw(app);
+    });
+
+    assert!(
+        cx.debug_bounds("file_editor_scrollbar").is_some(),
+        "edit mode should mount its vertical scrollbar beside the scroll surface"
+    );
+    cx.update(|_window, app| {
+        let pane = view.read(app).main_pane.read(app);
+        assert!(
+            pane.file_editor_scroll.max_offset().y > px(0.0),
+            "the long editor fixture should expose a vertical scroll range"
         );
     });
 
@@ -1726,6 +1780,63 @@ async fn discarding_from_the_toolbar_returns_to_the_read_only_view(cx: &mut gpui
             std::fs::read_to_string(workdir.join(&file_rel)).expect("file still on disk"),
             "fn main() {}\n",
             "and the file on disk was never written"
+        );
+    });
+
+    let _ = std::fs::remove_dir_all(&workdir);
+}
+
+#[gpui::test]
+async fn saving_from_the_toolbar_exits_the_editor(cx: &mut gpui::TestAppContext) {
+    let _visual_guard = lock_visual_test();
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        super::super::GitCometView::new(store, events, None, window, cx)
+    });
+
+    let repo_id = gitcomet_state::model::RepoId(976);
+    let workdir = unique_workdir("file_editor_save_exits");
+    let file_rel = std::path::PathBuf::from("main.rs");
+    std::fs::write(workdir.join(&file_rel), "fn main() {}\n").expect("write fixture");
+
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            push_test_state(this, editor_state(repo_id, &workdir, &file_rel), cx);
+            this.main_pane
+                .update(cx, |pane, cx| pane.ensure_file_editor_loaded(cx));
+        });
+    });
+    cx.run_until_parked();
+
+    let main_pane = cx.update(|_window, app| view.read(app).main_pane.clone());
+    cx.update(|_window, app| {
+        main_pane.update(app, |pane, cx| {
+            pane.file_editor_input.update(cx, |input, cx| {
+                input.replace_utf8_range(0..0, "// saved\n", cx);
+            });
+        });
+    });
+    cx.run_until_parked();
+
+    cx.update(|window, app| {
+        main_pane.update(app, |pane, cx| {
+            pane.save_file_editor_buffer_and_exit(window, cx);
+        });
+    });
+    cx.run_until_parked();
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            crate::view::test_support::sync_store_snapshot(this, cx)
+        });
+    });
+    cx.run_until_parked();
+
+    cx.update(|_window, app| {
+        let pane = main_pane.read(app);
+        assert!(!pane.file_editor_is_dirty());
+        assert!(
+            !pane.is_file_editor_active(),
+            "the toolbar Save action should close edit mode after dispatching the write"
         );
     });
 

--- a/crates/gitcomet-ui-gpui/src/view/panes/main/file_editor.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panes/main/file_editor.rs
@@ -1335,6 +1335,14 @@ impl MainPaneView {
 
         let editor_scroll = self.file_editor_scroll.clone();
         let gutter_scroll = self.file_editor_gutter_scroll.clone();
+        let scrollbar_gutter = components::Scrollbar::visible_gutter(
+            editor_scroll.clone(),
+            components::ScrollbarAxis::Vertical,
+        );
+        let editor_scrollbar =
+            components::Scrollbar::new("file_editor_scrollbar", editor_scroll.clone());
+        #[cfg(test)]
+        let editor_scrollbar = editor_scrollbar.debug_selector("file_editor_scrollbar");
 
         // Copy the editor's offset into the gutter *before* the list lays out,
         // not only after its children prepaint. A wheel event updates the
@@ -1407,26 +1415,38 @@ impl MainPaneView {
             })
             .child(
                 div()
-                    .id("file_editor_scroll")
-                    .debug_selector(|| "file_editor_scroll".to_string())
-                    // flex-col so a content-width input overflows to the right
-                    // instead of being shrunk to the viewport, which is what
-                    // gives the container a horizontal range to scroll. With
-                    // wrap on there is nothing to overflow, and the input is
-                    // stretched to the viewport so it has a width to wrap at.
+                    .relative()
                     .flex()
                     .flex_col()
-                    .when(soft_wrap, |d| d.items_stretch())
-                    .when(!soft_wrap, |d| d.items_start())
-                    .w_full()
+                    .flex_1()
                     .min_w(px(0.0))
                     .h_full()
                     .min_h(px(0.0))
-                    .pl_2()
-                    .when(soft_wrap, |d| d.overflow_y_scroll())
-                    .when(!soft_wrap, |d| d.overflow_scroll())
-                    .track_scroll(&self.file_editor_scroll)
-                    .child(self.file_editor_input.clone()),
+                    .child(
+                        div()
+                            .id("file_editor_scroll")
+                            .debug_selector(|| "file_editor_scroll".to_string())
+                            // flex-col so a content-width input overflows to the
+                            // right instead of being shrunk to the viewport,
+                            // which gives the container a horizontal range.
+                            .flex()
+                            .flex_col()
+                            .when(soft_wrap, |d| d.items_stretch())
+                            .when(!soft_wrap, |d| d.items_start())
+                            .w_full()
+                            .min_w(px(0.0))
+                            .h_full()
+                            .min_h(px(0.0))
+                            .pl_2()
+                            .pr(scrollbar_gutter)
+                            .when(soft_wrap, |d| d.overflow_y_scroll())
+                            .when(!soft_wrap, |d| d.overflow_scroll())
+                            .track_scroll(&self.file_editor_scroll)
+                            .child(self.file_editor_input.clone()),
+                    )
+                    // The track must be outside the moving scroll surface or
+                    // GPUI applies the content offset to the scrollbar itself.
+                    .child(editor_scrollbar.render(theme)),
             )
             .into_any_element()
     }


### PR DESCRIPTION
- Fix an issue where scroll bar was not visible in file edit mode.
- Fix an issue where exiting edit mode always took client back to preview mode.
- Fix an issue with mouse selection flickering in edit mode