### PR TITLE
feat: virtual-branch workspace prototype (per-file/hunk assignment, drag & drop, persistence)

### DIFF
--- a/crates/gitcomet-core/src/domain.rs
+++ b/crates/gitcomet-core/src/domain.rs
@@ -916,6 +916,30 @@ pub struct StashEntry {
     pub created_at: Option<SystemTime>,
 }
 
+/// A virtual branch in the prototype workspace: an in-app grouping of working
+/// tree changes (by path) that can be committed together or moved in/out of the
+/// worktree without touching the real git branch.
+///
+/// `stored_patch` holds the unified diff (worktree + index vs HEAD) captured
+/// when the branch was unapplied, so `apply` can put the changes back. It is
+/// in-memory only for now.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VirtualBranch {
+    pub id: u64,
+    pub name: Arc<str>,
+    /// Paths whose worktree changes belong to this branch. A path can belong to
+    /// at most one virtual branch.
+    pub paths: Vec<std::path::PathBuf>,
+    /// Whether this branch's changes are currently present in the worktree.
+    pub applied: bool,
+    /// Unified diff captured on unapply, re-applied on `apply`. `None` while
+    /// applied.
+    pub stored_patch: Option<Arc<str>>,
+    /// An apply/unapply operation is in flight (drives the spinner and gates
+    /// re-entry).
+    pub pending: bool,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReflogEntry {
     pub index: usize,

--- a/crates/gitcomet-core/src/services.rs
+++ b/crates/gitcomet-core/src/services.rs
@@ -1131,6 +1131,15 @@ pub trait GitRepository: Send + Sync {
         )))
     }
 
+    /// Unified diff of the given paths (worktree + index) against HEAD, used by
+    /// the virtual-branch workspace to capture a branch's changes before
+    /// unapplying them. Empty when the paths have no changes.
+    fn diff_paths_vs_head(&self, _paths: &[std::path::PathBuf]) -> Result<String> {
+        Err(Error::new(ErrorKind::Unsupported(
+            "path diff is not implemented for this backend",
+        )))
+    }
+
     fn list_worktrees(&self) -> Result<Vec<Worktree>> {
         Err(Error::new(ErrorKind::Unsupported(
             "worktree listing is not implemented for this backend",

--- a/crates/gitcomet-git-gix/src/repo/mod.rs
+++ b/crates/gitcomet-git-gix/src/repo/mod.rs
@@ -937,6 +937,10 @@ impl GitRepository for GixRepo {
         self.apply_unified_patch_to_worktree_with_output_impl(patch, reverse)
     }
 
+    fn diff_paths_vs_head(&self, paths: &[std::path::PathBuf]) -> Result<String> {
+        self.diff_paths_vs_head_impl(paths)
+    }
+
     fn list_worktrees(&self) -> Result<Vec<Worktree>> {
         self.list_worktrees_impl()
     }

--- a/crates/gitcomet-git-gix/src/repo/patch.rs
+++ b/crates/gitcomet-git-gix/src/repo/patch.rs
@@ -66,6 +66,15 @@ impl GixRepo {
         run_git_with_output(cmd, &label)
     }
 
+    pub(super) fn diff_paths_vs_head_impl(&self, paths: &[std::path::PathBuf]) -> Result<String> {
+        let mut cmd = self.git_workdir_cmd();
+        cmd.arg("diff").arg("HEAD").arg("--");
+        for path in paths {
+            cmd.arg(path);
+        }
+        run_git_capture(cmd, "git diff HEAD -- <paths>")
+    }
+
     pub(super) fn apply_unified_patch_to_worktree_with_output_impl(
         &self,
         patch: &str,

--- a/crates/gitcomet-state/src/model.rs
+++ b/crates/gitcomet-state/src/model.rs
@@ -2109,6 +2109,33 @@ impl<T> Loadable<T> {
     }
 }
 
+/// Virtual branches whose assigned paths no longer have any changes in the
+/// worktree (unstaged or staged) and that hold no parked patch. Such a branch
+/// is purely leftover accounting: its changes were committed, discarded, or
+/// reverted outside the virtual-branch flow. Branches with a parked
+/// `stored_patch` are never stale (their hunks are recoverable by applying).
+pub fn stale_virtual_branch_ids(repo: &RepoState) -> Vec<u64> {
+    let mut changed_paths: HashSet<&std::path::Path> = HashSet::default();
+    for loaded in [&repo.worktree_status, &repo.staged_status] {
+        if let Loadable::Ready(entries) = loaded {
+            for entry in entries.iter() {
+                changed_paths.insert(entry.path.as_path());
+            }
+        }
+    }
+    repo.virtual_branches
+        .iter()
+        .filter(|branch| {
+            branch.stored_patch.is_none()
+                && branch
+                    .paths
+                    .iter()
+                    .all(|path| !changed_paths.contains(path.as_path()))
+        })
+        .map(|branch| branch.id)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gitcomet-state/src/model.rs
+++ b/crates/gitcomet-state/src/model.rs
@@ -1175,6 +1175,12 @@ pub struct RepoState {
     pub stashes: Loadable<Arc<Vec<StashEntry>>>,
     pub stashes_rev: u64,
     pub reflog: Loadable<Vec<ReflogEntry>>,
+    /// Prototype virtual-branch workspace: in-app groupings of worktree paths.
+    /// Transient (not persisted to session yet).
+    pub virtual_branches: Vec<VirtualBranch>,
+    pub next_virtual_branch_id: u64,
+    /// Bumped on every virtual-branch mutation; drives sidebar row caching.
+    pub virtual_branches_rev: u64,
     pub recent_commit_messages: Loadable<Arc<Vec<RecentCommitMessage>>>,
     pub recent_commit_messages_rev: u64,
     pub rebase_in_progress: Loadable<bool>,
@@ -1293,6 +1299,9 @@ impl RepoState {
             stashes: Loadable::NotLoaded,
             stashes_rev: 0,
             reflog: Loadable::NotLoaded,
+            virtual_branches: Vec::new(),
+            next_virtual_branch_id: 1,
+            virtual_branches_rev: 0,
             recent_commit_messages: Loadable::NotLoaded,
             recent_commit_messages_rev: 0,
             rebase_in_progress: Loadable::NotLoaded,

--- a/crates/gitcomet-state/src/msg/effect.rs
+++ b/crates/gitcomet-state/src/msg/effect.rs
@@ -37,6 +37,14 @@ pub enum Effect {
         author: Option<String>,
         action: &'static str,
     },
+    /// Persists the virtual branch workspace (path assignments + parked
+    /// patches) for a repo, keyed by workdir in the session file.
+    PersistVirtualBranches {
+        repo_id: Option<RepoId>,
+        workdir: PathBuf,
+        data: crate::session::VirtualBranchesSessionFile,
+        action: &'static str,
+    },
     OpenRepo {
         repo_id: RepoId,
         path: PathBuf,

--- a/crates/gitcomet-state/src/msg/effect.rs
+++ b/crates/gitcomet-state/src/msg/effect.rs
@@ -107,6 +107,16 @@ pub enum Effect {
         branch_id: u64,
         patch: String,
     },
+    /// Reverse-apply a single hunk patch to the worktree (removing the hunk's
+    /// changes) so the hunk can be parked in the branch's stored patch. The
+    /// path is echoed back in the completion message so the reducer can assign
+    /// the file to the branch only on success.
+    MoveHunkToVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+        patch: String,
+        path: std::path::PathBuf,
+    },
     LoadRecentCommitMessages {
         repo_id: RepoId,
         limit: usize,

--- a/crates/gitcomet-state/src/msg/effect.rs
+++ b/crates/gitcomet-state/src/msg/effect.rs
@@ -94,6 +94,19 @@ pub enum Effect {
         repo_id: RepoId,
         limit: usize,
     },
+    /// Capture the branch's diff (worktree + index vs HEAD) and reverse-apply
+    /// it so the changes leave the worktree.
+    UnapplyVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+        paths: Vec<std::path::PathBuf>,
+    },
+    /// Re-apply a previously captured branch diff to the worktree.
+    ApplyVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+        patch: String,
+    },
     LoadRecentCommitMessages {
         repo_id: RepoId,
         limit: usize,

--- a/crates/gitcomet-state/src/msg/message.rs
+++ b/crates/gitcomet-state/src/msg/message.rs
@@ -771,6 +771,16 @@ pub enum Msg {
         repo_id: RepoId,
         branch_id: u64,
     },
+    /// Moves a single diff hunk out of the worktree into a virtual branch's
+    /// parked patch collection. The patch is built by the UI from the loaded
+    /// diff (`build_unified_patch_for_hunk_src_ix`) and reverse-applied to the
+    /// worktree by the worker; on success it is recorded in `stored_patch`.
+    MoveHunkToVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+        patch: String,
+        path: std::path::PathBuf,
+    },
     /// Builds the squash message preview for the current multi-selection so
     /// the squash prompt can prefill its message input.
     PrepareSquash {
@@ -1110,6 +1120,15 @@ pub enum InternalMsg {
         repo_id: RepoId,
         branch_id: u64,
         result: Result<(), Error>,
+    },
+    /// Result of a hunk move. `Ok(patch)` is the patch that was successfully
+    /// reverse-applied; the reducer records it (and the hunk's path) in the
+    /// branch's parked patch collection.
+    VirtualBranchHunkMoved {
+        repo_id: RepoId,
+        branch_id: u64,
+        path: std::path::PathBuf,
+        result: Result<String, Error>,
     },
     RecentCommitMessagesLoaded {
         repo_id: RepoId,

--- a/crates/gitcomet-state/src/msg/message.rs
+++ b/crates/gitcomet-state/src/msg/message.rs
@@ -738,6 +738,39 @@ pub enum Msg {
         target: String,
         mode: ResetMode,
     },
+    CreateVirtualBranch {
+        repo_id: RepoId,
+        name: String,
+    },
+    RenameVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+        name: String,
+    },
+    DeleteVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+    },
+    /// Moves `path` into the branch: it is removed from every other virtual
+    /// branch first, since a path belongs to at most one.
+    AssignPathToVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+        path: std::path::PathBuf,
+    },
+    UnassignPathFromVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+        path: std::path::PathBuf,
+    },
+    UnapplyVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+    },
+    ApplyVirtualBranch {
+        repo_id: RepoId,
+        branch_id: u64,
+    },
     /// Builds the squash message preview for the current multi-selection so
     /// the squash prompt can prefill its message input.
     PrepareSquash {
@@ -1066,6 +1099,17 @@ pub enum InternalMsg {
     ReflogLoaded {
         repo_id: RepoId,
         result: Result<Vec<ReflogEntry>, Error>,
+    },
+    VirtualBranchUnapplied {
+        repo_id: RepoId,
+        branch_id: u64,
+        /// Ok(patch) is the captured unified diff, stored for re-apply.
+        result: Result<String, Error>,
+    },
+    VirtualBranchApplied {
+        repo_id: RepoId,
+        branch_id: u64,
+        result: Result<(), Error>,
     },
     RecentCommitMessagesLoaded {
         repo_id: RepoId,

--- a/crates/gitcomet-state/src/msg/message.rs
+++ b/crates/gitcomet-state/src/msg/message.rs
@@ -781,6 +781,12 @@ pub enum Msg {
         patch: String,
         path: std::path::PathBuf,
     },
+    /// Removes the given virtual branches (computed stale by the UI via
+    /// `stale_virtual_branch_ids` and confirmed by the user).
+    PruneVirtualBranches {
+        repo_id: RepoId,
+        branch_ids: Vec<u64>,
+    },
     /// Builds the squash message preview for the current multi-selection so
     /// the squash prompt can prefill its message input.
     PrepareSquash {

--- a/crates/gitcomet-state/src/msg/message_debug.rs
+++ b/crates/gitcomet-state/src/msg/message_debug.rs
@@ -156,6 +156,18 @@ impl std::fmt::Debug for InternalMsg {
                 .field("branch_id", branch_id)
                 .field("result", result)
                 .finish(),
+            InternalMsg::VirtualBranchHunkMoved {
+                repo_id,
+                branch_id,
+                path,
+                result,
+            } => f
+                .debug_struct("VirtualBranchHunkMoved")
+                .field("repo_id", repo_id)
+                .field("branch_id", branch_id)
+                .field("path", path)
+                .field("result", result)
+                .finish(),
             InternalMsg::RecentCommitMessagesLoaded {
                 repo_id,
                 request_rev,

--- a/crates/gitcomet-state/src/msg/message_debug.rs
+++ b/crates/gitcomet-state/src/msg/message_debug.rs
@@ -136,6 +136,26 @@ impl std::fmt::Debug for InternalMsg {
                 .field("repo_id", repo_id)
                 .field("result", result)
                 .finish(),
+            InternalMsg::VirtualBranchUnapplied {
+                repo_id,
+                branch_id,
+                result,
+            } => f
+                .debug_struct("VirtualBranchUnapplied")
+                .field("repo_id", repo_id)
+                .field("branch_id", branch_id)
+                .field("result", result)
+                .finish(),
+            InternalMsg::VirtualBranchApplied {
+                repo_id,
+                branch_id,
+                result,
+            } => f
+                .debug_struct("VirtualBranchApplied")
+                .field("repo_id", repo_id)
+                .field("branch_id", branch_id)
+                .field("result", result)
+                .finish(),
             InternalMsg::RecentCommitMessagesLoaded {
                 repo_id,
                 request_rev,

--- a/crates/gitcomet-state/src/session.rs
+++ b/crates/gitcomet-state/src/session.rs
@@ -267,11 +267,7 @@ impl From<&VirtualBranchSessionFile> for gitcomet_core::domain::VirtualBranch {
         VirtualBranch {
             id: file.id,
             name: file.name.clone().into(),
-            paths: file
-                .paths
-                .iter()
-                .map(std::path::PathBuf::from)
-                .collect(),
+            paths: file.paths.iter().map(std::path::PathBuf::from).collect(),
             applied: file.applied,
             stored_patch: file.stored_patch.clone().map(Into::into),
             // Restored branches are never mid-operation.

--- a/crates/gitcomet-state/src/session.rs
+++ b/crates/gitcomet-state/src/session.rs
@@ -218,7 +218,66 @@ struct UiSessionFile {
     repo_history_scopes: Option<BTreeMap<String, HistoryScopeSetting>>,
     repo_history_author_filters: Option<BTreeMap<String, Option<String>>>,
     repo_fetch_prune_deleted_remote_tracking_branches: Option<BTreeMap<String, bool>>,
+    virtual_branches: Option<BTreeMap<String, VirtualBranchesSessionFile>>,
     survey_prompt: Option<SurveyPromptSession>,
+}
+
+/// One persisted virtual branch (prototype workspace): the accounting of which
+/// worktree paths belong to the branch plus any parked unified patch.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VirtualBranchSessionFile {
+    pub id: u64,
+    pub name: String,
+    /// Repo-relative paths assigned to the branch.
+    pub paths: Vec<String>,
+    /// Whether the branch's changes are present in the worktree. Persisted so
+    /// unapplied branches (parked patches) restore as unapplied.
+    pub applied: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stored_patch: Option<String>,
+}
+
+/// Per-repo persisted virtual branch workspace: the next id allocator plus the
+/// branch list.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VirtualBranchesSessionFile {
+    pub next_id: u64,
+    pub branches: Vec<VirtualBranchSessionFile>,
+}
+
+impl From<&gitcomet_core::domain::VirtualBranch> for VirtualBranchSessionFile {
+    fn from(branch: &gitcomet_core::domain::VirtualBranch) -> Self {
+        Self {
+            id: branch.id,
+            name: branch.name.to_string(),
+            paths: branch
+                .paths
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect(),
+            applied: branch.applied,
+            stored_patch: branch.stored_patch.as_deref().map(ToOwned::to_owned),
+        }
+    }
+}
+
+impl From<&VirtualBranchSessionFile> for gitcomet_core::domain::VirtualBranch {
+    fn from(file: &VirtualBranchSessionFile) -> Self {
+        use gitcomet_core::domain::VirtualBranch;
+        VirtualBranch {
+            id: file.id,
+            name: file.name.clone().into(),
+            paths: file
+                .paths
+                .iter()
+                .map(std::path::PathBuf::from)
+                .collect(),
+            applied: file.applied,
+            stored_patch: file.stored_patch.clone().map(Into::into),
+            // Restored branches are never mid-operation.
+            pending: false,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -349,6 +408,7 @@ pub(crate) struct RepoSessionPreferences {
     pub(crate) repo_history_scopes: BTreeMap<String, LogScope>,
     pub(crate) repo_history_author_filters: BTreeMap<String, Option<String>>,
     pub(crate) repo_fetch_prune_deleted_remote_tracking_branches: BTreeMap<String, bool>,
+    pub(crate) virtual_branches: BTreeMap<String, VirtualBranchesSessionFile>,
 }
 
 pub(crate) fn load_repo_session_preferences() -> RepoSessionPreferences {
@@ -383,6 +443,7 @@ pub(crate) fn load_repo_session_preferences_from_path(
         repo_fetch_prune_deleted_remote_tracking_branches: file
             .repo_fetch_prune_deleted_remote_tracking_branches
             .unwrap_or_default(),
+        virtual_branches: file.virtual_branches.unwrap_or_default(),
     }
 }
 
@@ -1194,6 +1255,34 @@ pub fn persist_repo_history_author_filter_to_path(
             stored.insert(workdir_key, Some(author.to_owned()));
         } else {
             stored.remove(&workdir_key);
+        }
+        file.version = CURRENT_SESSION_FILE_VERSION;
+        persist_to_path(session_file_path, &file)
+    })
+}
+
+/// Persists the virtual branch workspace for `workdir`. An empty branch list
+/// removes the stored workspace for the repo (nothing to restore).
+pub fn persist_virtual_branches_to_path(
+    workdir: &Path,
+    data: &VirtualBranchesSessionFile,
+    session_file_path: &Path,
+) -> io::Result<()> {
+    with_session_file_persist_lock(|| {
+        let mut file = load_file(session_file_path).unwrap_or_default();
+        let workdir_key = path_storage_key(workdir);
+        let stored = file.virtual_branches.get_or_insert_with(BTreeMap::new);
+        let unchanged = stored.get(&workdir_key) == Some(data);
+        if unchanged {
+            return Ok(());
+        }
+        if data.branches.is_empty() {
+            stored.remove(&workdir_key);
+            if stored.is_empty() {
+                file.virtual_branches = None;
+            }
+        } else {
+            stored.insert(workdir_key, data.clone());
         }
         file.version = CURRENT_SESSION_FILE_VERSION;
         persist_to_path(session_file_path, &file)
@@ -2061,6 +2150,76 @@ mod tests {
                 .get(&path_storage_key(&repo_fetch)),
             Some(&true)
         );
+    }
+
+    #[test]
+    fn persist_virtual_branches_round_trips_workspace() {
+        let dir = unique_session_test_dir("virtual-branches");
+        let session_file = dir.join("session.json");
+        let repo = dir.join("repo");
+        let _ = fs::create_dir_all(&repo);
+        let repo_key = path_storage_key(&repo);
+
+        let data = VirtualBranchesSessionFile {
+            next_id: 3,
+            branches: vec![
+                VirtualBranchSessionFile {
+                    id: 1,
+                    name: "feature".into(),
+                    paths: vec!["src/lib.rs".into()],
+                    applied: false,
+                    stored_patch: Some(
+                        "diff --git a/src/lib.rs b/src/lib.rs\n@@ -1,1 +1,1 @@\n-foo\n+bar\n"
+                            .into(),
+                    ),
+                },
+                VirtualBranchSessionFile {
+                    id: 2,
+                    name: "fix".into(),
+                    paths: vec![],
+                    applied: true,
+                    stored_patch: None,
+                },
+            ],
+        };
+        persist_virtual_branches_to_path(&repo, &data, &session_file).expect("persist workspace");
+
+        let loaded = load_repo_session_preferences_from_path(&session_file);
+        assert_eq!(loaded.virtual_branches.get(&repo_key), Some(&data));
+
+        // An empty branch list removes the stored workspace for the repo.
+        persist_virtual_branches_to_path(
+            &repo,
+            &VirtualBranchesSessionFile::default(),
+            &session_file,
+        )
+        .expect("clear workspace");
+        let loaded = load_repo_session_preferences_from_path(&session_file);
+        assert!(loaded.virtual_branches.is_empty());
+    }
+
+    #[test]
+    fn virtual_branch_session_conversion_round_trips_domain() {
+        let file = VirtualBranchSessionFile {
+            id: 7,
+            name: "feature".into(),
+            paths: vec!["src/lib.rs".into(), "README.md".into()],
+            applied: false,
+            stored_patch: Some("patch text".into()),
+        };
+        let branch: gitcomet_core::domain::VirtualBranch = (&file).into();
+        assert_eq!(branch.id, 7);
+        assert_eq!(branch.name.as_ref(), "feature");
+        assert_eq!(
+            branch.paths,
+            vec![PathBuf::from("src/lib.rs"), PathBuf::from("README.md")]
+        );
+        assert!(!branch.applied);
+        assert_eq!(branch.stored_patch.as_deref(), Some("patch text"));
+        assert!(!branch.pending);
+
+        let back = VirtualBranchSessionFile::from(&branch);
+        assert_eq!(back, file);
     }
 
     #[test]

--- a/crates/gitcomet-state/src/store/effects.rs
+++ b/crates/gitcomet-state/src/store/effects.rs
@@ -349,9 +349,7 @@ fn send_unavailable_git_effect_result(
             }))
         }
         Effect::UnapplyVirtualBranch {
-            repo_id,
-            branch_id,
-            ..
+            repo_id, branch_id, ..
         } => send(Msg::Internal(
             crate::msg::InternalMsg::VirtualBranchUnapplied {
                 repo_id,
@@ -360,25 +358,27 @@ fn send_unavailable_git_effect_result(
             },
         )),
         Effect::ApplyVirtualBranch {
-            repo_id,
-            branch_id,
-            ..
-        } => send(Msg::Internal(crate::msg::InternalMsg::VirtualBranchApplied {
-            repo_id,
-            branch_id,
-            result: Err(git_unavailable_error(runtime)),
-        })),
+            repo_id, branch_id, ..
+        } => send(Msg::Internal(
+            crate::msg::InternalMsg::VirtualBranchApplied {
+                repo_id,
+                branch_id,
+                result: Err(git_unavailable_error(runtime)),
+            },
+        )),
         Effect::MoveHunkToVirtualBranch {
             repo_id,
             branch_id,
             path,
             ..
-        } => send(Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
-            repo_id,
-            branch_id,
-            path: path.clone(),
-            result: Err(git_unavailable_error(runtime)),
-        })),
+        } => send(Msg::Internal(
+            crate::msg::InternalMsg::VirtualBranchHunkMoved {
+                repo_id,
+                branch_id,
+                path: path.clone(),
+                result: Err(git_unavailable_error(runtime)),
+            },
+        )),
         Effect::LoadRecentCommitMessages {
             repo_id,
             request_rev,
@@ -1502,11 +1502,9 @@ pub(super) fn schedule_effect(
                 return;
             };
             session_persist_executor.spawn(move || {
-                if let Err(error) = session::persist_virtual_branches_to_path(
-                    &workdir,
-                    &data,
-                    &session_file_path,
-                ) {
+                if let Err(error) =
+                    session::persist_virtual_branches_to_path(&workdir, &data, &session_file_path)
+                {
                     util::send_or_log(
                         &msg_tx,
                         Msg::Internal(crate::msg::InternalMsg::SessionPersistFailed {
@@ -1751,12 +1749,7 @@ pub(super) fn schedule_effect(
                 repo_load_context(thread_state, repo_task_tokens, msg_tx, repo_id)
             {
                 repo_load::schedule_unapply_virtual_branch(
-                    executor,
-                    repos,
-                    msg_tx,
-                    repo_id,
-                    branch_id,
-                    paths,
+                    executor, repos, msg_tx, repo_id, branch_id, paths,
                 );
             }
         }
@@ -1769,12 +1762,7 @@ pub(super) fn schedule_effect(
                 repo_load_context(thread_state, repo_task_tokens, msg_tx, repo_id)
             {
                 repo_load::schedule_apply_virtual_branch(
-                    executor,
-                    repos,
-                    msg_tx,
-                    repo_id,
-                    branch_id,
-                    patch,
+                    executor, repos, msg_tx, repo_id, branch_id, patch,
                 );
             }
         }
@@ -1788,13 +1776,7 @@ pub(super) fn schedule_effect(
                 repo_load_context(thread_state, repo_task_tokens, msg_tx, repo_id)
             {
                 repo_load::schedule_move_hunk_to_virtual_branch(
-                    executor,
-                    repos,
-                    msg_tx,
-                    repo_id,
-                    branch_id,
-                    patch,
-                    path,
+                    executor, repos, msg_tx, repo_id, branch_id, patch, path,
                 );
             }
         }

--- a/crates/gitcomet-state/src/store/effects.rs
+++ b/crates/gitcomet-state/src/store/effects.rs
@@ -366,6 +366,17 @@ fn send_unavailable_git_effect_result(
             branch_id,
             result: Err(git_unavailable_error(runtime)),
         })),
+        Effect::MoveHunkToVirtualBranch {
+            repo_id,
+            branch_id,
+            path,
+            ..
+        } => send(Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
+            repo_id,
+            branch_id,
+            path: path.clone(),
+            result: Err(git_unavailable_error(runtime)),
+        })),
         Effect::LoadRecentCommitMessages {
             repo_id,
             request_rev,
@@ -1736,6 +1747,26 @@ pub(super) fn schedule_effect(
                     repo_id,
                     branch_id,
                     patch,
+                );
+            }
+        }
+        Effect::MoveHunkToVirtualBranch {
+            repo_id,
+            branch_id,
+            patch,
+            path,
+        } => {
+            if let Some((msg_tx, _)) =
+                repo_load_context(thread_state, repo_task_tokens, msg_tx, repo_id)
+            {
+                repo_load::schedule_move_hunk_to_virtual_branch(
+                    executor,
+                    repos,
+                    msg_tx,
+                    repo_id,
+                    branch_id,
+                    patch,
+                    path,
                 );
             }
         }

--- a/crates/gitcomet-state/src/store/effects.rs
+++ b/crates/gitcomet-state/src/store/effects.rs
@@ -346,6 +346,26 @@ fn send_unavailable_git_effect_result(
                 result: Err(git_unavailable_error(runtime)),
             }))
         }
+        Effect::UnapplyVirtualBranch {
+            repo_id,
+            branch_id,
+            ..
+        } => send(Msg::Internal(
+            crate::msg::InternalMsg::VirtualBranchUnapplied {
+                repo_id,
+                branch_id,
+                result: Err(git_unavailable_error(runtime)),
+            },
+        )),
+        Effect::ApplyVirtualBranch {
+            repo_id,
+            branch_id,
+            ..
+        } => send(Msg::Internal(crate::msg::InternalMsg::VirtualBranchApplied {
+            repo_id,
+            branch_id,
+            result: Err(git_unavailable_error(runtime)),
+        })),
         Effect::LoadRecentCommitMessages {
             repo_id,
             request_rev,
@@ -1681,6 +1701,42 @@ pub(super) fn schedule_effect(
                 repo_load_context(thread_state, repo_task_tokens, msg_tx, repo_id)
             {
                 repo_load::schedule_load_reflog(executor, repos, msg_tx, repo_id, limit);
+            }
+        }
+        Effect::UnapplyVirtualBranch {
+            repo_id,
+            branch_id,
+            paths,
+        } => {
+            if let Some((msg_tx, _)) =
+                repo_load_context(thread_state, repo_task_tokens, msg_tx, repo_id)
+            {
+                repo_load::schedule_unapply_virtual_branch(
+                    executor,
+                    repos,
+                    msg_tx,
+                    repo_id,
+                    branch_id,
+                    paths,
+                );
+            }
+        }
+        Effect::ApplyVirtualBranch {
+            repo_id,
+            branch_id,
+            patch,
+        } => {
+            if let Some((msg_tx, _)) =
+                repo_load_context(thread_state, repo_task_tokens, msg_tx, repo_id)
+            {
+                repo_load::schedule_apply_virtual_branch(
+                    executor,
+                    repos,
+                    msg_tx,
+                    repo_id,
+                    branch_id,
+                    patch,
+                );
             }
         }
         Effect::SaveWorktreeFile {

--- a/crates/gitcomet-state/src/store/effects.rs
+++ b/crates/gitcomet-state/src/store/effects.rs
@@ -206,6 +206,7 @@ fn effect_requires_available_git(effect: &Effect) -> bool {
             | Effect::PersistRecentRepo { .. }
             | Effect::PersistRepoHistoryMode { .. }
             | Effect::PersistRepoHistoryModesBatch { .. }
+            | Effect::PersistVirtualBranches { .. }
             | Effect::CancelRepoLoads { .. }
             | Effect::AbortCloneRepo { .. }
     )
@@ -247,6 +248,7 @@ fn send_unavailable_git_effect_result(
         | Effect::PersistRepoHistoryMode { .. }
         | Effect::PersistRepoHistoryModesBatch { .. }
         | Effect::PersistRepoHistoryAuthorFilter { .. }
+        | Effect::PersistVirtualBranches { .. }
         | Effect::CancelRepoLoads { .. } => {}
         Effect::OpenRepo { repo_id, path } => {
             send(Msg::Internal(crate::msg::InternalMsg::RepoOpenedErr {
@@ -1479,6 +1481,32 @@ pub(super) fn schedule_effect(
                 if let Err(error) =
                     session::persist_repo_history_modes_batch_to_path(&updates, &session_file_path)
                 {
+                    util::send_or_log(
+                        &msg_tx,
+                        Msg::Internal(crate::msg::InternalMsg::SessionPersistFailed {
+                            repo_id,
+                            action,
+                            error: error.to_string(),
+                        }),
+                    );
+                }
+            });
+        }
+        Effect::PersistVirtualBranches {
+            repo_id,
+            workdir,
+            data,
+            action,
+        } => {
+            let Some(session_file_path) = session::default_session_file_path_for_effect() else {
+                return;
+            };
+            session_persist_executor.spawn(move || {
+                if let Err(error) = session::persist_virtual_branches_to_path(
+                    &workdir,
+                    &data,
+                    &session_file_path,
+                ) {
                     util::send_or_log(
                         &msg_tx,
                         Msg::Internal(crate::msg::InternalMsg::SessionPersistFailed {

--- a/crates/gitcomet-state/src/store/effects/repo_load.rs
+++ b/crates/gitcomet-state/src/store/effects/repo_load.rs
@@ -849,6 +849,91 @@ pub(super) fn schedule_load_reflog(
     );
 }
 
+pub(super) fn schedule_unapply_virtual_branch(
+    executor: &TaskExecutor,
+    repos: &RepoMap,
+    msg_tx: StoreWorkerSender,
+    repo_id: RepoId,
+    branch_id: u64,
+    paths: Vec<std::path::PathBuf>,
+) {
+    spawn_with_repo_or_else(
+        executor,
+        repos,
+        repo_id,
+        msg_tx,
+        move |repo, msg_tx| {
+            let result = repo.diff_paths_vs_head(&paths).and_then(|patch| {
+                if patch.trim().is_empty() {
+                    return Ok(patch);
+                }
+                repo.apply_unified_patch_to_worktree_with_output(&patch, true)
+                    .map(|_| patch)
+            });
+            send_or_log(
+                &msg_tx,
+                Msg::Internal(crate::msg::InternalMsg::VirtualBranchUnapplied {
+                    repo_id,
+                    branch_id,
+                    result,
+                }),
+            );
+        },
+        move |msg_tx| {
+            send_or_log(
+                &msg_tx,
+                Msg::Internal(crate::msg::InternalMsg::VirtualBranchUnapplied {
+                    repo_id,
+                    branch_id,
+                    result: Err(missing_repo_error(repo_id)),
+                }),
+            );
+        },
+    );
+}
+
+pub(super) fn schedule_apply_virtual_branch(
+    executor: &TaskExecutor,
+    repos: &RepoMap,
+    msg_tx: StoreWorkerSender,
+    repo_id: RepoId,
+    branch_id: u64,
+    patch: String,
+) {
+    spawn_with_repo_or_else(
+        executor,
+        repos,
+        repo_id,
+        msg_tx,
+        move |repo, msg_tx| {
+            let result = if patch.trim().is_empty() {
+                Ok(())
+            } else {
+                repo.apply_unified_patch_to_worktree_with_output(&patch, false)
+                    .map(|_| ())
+            };
+            send_or_log(
+                &msg_tx,
+                Msg::Internal(crate::msg::InternalMsg::VirtualBranchApplied {
+                    repo_id,
+                    branch_id,
+                    result,
+                }),
+            );
+        },
+        move |msg_tx| {
+            send_or_log(
+                &msg_tx,
+                Msg::Internal(crate::msg::InternalMsg::VirtualBranchApplied {
+                    repo_id,
+                    branch_id,
+                    result: Err(missing_repo_error(repo_id)),
+                }),
+            );
+        },
+    );
+}
+
 pub(super) fn schedule_load_file_history(
     executor: &TaskExecutor,
     repos: &RepoMap,

--- a/crates/gitcomet-state/src/store/effects/repo_load.rs
+++ b/crates/gitcomet-state/src/store/effects/repo_load.rs
@@ -934,6 +934,54 @@ pub(super) fn schedule_apply_virtual_branch(
     );
 }
 
+pub(super) fn schedule_move_hunk_to_virtual_branch(
+    executor: &TaskExecutor,
+    repos: &RepoMap,
+    msg_tx: StoreWorkerSender,
+    repo_id: RepoId,
+    branch_id: u64,
+    patch: String,
+    path: PathBuf,
+) {
+    let path_for_missing_repo = path.clone();
+    spawn_with_repo_or_else(
+        executor,
+        repos,
+        repo_id,
+        msg_tx,
+        move |repo, msg_tx| {
+            let result = if patch.trim().is_empty() {
+                Err(Error::new(ErrorKind::Backend(
+                    "Cannot move an empty hunk patch".to_string(),
+                )))
+            } else {
+                repo.apply_unified_patch_to_worktree_with_output(&patch, true)
+                    .map(|_| patch)
+            };
+            send_or_log(
+                &msg_tx,
+                Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
+                    repo_id,
+                    branch_id,
+                    path,
+                    result,
+                }),
+            );
+        },
+        move |msg_tx| {
+            send_or_log(
+                &msg_tx,
+                Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
+                    repo_id,
+                    branch_id,
+                    path: path_for_missing_repo,
+                    result: Err(missing_repo_error(repo_id)),
+                }),
+            );
+        },
+    );
+}
+
 pub(super) fn schedule_load_file_history(
     executor: &TaskExecutor,
     repos: &RepoMap,

--- a/crates/gitcomet-state/src/store/reducer.rs
+++ b/crates/gitcomet-state/src/store/reducer.rs
@@ -5,6 +5,7 @@ mod effects;
 mod external_and_history;
 mod repo_management;
 mod util;
+mod virtual_branches;
 
 use crate::model::{
     AppState, AuthPromptState, AuthRetryOperation, BannerErrorState, PendingCommitRetry, RepoId,
@@ -1024,6 +1025,33 @@ fn reduce_inner(
         Msg::LoadHoverCommitMessage { repo_id, commit_id } => {
             effects::load_hover_commit_message(state, repo_id, commit_id)
         }
+        Msg::CreateVirtualBranch { repo_id, name } => {
+            virtual_branches::create_virtual_branch(state, repo_id, name)
+        }
+        Msg::RenameVirtualBranch {
+            repo_id,
+            branch_id,
+            name,
+        } => virtual_branches::rename_virtual_branch(state, repo_id, branch_id, name),
+        Msg::DeleteVirtualBranch { repo_id, branch_id } => {
+            virtual_branches::delete_virtual_branch(state, repo_id, branch_id)
+        }
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id,
+            path,
+        } => virtual_branches::assign_path_to_virtual_branch(state, repo_id, branch_id, path),
+        Msg::UnassignPathFromVirtualBranch {
+            repo_id,
+            branch_id,
+            path,
+        } => virtual_branches::unassign_path_from_virtual_branch(state, repo_id, branch_id, path),
+        Msg::UnapplyVirtualBranch { repo_id, branch_id } => {
+            virtual_branches::unapply_virtual_branch(state, repo_id, branch_id)
+        }
+        Msg::ApplyVirtualBranch { repo_id, branch_id } => {
+            virtual_branches::apply_virtual_branch(state, repo_id, branch_id)
+        }
         Msg::LoadRecentCommitMessages { repo_id, limit } => {
             effects::load_recent_commit_messages(state, repo_id, limit)
         }
@@ -1936,6 +1964,16 @@ fn reduce_inner(
         Msg::Internal(crate::msg::InternalMsg::ReflogLoaded { repo_id, result }) => {
             effects::reflog_loaded(state, repo_id, result)
         }
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchUnapplied {
+            repo_id,
+            branch_id,
+            result,
+        }) => virtual_branches::virtual_branch_unapplied(state, repo_id, branch_id, result),
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchApplied {
+            repo_id,
+            branch_id,
+            result,
+        }) => virtual_branches::virtual_branch_applied(state, repo_id, branch_id, result),
         Msg::Internal(crate::msg::InternalMsg::RebaseStateLoaded { repo_id, result }) => {
             external_and_history::rebase_state_loaded(state, repo_id, result)
         }

--- a/crates/gitcomet-state/src/store/reducer.rs
+++ b/crates/gitcomet-state/src/store/reducer.rs
@@ -1052,6 +1052,12 @@ fn reduce_inner(
         Msg::ApplyVirtualBranch { repo_id, branch_id } => {
             virtual_branches::apply_virtual_branch(state, repo_id, branch_id)
         }
+        Msg::MoveHunkToVirtualBranch {
+            repo_id,
+            branch_id,
+            patch,
+            path,
+        } => virtual_branches::move_hunk_to_virtual_branch(state, repo_id, branch_id, patch, path),
         Msg::LoadRecentCommitMessages { repo_id, limit } => {
             effects::load_recent_commit_messages(state, repo_id, limit)
         }
@@ -1974,6 +1980,12 @@ fn reduce_inner(
             branch_id,
             result,
         }) => virtual_branches::virtual_branch_applied(state, repo_id, branch_id, result),
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
+            repo_id,
+            branch_id,
+            path,
+            result,
+        }) => virtual_branches::virtual_branch_hunk_moved(state, repo_id, branch_id, path, result),
         Msg::Internal(crate::msg::InternalMsg::RebaseStateLoaded { repo_id, result }) => {
             external_and_history::rebase_state_loaded(state, repo_id, result)
         }

--- a/crates/gitcomet-state/src/store/reducer.rs
+++ b/crates/gitcomet-state/src/store/reducer.rs
@@ -1058,6 +1058,10 @@ fn reduce_inner(
             patch,
             path,
         } => virtual_branches::move_hunk_to_virtual_branch(state, repo_id, branch_id, patch, path),
+        Msg::PruneVirtualBranches {
+            repo_id,
+            branch_ids,
+        } => virtual_branches::prune_virtual_branches(state, repo_id, branch_ids),
         Msg::LoadRecentCommitMessages { repo_id, limit } => {
             effects::load_recent_commit_messages(state, repo_id, limit)
         }

--- a/crates/gitcomet-state/src/store/reducer/repo_management.rs
+++ b/crates/gitcomet-state/src/store/reducer/repo_management.rs
@@ -91,11 +91,7 @@ fn restore_virtual_branches_from_session(
     let Some(data) = session_preferences.virtual_branches.get(workdir_key) else {
         return;
     };
-    repo_state.virtual_branches = data
-        .branches
-        .iter()
-        .map(Into::into)
-        .collect::<Vec<_>>();
+    repo_state.virtual_branches = data.branches.iter().map(Into::into).collect::<Vec<_>>();
     repo_state.next_virtual_branch_id = data.next_id.max(
         repo_state
             .virtual_branches
@@ -504,7 +500,11 @@ pub(super) fn restore_session(
             {
                 repo_state.fetch_prune_deleted_remote_tracking_branches = enabled;
             }
-            restore_virtual_branches_from_session(&mut repo_state, &session_preferences, &workdir_key);
+            restore_virtual_branches_from_session(
+                &mut repo_state,
+                &session_preferences,
+                &workdir_key,
+            );
             repo_state
         };
         repo_state.set_open(Loadable::NotLoaded);

--- a/crates/gitcomet-state/src/store/reducer/repo_management.rs
+++ b/crates/gitcomet-state/src/store/reducer/repo_management.rs
@@ -81,6 +81,31 @@ fn persist_session_effect(
     Effect::PersistSession { repo_id, action }
 }
 
+/// Restores the persisted virtual branch workspace (path assignments + parked
+/// patches) onto a freshly opened repo state.
+fn restore_virtual_branches_from_session(
+    repo_state: &mut crate::model::RepoState,
+    session_preferences: &session::RepoSessionPreferences,
+    workdir_key: &str,
+) {
+    let Some(data) = session_preferences.virtual_branches.get(workdir_key) else {
+        return;
+    };
+    repo_state.virtual_branches = data
+        .branches
+        .iter()
+        .map(Into::into)
+        .collect::<Vec<_>>();
+    repo_state.next_virtual_branch_id = data.next_id.max(
+        repo_state
+            .virtual_branches
+            .iter()
+            .map(|branch| branch.id.saturating_add(1))
+            .max()
+            .unwrap_or(1),
+    );
+}
+
 fn persist_recent_repo_effect(repo_id: Option<RepoId>, workdir: PathBuf) -> Effect {
     Effect::PersistRecentRepo {
         repo_id,
@@ -384,6 +409,7 @@ pub(super) fn open_repo(id_alloc: &AtomicU64, state: &mut AppState, path: PathBu
         {
             repo_state.fetch_prune_deleted_remote_tracking_branches = enabled;
         }
+        restore_virtual_branches_from_session(&mut repo_state, &session_preferences, &workdir_key);
         repo_state.last_active_at = Some(now);
         repo_state
     });
@@ -478,6 +504,7 @@ pub(super) fn restore_session(
             {
                 repo_state.fetch_prune_deleted_remote_tracking_branches = enabled;
             }
+            restore_virtual_branches_from_session(&mut repo_state, &session_preferences, &workdir_key);
             repo_state
         };
         repo_state.set_open(Loadable::NotLoaded);

--- a/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
@@ -1,0 +1,217 @@
+use super::util::push_diagnostic;
+use crate::model::{AppState, DiagnosticKind, RepoId};
+use crate::msg::Effect;
+use gitcomet_core::domain::VirtualBranch;
+use gitcomet_core::error::Error;
+
+pub(super) fn create_virtual_branch(
+    state: &mut AppState,
+    repo_id: RepoId,
+    name: String,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    let id = repo.next_virtual_branch_id;
+    repo.next_virtual_branch_id += 1;
+    let name = if name.trim().is_empty() {
+        format!("Branch {id}")
+    } else {
+        name
+    };
+    repo.virtual_branches.push(VirtualBranch {
+        id,
+        name: name.into(),
+        paths: Vec::new(),
+        applied: true,
+        stored_patch: None,
+        pending: false,
+    });
+    repo.virtual_branches_rev += 1;
+    Vec::new()
+}
+
+pub(super) fn rename_virtual_branch(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+    name: String,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+        return Vec::new();
+    };
+    if !name.trim().is_empty() {
+        branch.name = name.into();
+        repo.virtual_branches_rev += 1;
+    }
+    Vec::new()
+}
+
+pub(super) fn delete_virtual_branch(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    repo.virtual_branches.retain(|b| b.id != branch_id);
+    repo.virtual_branches_rev += 1;
+    Vec::new()
+}
+
+/// Assigns `path` to the branch: the path is removed from every other branch
+/// first (a path belongs to at most one virtual branch).
+pub(super) fn assign_path_to_virtual_branch(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+    path: std::path::PathBuf,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    if !repo.virtual_branches.iter().any(|b| b.id == branch_id) {
+        return Vec::new();
+    }
+    for other in repo.virtual_branches.iter_mut() {
+        other.paths.retain(|p| p != &path);
+    }
+    if let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id)
+        && !branch.paths.contains(&path)
+    {
+        branch.paths.push(path);
+        repo.virtual_branches_rev += 1;
+    }
+    Vec::new()
+}
+
+pub(super) fn unassign_path_from_virtual_branch(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+    path: std::path::PathBuf,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+        return Vec::new();
+    };
+    let old_len = branch.paths.len();
+    branch.paths.retain(|p| p != &path);
+    if branch.paths.len() != old_len {
+        repo.virtual_branches_rev += 1;
+    }
+    Vec::new()
+}
+
+pub(super) fn unapply_virtual_branch(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+        return Vec::new();
+    };
+    if !branch.applied || branch.pending || branch.paths.is_empty() {
+        return Vec::new();
+    }
+    branch.pending = true;
+    vec![Effect::UnapplyVirtualBranch {
+        repo_id,
+        branch_id,
+        paths: branch.paths.clone(),
+    }]
+}
+
+pub(super) fn apply_virtual_branch(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+        return Vec::new();
+    };
+    if branch.applied || branch.pending {
+        return Vec::new();
+    }
+    let Some(patch) = branch.stored_patch.clone() else {
+        return Vec::new();
+    };
+    branch.pending = true;
+    vec![Effect::ApplyVirtualBranch {
+        repo_id,
+        branch_id,
+        patch: patch.to_string(),
+    }]
+}
+
+pub(super) fn virtual_branch_unapplied(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+    result: Result<String, Error>,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+        return Vec::new();
+    };
+    branch.pending = false;
+    match result {
+        Ok(patch) => {
+            branch.stored_patch = Some(patch.into());
+            branch.applied = false;
+            repo.virtual_branches_rev += 1;
+        }
+        Err(e) => {
+            push_diagnostic(
+                repo,
+                DiagnosticKind::Error,
+                format!("Unapply virtual branch: {e}"),
+            );
+        }
+    }
+    Vec::new()
+}
+
+pub(super) fn virtual_branch_applied(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+    result: Result<(), Error>,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+        return Vec::new();
+    };
+    branch.pending = false;
+    match result {
+        Ok(()) => {
+            branch.applied = true;
+            branch.stored_patch = None;
+            repo.virtual_branches_rev += 1;
+        }
+        Err(e) => {
+            push_diagnostic(
+                repo,
+                DiagnosticKind::Error,
+                format!("Apply virtual branch: {e}"),
+            );
+        }
+    }
+    Vec::new()
+}

--- a/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
@@ -4,6 +4,19 @@ use crate::msg::Effect;
 use gitcomet_core::domain::VirtualBranch;
 use gitcomet_core::error::Error;
 
+/// Builds the session persist effect for a repo's virtual branch workspace.
+fn persist_effect(repo: &crate::model::RepoState, action: &'static str) -> Effect {
+    Effect::PersistVirtualBranches {
+        repo_id: Some(repo.id),
+        workdir: repo.spec.workdir.clone(),
+        data: crate::session::VirtualBranchesSessionFile {
+            next_id: repo.next_virtual_branch_id,
+            branches: repo.virtual_branches.iter().map(Into::into).collect(),
+        },
+        action,
+    }
+}
+
 pub(super) fn create_virtual_branch(
     state: &mut AppState,
     repo_id: RepoId,
@@ -28,7 +41,7 @@ pub(super) fn create_virtual_branch(
         pending: false,
     });
     repo.virtual_branches_rev += 1;
-    Vec::new()
+    vec![persist_effect(repo, "creating a virtual branch")]
 }
 
 pub(super) fn rename_virtual_branch(
@@ -46,8 +59,10 @@ pub(super) fn rename_virtual_branch(
     if !name.trim().is_empty() {
         branch.name = name.into();
         repo.virtual_branches_rev += 1;
+        vec![persist_effect(repo, "renaming a virtual branch")]
+    } else {
+        Vec::new()
     }
-    Vec::new()
 }
 
 pub(super) fn delete_virtual_branch(
@@ -60,7 +75,7 @@ pub(super) fn delete_virtual_branch(
     };
     repo.virtual_branches.retain(|b| b.id != branch_id);
     repo.virtual_branches_rev += 1;
-    Vec::new()
+    vec![persist_effect(repo, "deleting a virtual branch")]
 }
 
 /// Bulk-removes virtual branches (used by the stale-branch cleanup after
@@ -103,13 +118,20 @@ pub(super) fn assign_path_to_virtual_branch(
     for other in repo.virtual_branches.iter_mut() {
         other.paths.retain(|p| p != &path);
     }
-    if let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id)
+    let changed = if let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id)
         && !branch.paths.contains(&path)
     {
         branch.paths.push(path);
         repo.virtual_branches_rev += 1;
+        true
+    } else {
+        false
+    };
+    if changed {
+        vec![persist_effect(repo, "assigning a path to a virtual branch")]
+    } else {
+        Vec::new()
     }
-    Vec::new()
 }
 
 pub(super) fn unassign_path_from_virtual_branch(
@@ -128,8 +150,10 @@ pub(super) fn unassign_path_from_virtual_branch(
     branch.paths.retain(|p| p != &path);
     if branch.paths.len() != old_len {
         repo.virtual_branches_rev += 1;
+        vec![persist_effect(repo, "unassigning a path from a virtual branch")]
+    } else {
+        Vec::new()
     }
-    Vec::new()
 }
 
 pub(super) fn unapply_virtual_branch(
@@ -205,6 +229,7 @@ pub(super) fn virtual_branch_unapplied(
             });
             branch.applied = false;
             repo.virtual_branches_rev += 1;
+            vec![persist_effect(repo, "unapplying a virtual branch")]
         }
         Err(e) => {
             push_diagnostic(
@@ -212,9 +237,9 @@ pub(super) fn virtual_branch_unapplied(
                 DiagnosticKind::Error,
                 format!("Unapply virtual branch: {e}"),
             );
+            Vec::new()
         }
     }
-    Vec::new()
 }
 
 pub(super) fn virtual_branch_applied(
@@ -235,6 +260,7 @@ pub(super) fn virtual_branch_applied(
             branch.applied = true;
             branch.stored_patch = None;
             repo.virtual_branches_rev += 1;
+            vec![persist_effect(repo, "applying a virtual branch")]
         }
         Err(e) => {
             push_diagnostic(
@@ -242,9 +268,9 @@ pub(super) fn virtual_branch_applied(
                 DiagnosticKind::Error,
                 format!("Apply virtual branch: {e}"),
             );
+            Vec::new()
         }
     }
-    Vec::new()
 }
 
 /// Parks a single hunk (already reverse-applied to the worktree by the
@@ -316,6 +342,7 @@ pub(super) fn virtual_branch_hunk_moved(
                 branch.paths.push(path);
             }
             repo.virtual_branches_rev += 1;
+            vec![persist_effect(repo, "moving a hunk to a virtual branch")]
         }
         Err(e) => {
             push_diagnostic(
@@ -323,7 +350,7 @@ pub(super) fn virtual_branch_hunk_moved(
                 DiagnosticKind::Error,
                 format!("Move hunk to virtual branch: {e}"),
             );
+            Vec::new()
         }
     }
-    Vec::new()
 }

--- a/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
@@ -150,7 +150,10 @@ pub(super) fn unassign_path_from_virtual_branch(
     branch.paths.retain(|p| p != &path);
     if branch.paths.len() != old_len {
         repo.virtual_branches_rev += 1;
-        vec![persist_effect(repo, "unassigning a path from a virtual branch")]
+        vec![persist_effect(
+            repo,
+            "unassigning a path from a virtual branch",
+        )]
     } else {
         Vec::new()
     }
@@ -321,7 +324,8 @@ pub(super) fn virtual_branch_hunk_moved(
         Ok(patch) => {
             let patch = patch.trim_end().to_string();
             {
-                let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+                let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id)
+                else {
                     return Vec::new();
                 };
                 branch.stored_patch = Some(match branch.stored_patch.take() {

--- a/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
@@ -63,6 +63,29 @@ pub(super) fn delete_virtual_branch(
     Vec::new()
 }
 
+/// Bulk-removes virtual branches (used by the stale-branch cleanup after
+/// user confirmation).
+pub(super) fn prune_virtual_branches(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_ids: Vec<u64>,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    if branch_ids.is_empty() {
+        return Vec::new();
+    }
+    let before = repo.virtual_branches.len();
+    repo.virtual_branches
+        .retain(|branch| !branch_ids.contains(&branch.id));
+    if repo.virtual_branches.len() == before {
+        return Vec::new();
+    }
+    repo.virtual_branches_rev += 1;
+    vec![persist_effect(repo, "pruning stale virtual branches")]
+}
+
 /// Assigns `path` to the branch: the path is removed from every other branch
 /// first (a path belongs to at most one virtual branch).
 pub(super) fn assign_path_to_virtual_branch(

--- a/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/reducer/virtual_branches.rs
@@ -171,7 +171,15 @@ pub(super) fn virtual_branch_unapplied(
     branch.pending = false;
     match result {
         Ok(patch) => {
-            branch.stored_patch = Some(patch.into());
+            // A branch may already park hunks moved out of the worktree; the
+            // newly captured diff is appended rather than replacing them.
+            let patch = patch.trim_end().to_string();
+            branch.stored_patch = Some(match branch.stored_patch.take() {
+                Some(previous) if !previous.trim().is_empty() => {
+                    format!("{}\n{}", previous.trim_end(), patch).into()
+                }
+                _ => patch.clone().into(),
+            });
             branch.applied = false;
             repo.virtual_branches_rev += 1;
         }
@@ -210,6 +218,87 @@ pub(super) fn virtual_branch_applied(
                 repo,
                 DiagnosticKind::Error,
                 format!("Apply virtual branch: {e}"),
+            );
+        }
+    }
+    Vec::new()
+}
+
+/// Parks a single hunk (already reverse-applied to the worktree by the
+/// worker) into the branch's stored patch collection. The branch is marked
+/// unapplied so `Apply` restores the parked hunks (undo).
+pub(super) fn move_hunk_to_virtual_branch(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+    patch: String,
+    _path: std::path::PathBuf,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+        return Vec::new();
+    };
+    if branch.pending || patch.trim().is_empty() {
+        return Vec::new();
+    }
+    branch.pending = true;
+    vec![Effect::MoveHunkToVirtualBranch {
+        repo_id,
+        branch_id,
+        patch,
+        path: _path,
+    }]
+}
+
+pub(super) fn virtual_branch_hunk_moved(
+    state: &mut AppState,
+    repo_id: RepoId,
+    branch_id: u64,
+    path: std::path::PathBuf,
+    result: Result<String, Error>,
+) -> Vec<Effect> {
+    let Some(repo) = state.repos.iter_mut().find(|r| r.id == repo_id) else {
+        return Vec::new();
+    };
+    {
+        let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+            return Vec::new();
+        };
+        branch.pending = false;
+    }
+    match result {
+        Ok(patch) => {
+            let patch = patch.trim_end().to_string();
+            {
+                let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id) else {
+                    return Vec::new();
+                };
+                branch.stored_patch = Some(match branch.stored_patch.take() {
+                    Some(previous) if !previous.trim().is_empty() => {
+                        format!("{}\n{}", previous.trim_end(), patch).into()
+                    }
+                    _ => patch.clone().into(),
+                });
+                branch.applied = false;
+            }
+            // The hunk's file now belongs to this branch.
+            for other in repo.virtual_branches.iter_mut() {
+                other.paths.retain(|p| p != &path);
+            }
+            if let Some(branch) = repo.virtual_branches.iter_mut().find(|b| b.id == branch_id)
+                && !branch.paths.contains(&path)
+            {
+                branch.paths.push(path);
+            }
+            repo.virtual_branches_rev += 1;
+        }
+        Err(e) => {
+            push_diagnostic(
+                repo,
+                DiagnosticKind::Error,
+                format!("Move hunk to virtual branch: {e}"),
             );
         }
     }

--- a/crates/gitcomet-state/src/store/tests.rs
+++ b/crates/gitcomet-state/src/store/tests.rs
@@ -416,3 +416,4 @@ mod reducer_diagnostics;
 mod repo_management;
 mod repo_monitor;
 mod send_failures;
+mod virtual_branches;

--- a/crates/gitcomet-state/src/store/tests/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/tests/virtual_branches.rs
@@ -1,0 +1,416 @@
+use super::*;
+
+fn fixture_repo() -> (HashMap<RepoId, Arc<dyn GitRepository>>, AtomicU64, AppState, RepoId) {
+    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let id_alloc = AtomicU64::new(1);
+    let repo_id = RepoId(1);
+    let mut state = AppState::default();
+    state.repos.push(RepoState::new_opening(
+        repo_id,
+        RepoSpec {
+            workdir: PathBuf::from("/tmp/repo"),
+        },
+    ));
+    state.repos[0].set_open(Loadable::Ready(()));
+    state.active_repo = Some(repo_id);
+    (repos, id_alloc, state, repo_id)
+}
+
+fn branch_ids(state: &AppState) -> Vec<u64> {
+    state.repos[0].virtual_branches.iter().map(|b| b.id).collect()
+}
+
+#[test]
+fn create_assigns_incrementing_ids_and_default_name() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: String::new(),
+        },
+    );
+    assert!(effects.is_empty());
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "feature".into(),
+        },
+    );
+    assert!(effects.is_empty());
+    let branches = &state.repos[0].virtual_branches;
+    assert_eq!(branches.len(), 2);
+    assert_eq!(branch_ids(&state), vec![1, 2]);
+    assert_eq!(branches[0].name.as_ref(), "Branch 1");
+    assert_eq!(branches[1].name.as_ref(), "feature");
+    assert!(branches.iter().all(|b| b.applied && !b.pending && b.paths.is_empty()));
+}
+
+#[test]
+fn assign_path_moves_it_between_branches() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    for name in ["a", "b"] {
+        let _ = reduce(
+            &mut repos,
+            &id_alloc,
+            &mut state,
+            Msg::CreateVirtualBranch {
+                repo_id,
+                name: name.into(),
+            },
+        );
+    }
+    let path = PathBuf::from("src/lib.rs");
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            path: path.clone(),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 2,
+            path: path.clone(),
+        },
+    );
+    let branches = &state.repos[0].virtual_branches;
+    assert!(branches[0].paths.is_empty());
+    assert_eq!(branches[1].paths, vec![path]);
+}
+
+#[test]
+fn unassign_path_removes_it_from_branch() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "a".into(),
+        },
+    );
+    let path = PathBuf::from("src/lib.rs");
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            path: path.clone(),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::UnassignPathFromVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            path,
+        },
+    );
+    assert!(state.repos[0].virtual_branches[0].paths.is_empty());
+}
+
+#[test]
+fn rename_and_delete_virtual_branch() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "old".into(),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::RenameVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            name: "new".into(),
+        },
+    );
+    assert_eq!(state.repos[0].virtual_branches[0].name.as_ref(), "new");
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::DeleteVirtualBranch {
+            repo_id,
+            branch_id: 1,
+        },
+    );
+    assert!(state.repos[0].virtual_branches.is_empty());
+}
+
+#[test]
+fn unapply_dispatches_effect_with_paths_and_marks_pending() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "a".into(),
+        },
+    );
+    let path = PathBuf::from("src/lib.rs");
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            path: path.clone(),
+        },
+    );
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::UnapplyVirtualBranch {
+            repo_id,
+            branch_id: 1,
+        },
+    );
+    assert_eq!(effects.len(), 1);
+    let Effect::UnapplyVirtualBranch {
+        repo_id: rid,
+        branch_id,
+        paths: effect_paths,
+    } = &effects[0]
+    else {
+        panic!("expected UnapplyVirtualBranch effect");
+    };
+    assert_eq!(*rid, repo_id);
+    assert_eq!(*branch_id, 1);
+    assert_eq!(*effect_paths, vec![path]);
+    let branch = &state.repos[0].virtual_branches[0];
+    assert!(branch.pending);
+    assert!(branch.applied);
+}
+
+#[test]
+fn unapply_without_paths_is_noop() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "empty".into(),
+        },
+    );
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::UnapplyVirtualBranch {
+            repo_id,
+            branch_id: 1,
+        },
+    );
+    assert!(effects.is_empty());
+    let branch = &state.repos[0].virtual_branches[0];
+    assert!(branch.applied && !branch.pending);
+}
+
+#[test]
+fn unapplied_result_stores_patch_and_marks_unapplied() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "a".into(),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            path: PathBuf::from("src/lib.rs"),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::UnapplyVirtualBranch {
+            repo_id,
+            branch_id: 1,
+        },
+    );
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchUnapplied {
+            repo_id,
+            branch_id: 1,
+            result: Ok("diff --git a/src/lib.rs b/src/lib.rs".to_string()),
+        }),
+    );
+    assert!(effects.is_empty());
+    let branch = &state.repos[0].virtual_branches[0];
+    assert!(!branch.pending);
+    assert!(!branch.applied);
+    assert_eq!(
+        branch.stored_patch.as_deref(),
+        Some("diff --git a/src/lib.rs b/src/lib.rs")
+    );
+}
+
+#[test]
+fn unapplied_error_keeps_applied_and_reports_diagnostic() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "a".into(),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            path: PathBuf::from("src/lib.rs"),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::UnapplyVirtualBranch {
+            repo_id,
+            branch_id: 1,
+        },
+    );
+    let err = gitcomet_core::error::Error::new(gitcomet_core::error::ErrorKind::Backend(
+        "boom".into(),
+    ));
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchUnapplied {
+            repo_id,
+            branch_id: 1,
+            result: Err(err),
+        }),
+    );
+    let branch = &state.repos[0].virtual_branches[0];
+    assert!(!branch.pending);
+    assert!(branch.applied);
+    assert!(branch.stored_patch.is_none());
+    assert!(!state.repos[0].diagnostics.is_empty());
+}
+
+#[test]
+fn apply_dispatches_effect_and_clears_patch_on_success() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "a".into(),
+        },
+    );
+    let patch = "diff --git a/src/lib.rs b/src/lib.rs".to_string();
+    state.repos[0].virtual_branches[0].applied = false;
+    state.repos[0].virtual_branches[0].stored_patch = Some(patch.clone().into());
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::ApplyVirtualBranch {
+            repo_id,
+            branch_id: 1,
+        },
+    );
+    assert_eq!(effects.len(), 1);
+    let Effect::ApplyVirtualBranch {
+        repo_id: rid,
+        branch_id,
+        patch: effect_patch,
+    } = &effects[0]
+    else {
+        panic!("expected ApplyVirtualBranch effect");
+    };
+    assert_eq!(*rid, repo_id);
+    assert_eq!(*branch_id, 1);
+    assert_eq!(*effect_patch, patch);
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchApplied {
+            repo_id,
+            branch_id: 1,
+            result: Ok(()),
+        }),
+    );
+    let branch = &state.repos[0].virtual_branches[0];
+    assert!(!branch.pending);
+    assert!(branch.applied);
+    assert!(branch.stored_patch.is_none());
+}
+
+#[test]
+fn apply_without_stored_patch_is_noop() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "a".into(),
+        },
+    );
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::ApplyVirtualBranch {
+            repo_id,
+            branch_id: 1,
+        },
+    );
+    assert!(effects.is_empty());
+}

--- a/crates/gitcomet-state/src/store/tests/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/tests/virtual_branches.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 fn fixture_repo() -> (HashMap<RepoId, Arc<dyn GitRepository>>, AtomicU64, AppState, RepoId) {
-    let mut repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
+    let repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
     let id_alloc = AtomicU64::new(1);
     let repo_id = RepoId(1);
     let mut state = AppState::default();
@@ -706,4 +706,118 @@ fn unapply_after_move_appends_captured_diff_to_parked_patch() {
         branch.stored_patch.as_deref(),
         Some(format!("{}\n{captured}", parked.trim_end()).as_str())
     );
+}
+
+fn set_status(state: &mut AppState, paths: &[&str]) {
+    use gitcomet_core::domain::{FileStatus, FileStatusKind};
+    state.repos[0].worktree_status = Loadable::Ready(Arc::new(
+        paths
+            .iter()
+            .map(|p| FileStatus {
+                path: PathBuf::from(p),
+                kind: FileStatusKind::Modified,
+                conflict: None,
+            })
+            .collect(),
+    ));
+}
+
+#[test]
+fn stale_virtual_branch_ids_ignores_branches_with_changes_or_parked_patches() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    for name in ["changed", "stale", "parked"] {
+        let _ = reduce(
+            &mut repos,
+            &id_alloc,
+            &mut state,
+            Msg::CreateVirtualBranch {
+                repo_id,
+                name: name.into(),
+            },
+        );
+    }
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            path: PathBuf::from("src/active.rs"),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 2,
+            path: PathBuf::from("src/gone.rs"),
+        },
+    );
+    // Branch 3 has a parked patch: it must never be pruned.
+    state.repos[0].virtual_branches[2].stored_patch = Some("parked diff".into());
+    state.repos[0].virtual_branches[2].applied = false;
+    set_status(&mut state, &["src/active.rs"]);
+
+    let stale = crate::model::stale_virtual_branch_ids(&state.repos[0]);
+    assert_eq!(stale, vec![2]);
+}
+
+#[test]
+fn stale_virtual_branch_ids_treats_empty_branches_as_stale() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "empty".into(),
+        },
+    );
+    set_status(&mut state, &[]);
+    let stale = crate::model::stale_virtual_branch_ids(&state.repos[0]);
+    assert_eq!(stale, vec![1]);
+}
+
+#[test]
+fn prune_virtual_branches_removes_only_given_ids_and_persists() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    for _ in 0..3 {
+        let _ = reduce(
+            &mut repos,
+            &id_alloc,
+            &mut state,
+            Msg::CreateVirtualBranch {
+                repo_id,
+                name: String::new(),
+            },
+        );
+    }
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::PruneVirtualBranches {
+            repo_id,
+            branch_ids: vec![1, 3],
+        },
+    );
+    assert!(has_persist_effect(&effects));
+    assert_eq!(branch_ids(&state), vec![2]);
+
+    // Pruning nothing is a no-op.
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::PruneVirtualBranches {
+            repo_id,
+            branch_ids: vec![999],
+        },
+    );
+    assert!(effects.is_empty());
+    assert_eq!(branch_ids(&state), vec![2]);
 }

--- a/crates/gitcomet-state/src/store/tests/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/tests/virtual_branches.rs
@@ -1,6 +1,11 @@
 use super::*;
 
-fn fixture_repo() -> (HashMap<RepoId, Arc<dyn GitRepository>>, AtomicU64, AppState, RepoId) {
+fn fixture_repo() -> (
+    HashMap<RepoId, Arc<dyn GitRepository>>,
+    AtomicU64,
+    AppState,
+    RepoId,
+) {
     let repos: HashMap<RepoId, Arc<dyn GitRepository>> = HashMap::default();
     let id_alloc = AtomicU64::new(1);
     let repo_id = RepoId(1);
@@ -17,7 +22,11 @@ fn fixture_repo() -> (HashMap<RepoId, Arc<dyn GitRepository>>, AtomicU64, AppSta
 }
 
 fn branch_ids(state: &AppState) -> Vec<u64> {
-    state.repos[0].virtual_branches.iter().map(|b| b.id).collect()
+    state.repos[0]
+        .virtual_branches
+        .iter()
+        .map(|b| b.id)
+        .collect()
 }
 
 fn has_persist_effect(effects: &[Effect]) -> bool {
@@ -64,7 +73,11 @@ fn create_assigns_incrementing_ids_and_default_name() {
     assert_eq!(branch_ids(&state), vec![1, 2]);
     assert_eq!(branches[0].name.as_ref(), "Branch 1");
     assert_eq!(branches[1].name.as_ref(), "feature");
-    assert!(branches.iter().all(|b| b.applied && !b.pending && b.paths.is_empty()));
+    assert!(
+        branches
+            .iter()
+            .all(|b| b.applied && !b.pending && b.paths.is_empty())
+    );
 }
 
 #[test]
@@ -335,9 +348,8 @@ fn unapplied_error_keeps_applied_and_reports_diagnostic() {
             branch_id: 1,
         },
     );
-    let err = gitcomet_core::error::Error::new(gitcomet_core::error::ErrorKind::Backend(
-        "boom".into(),
-    ));
+    let err =
+        gitcomet_core::error::Error::new(gitcomet_core::error::ErrorKind::Backend("boom".into()));
     let _ = reduce(
         &mut repos,
         &id_alloc,
@@ -469,7 +481,9 @@ fn persist_effect_carries_full_workspace_snapshot() {
         Msg::Internal(crate::msg::InternalMsg::VirtualBranchUnapplied {
             repo_id,
             branch_id: 1,
-            result: Ok("diff --git a/src/lib.rs b/src/lib.rs\n@@ -1,1 +1,1 @@\n-foo\n+bar\n".to_string()),
+            result: Ok(
+                "diff --git a/src/lib.rs b/src/lib.rs\n@@ -1,1 +1,1 @@\n-foo\n+bar\n".to_string(),
+            ),
         }),
     );
     let data = persist_data(&effects);
@@ -480,10 +494,18 @@ fn persist_effect_carries_full_workspace_snapshot() {
     assert_eq!(branch.name, "feature");
     assert_eq!(branch.paths, vec!["src/lib.rs"]);
     assert!(!branch.applied);
-    assert!(branch.stored_patch.as_deref().unwrap().starts_with("diff --git"));
+    assert!(
+        branch
+            .stored_patch
+            .as_deref()
+            .unwrap()
+            .starts_with("diff --git")
+    );
     // The persist effect targets the repo's workdir.
     let Effect::PersistVirtualBranches {
-        workdir, repo_id: rid, ..
+        workdir,
+        repo_id: rid,
+        ..
     } = &effects[0]
     else {
         panic!("expected PersistVirtualBranches effect");

--- a/crates/gitcomet-state/src/store/tests/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/tests/virtual_branches.rs
@@ -414,3 +414,296 @@ fn apply_without_stored_patch_is_noop() {
     );
     assert!(effects.is_empty());
 }
+
+fn move_hunk_patch() -> String {
+    "@@ -1,3 +1,4 @@\n fn a() {\n+    let x = 1;\n-    let y = 2;\n }\n".to_string()
+}
+
+#[test]
+fn move_hunk_dispatches_reverse_apply_effect_and_marks_pending() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "target".into(),
+        },
+    );
+    let path = PathBuf::from("src/lib.rs");
+    let patch = move_hunk_patch();
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::MoveHunkToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            patch: patch.clone(),
+            path: path.clone(),
+        },
+    );
+    assert_eq!(effects.len(), 1);
+    let Effect::MoveHunkToVirtualBranch {
+        repo_id: rid,
+        branch_id,
+        patch: effect_patch,
+        path: effect_path,
+    } = &effects[0]
+    else {
+        panic!("expected MoveHunkToVirtualBranch effect");
+    };
+    assert_eq!(*rid, repo_id);
+    assert_eq!(*branch_id, 1);
+    assert_eq!(*effect_patch, patch);
+    assert_eq!(*effect_path, path);
+    let branch = &state.repos[0].virtual_branches[0];
+    assert!(branch.pending);
+    assert!(branch.applied);
+    assert!(branch.stored_patch.is_none());
+    assert!(branch.paths.is_empty());
+}
+
+#[test]
+fn move_hunk_empty_patch_is_noop() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "target".into(),
+        },
+    );
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::MoveHunkToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            patch: "   ".to_string(),
+            path: PathBuf::from("src/lib.rs"),
+        },
+    );
+    assert!(effects.is_empty());
+    let branch = &state.repos[0].virtual_branches[0];
+    assert!(!branch.pending);
+}
+
+#[test]
+fn move_hunk_success_parks_patch_and_assigns_path() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    for name in ["other", "target"] {
+        let _ = reduce(
+            &mut repos,
+            &id_alloc,
+            &mut state,
+            Msg::CreateVirtualBranch {
+                repo_id,
+                name: name.into(),
+            },
+        );
+    }
+    let path = PathBuf::from("src/lib.rs");
+    // The path is already assigned to branch 1; moving a hunk of it to
+    // branch 2 should reassign the file to branch 2.
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            path: path.clone(),
+        },
+    );
+    let patch = move_hunk_patch();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::MoveHunkToVirtualBranch {
+            repo_id,
+            branch_id: 2,
+            patch: patch.clone(),
+            path: path.clone(),
+        },
+    );
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
+            repo_id,
+            branch_id: 2,
+            path: path.clone(),
+            result: Ok(patch.clone()),
+        }),
+    );
+    assert!(effects.is_empty());
+    let branches = &state.repos[0].virtual_branches;
+    let target = &branches[1];
+    assert!(!target.pending);
+    assert!(!target.applied);
+    assert_eq!(target.stored_patch.as_deref(), Some(patch.trim_end()));
+    assert_eq!(target.paths, vec![path]);
+    assert!(branches[0].paths.is_empty());
+}
+
+#[test]
+fn move_hunk_appends_to_existing_parked_patch() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "target".into(),
+        },
+    );
+    let first = "@@ -1,1 +1,1 @@\n-a\n+b\n".to_string();
+    let second = "@@ -5,1 +5,1 @@\n-c\n+d\n".to_string();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::MoveHunkToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            patch: first.clone(),
+            path: PathBuf::from("src/a.rs"),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
+            repo_id,
+            branch_id: 1,
+            path: PathBuf::from("src/a.rs"),
+            result: Ok(first.clone()),
+        }),
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::MoveHunkToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            patch: second.clone(),
+            path: PathBuf::from("src/b.rs"),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
+            repo_id,
+            branch_id: 1,
+            path: PathBuf::from("src/b.rs"),
+            result: Ok(second.clone()),
+        }),
+    );
+    let branch = &state.repos[0].virtual_branches[0];
+    assert_eq!(
+        branch.stored_patch.as_deref(),
+        Some(format!("{}\n{}", first.trim_end(), second.trim_end()).as_str())
+    );
+    assert_eq!(branch.paths.len(), 2);
+}
+
+#[test]
+fn move_hunk_error_reports_diagnostic_without_recording() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "target".into(),
+        },
+    );
+    let path = PathBuf::from("src/lib.rs");
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::MoveHunkToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            patch: move_hunk_patch(),
+            path: path.clone(),
+        },
+    );
+    let err = gitcomet_core::error::Error::new(gitcomet_core::error::ErrorKind::Backend(
+        "patch does not apply".into(),
+    ));
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
+            repo_id,
+            branch_id: 1,
+            path: path.clone(),
+            result: Err(err),
+        }),
+    );
+    let branch = &state.repos[0].virtual_branches[0];
+    assert!(!branch.pending);
+    assert!(branch.applied);
+    assert!(branch.stored_patch.is_none());
+    assert!(branch.paths.is_empty());
+    assert!(!state.repos[0].diagnostics.is_empty());
+}
+
+#[test]
+fn unapply_after_move_appends_captured_diff_to_parked_patch() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "target".into(),
+        },
+    );
+    let parked = "@@ -1,1 +1,1 @@\n-a\n+b\n".to_string();
+    // Park a hunk first.
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchHunkMoved {
+            repo_id,
+            branch_id: 1,
+            path: PathBuf::from("src/lib.rs"),
+            result: Ok(parked.clone()),
+        }),
+    );
+    let captured = "diff --git a/src/lib.rs b/src/lib.rs".to_string();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchUnapplied {
+            repo_id,
+            branch_id: 1,
+            result: Ok(captured.clone()),
+        }),
+    );
+    let branch = &state.repos[0].virtual_branches[0];
+    assert_eq!(
+        branch.stored_patch.as_deref(),
+        Some(format!("{}\n{captured}", parked.trim_end()).as_str())
+    );
+}

--- a/crates/gitcomet-state/src/store/tests/virtual_branches.rs
+++ b/crates/gitcomet-state/src/store/tests/virtual_branches.rs
@@ -20,6 +20,22 @@ fn branch_ids(state: &AppState) -> Vec<u64> {
     state.repos[0].virtual_branches.iter().map(|b| b.id).collect()
 }
 
+fn has_persist_effect(effects: &[Effect]) -> bool {
+    effects
+        .iter()
+        .any(|e| matches!(e, Effect::PersistVirtualBranches { .. }))
+}
+
+fn persist_data(effects: &[Effect]) -> crate::session::VirtualBranchesSessionFile {
+    effects
+        .iter()
+        .find_map(|e| match e {
+            Effect::PersistVirtualBranches { data, .. } => Some(data.clone()),
+            _ => None,
+        })
+        .expect("expected a PersistVirtualBranches effect")
+}
+
 #[test]
 fn create_assigns_incrementing_ids_and_default_name() {
     let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
@@ -32,7 +48,7 @@ fn create_assigns_incrementing_ids_and_default_name() {
             name: String::new(),
         },
     );
-    assert!(effects.is_empty());
+    assert!(has_persist_effect(&effects));
     let effects = reduce(
         &mut repos,
         &id_alloc,
@@ -42,7 +58,7 @@ fn create_assigns_incrementing_ids_and_default_name() {
             name: "feature".into(),
         },
     );
-    assert!(effects.is_empty());
+    assert!(has_persist_effect(&effects));
     let branches = &state.repos[0].virtual_branches;
     assert_eq!(branches.len(), 2);
     assert_eq!(branch_ids(&state), vec![1, 2]);
@@ -278,7 +294,7 @@ fn unapplied_result_stores_patch_and_marks_unapplied() {
             result: Ok("diff --git a/src/lib.rs b/src/lib.rs".to_string()),
         }),
     );
-    assert!(effects.is_empty());
+    assert!(has_persist_effect(&effects));
     let branch = &state.repos[0].virtual_branches[0];
     assert!(!branch.pending);
     assert!(!branch.applied);
@@ -415,6 +431,67 @@ fn apply_without_stored_patch_is_noop() {
     assert!(effects.is_empty());
 }
 
+#[test]
+fn persist_effect_carries_full_workspace_snapshot() {
+    let (mut repos, id_alloc, mut state, repo_id) = fixture_repo();
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateVirtualBranch {
+            repo_id,
+            name: "feature".into(),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::AssignPathToVirtualBranch {
+            repo_id,
+            branch_id: 1,
+            path: PathBuf::from("src/lib.rs"),
+        },
+    );
+    let _ = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::UnapplyVirtualBranch {
+            repo_id,
+            branch_id: 1,
+        },
+    );
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::Internal(crate::msg::InternalMsg::VirtualBranchUnapplied {
+            repo_id,
+            branch_id: 1,
+            result: Ok("diff --git a/src/lib.rs b/src/lib.rs\n@@ -1,1 +1,1 @@\n-foo\n+bar\n".to_string()),
+        }),
+    );
+    let data = persist_data(&effects);
+    assert_eq!(data.next_id, 2);
+    assert_eq!(data.branches.len(), 1);
+    let branch = &data.branches[0];
+    assert_eq!(branch.id, 1);
+    assert_eq!(branch.name, "feature");
+    assert_eq!(branch.paths, vec!["src/lib.rs"]);
+    assert!(!branch.applied);
+    assert!(branch.stored_patch.as_deref().unwrap().starts_with("diff --git"));
+    // The persist effect targets the repo's workdir.
+    let Effect::PersistVirtualBranches {
+        workdir, repo_id: rid, ..
+    } = &effects[0]
+    else {
+        panic!("expected PersistVirtualBranches effect");
+    };
+    assert_eq!(*rid, Some(repo_id));
+    assert_eq!(workdir.as_path(), std::path::Path::new("/tmp/repo"));
+}
+
 fn move_hunk_patch() -> String {
     "@@ -1,3 +1,4 @@\n fn a() {\n+    let x = 1;\n-    let y = 2;\n }\n".to_string()
 }
@@ -543,7 +620,7 @@ fn move_hunk_success_parks_patch_and_assigns_path() {
             result: Ok(patch.clone()),
         }),
     );
-    assert!(effects.is_empty());
+    assert!(has_persist_effect(&effects));
     let branches = &state.repos[0].virtual_branches;
     let target = &branches[1];
     assert!(!target.pending);

--- a/crates/gitcomet-ui-gpui/src/view/branch_sidebar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/branch_sidebar.rs
@@ -18,6 +18,7 @@ const PIN_REMOTE_PREFIX: &str = "remote:";
 const WORKTREES_SECTION_KEY: &str = "section:worktrees";
 const SUBMODULES_SECTION_KEY: &str = "section:submodules";
 const STASH_SECTION_KEY: &str = "section:stash";
+const VIRTUAL_BRANCHES_SECTION_KEY: &str = "section:virtual-branches";
 const EXPANDED_DEFAULT_SECTION_PREFIX: &str = "expanded:";
 const TRAILING_BOTTOM_SPACERS: usize = 3;
 const REMOTE_HEADER_GROUP_PREFIX: &str = "group:remote-header:";
@@ -120,6 +121,10 @@ pub(super) const fn submodules_section_storage_key() -> &'static str {
 
 pub(super) const fn stash_section_storage_key() -> &'static str {
     STASH_SECTION_KEY
+}
+
+pub(super) const fn virtual_branches_section_storage_key() -> &'static str {
+    VIRTUAL_BRANCHES_SECTION_KEY
 }
 
 pub(super) fn remote_header_storage_key(name: &str) -> String {
@@ -239,6 +244,18 @@ pub(super) enum BranchSidebarRow {
         message: SharedString,
         tooltip: SharedString,
         created_at: Option<std::time::SystemTime>,
+    },
+    VirtualBranchesHeader {
+        top_border: bool,
+        collapsed: bool,
+        collapse_key: SharedString,
+    },
+    VirtualBranchItem {
+        branch_id: u64,
+        name: SharedString,
+        path_count: usize,
+        applied: bool,
+        pending: bool,
     },
 }
 
@@ -372,6 +389,8 @@ pub(in crate::view) struct BranchSidebarSourceFingerprintParts {
     stash_rev: u64,
     stash_hash: u64,
     stash_reuse_identity: fingerprint::LoadableArcIdentity,
+    virtual_branches_rev: u64,
+    virtual_branches_hash: u64,
 }
 
 impl BranchSidebarSourceFingerprintParts {
@@ -391,6 +410,8 @@ impl BranchSidebarSourceFingerprintParts {
         let submodule_reuse_identity = fingerprint::loadable_arc_identity(&repo.submodules);
         let stash_rev = repo.stashes_rev;
         let stash_reuse_identity = fingerprint::loadable_arc_identity(&repo.stashes);
+        let virtual_branches_rev = repo.virtual_branches_rev;
+        let virtual_branches_hash = branch_sidebar_virtual_branches_source_hash(repo);
 
         Self {
             local_revs,
@@ -446,6 +467,8 @@ impl BranchSidebarSourceFingerprintParts {
                     || branch_sidebar_stash_source_hash(repo),
                     |parts| parts.stash_hash,
                 ),
+            virtual_branches_rev,
+            virtual_branches_hash,
         }
     }
 
@@ -461,6 +484,8 @@ impl BranchSidebarSourceFingerprintParts {
         self.submodule_hash.hash(&mut hasher);
         4u8.hash(&mut hasher);
         self.stash_hash.hash(&mut hasher);
+        5u8.hash(&mut hasher);
+        self.virtual_branches_hash.hash(&mut hasher);
         BranchSidebarSourceFingerprint(hasher.finish())
     }
 }
@@ -518,6 +543,10 @@ pub(in crate::view) fn branch_sidebar_source_matches_cached(
     if cached.stash_rev != stash_rev
         && cached.stash_reuse_identity != fingerprint::loadable_arc_identity(&repo.stashes)
     {
+        return false;
+    }
+
+    if cached.virtual_branches_rev != repo.virtual_branches_rev {
         return false;
     }
 
@@ -685,6 +714,23 @@ fn branch_sidebar_stash_source_hash(repo: &RepoState) -> u64 {
     hasher.finish()
 }
 
+fn branch_sidebar_virtual_branches_source_hash(repo: &RepoState) -> u64 {
+    let mut hasher = FxHasher::default();
+    repo.virtual_branches.len().hash(&mut hasher);
+    for branch in repo.virtual_branches.iter() {
+        branch.id.hash(&mut hasher);
+        branch.name.hash(&mut hasher);
+        branch.applied.hash(&mut hasher);
+        branch.pending.hash(&mut hasher);
+        branch.paths.len().hash(&mut hasher);
+        for path in branch.paths.iter() {
+            path.hash(&mut hasher);
+        }
+        branch.stored_patch.as_ref().map(|p| p.len()).hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 fn cmp_ascii_case_insensitive(left: &[u8], right: &[u8]) -> Ordering {
     for (&left, &right) in left.iter().zip(right.iter()) {
         let ordering = left.to_ascii_lowercase().cmp(&right.to_ascii_lowercase());
@@ -835,6 +881,8 @@ pub(super) fn branch_sidebar_rows(
     let worktrees_collapsed = is_collapsed(collapsed_items, worktrees_section_storage_key());
     let submodules_collapsed = is_collapsed(collapsed_items, submodules_section_storage_key());
     let stash_collapsed = is_collapsed(collapsed_items, stash_section_storage_key());
+    let virtual_branches_collapsed =
+        is_collapsed(collapsed_items, virtual_branches_section_storage_key());
     let visible_rows = if local_collapsed {
         0
     } else {
@@ -870,6 +918,10 @@ pub(super) fn branch_sidebar_rows(
             Loadable::Ready(stashes) => stashes.len(),
             _ => 0,
         }
+    } + if virtual_branches_collapsed {
+        0
+    } else {
+        repo.virtual_branches.len()
     };
     let approx_rows = 16 + visible_rows + visible_rows / 8;
     let mut rows = Vec::with_capacity(approx_rows);
@@ -1225,6 +1277,24 @@ pub(super) fn branch_sidebar_rows(
             Loadable::Error(error) => rows.push(BranchSidebarRow::StashPlaceholder {
                 message: error.clone().into(),
             }),
+        }
+    }
+
+    rows.push(BranchSidebarRow::VirtualBranchesHeader {
+        top_border: true,
+        collapsed: virtual_branches_collapsed,
+        collapse_key: virtual_branches_section_storage_key().into(),
+    });
+
+    if !virtual_branches_collapsed {
+        for branch in repo.virtual_branches.iter() {
+            rows.push(BranchSidebarRow::VirtualBranchItem {
+                branch_id: branch.id,
+                name: branch.name.clone().into(),
+                path_count: branch.paths.len(),
+                applied: branch.applied,
+                pending: branch.pending,
+            });
         }
     }
 

--- a/crates/gitcomet-ui-gpui/src/view/branch_sidebar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/branch_sidebar.rs
@@ -726,7 +726,11 @@ fn branch_sidebar_virtual_branches_source_hash(repo: &RepoState) -> u64 {
         for path in branch.paths.iter() {
             path.hash(&mut hasher);
         }
-        branch.stored_patch.as_ref().map(|p| p.len()).hash(&mut hasher);
+        branch
+            .stored_patch
+            .as_ref()
+            .map(|p| p.len())
+            .hash(&mut hasher);
     }
     hasher.finish()
 }

--- a/crates/gitcomet-ui-gpui/src/view/command_palette.rs
+++ b/crates/gitcomet-ui-gpui/src/view/command_palette.rs
@@ -413,6 +413,14 @@ pub(crate) const COMMANDS: &[CommandEntry] = &[
         requires_repo: true,
     },
     CommandEntry {
+        id: "virtual-branches",
+        label: "Virtual Branches",
+        shortcut: Shortcut::None,
+        category: "Working Copy",
+        keywords: "virtual branch workspace changeset",
+        requires_repo: true,
+    },
+    CommandEntry {
         id: "back",
         label: "Navigate Back",
         shortcut: Shortcut::Alt("Left"),

--- a/crates/gitcomet-ui-gpui/src/view/dnd.rs
+++ b/crates/gitcomet-ui-gpui/src/view/dnd.rs
@@ -1,0 +1,40 @@
+//! Drag & drop payloads shared across views (source rows and drop targets).
+//!
+//! The worktree file rows in the Changes panel are draggable; virtual branch
+//! rows in the sidebar act as drop targets that assign the dragged path to the
+//! branch (the same operation as the "Assign to virtual branch…" context
+//! menu item).
+
+use gitcomet_state::model::RepoId;
+use gpui::prelude::*;
+use gpui::{div, px, App, Entity, Render, Window};
+use std::path::PathBuf;
+
+/// Payload dragged from a worktree file row: the repo owning the file and the
+/// file's path relative to the repo root.
+#[derive(Clone, Debug)]
+pub(super) struct StatusFileDrag {
+    pub repo_id: RepoId,
+    pub path: PathBuf,
+}
+
+/// Invisible drag preview required by gpui's drag machinery. The source row
+/// stays in place during the drag (like the repo tab reorder), so the carrier
+/// is empty.
+pub(super) struct StatusFileDragCarrier;
+
+impl Render for StatusFileDragCarrier {
+    fn render(&mut self, _window: &mut Window, _cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        div().size(px(1.0)).opacity(0.0)
+    }
+}
+
+/// Builds the invisible carrier entity for a `StatusFileDrag` payload.
+pub(super) fn status_file_drag_carrier(
+    _drag: &StatusFileDrag,
+    _offset: gpui::Point<gpui::Pixels>,
+    _window: &mut Window,
+    cx: &mut App,
+) -> Entity<StatusFileDragCarrier> {
+    cx.new(|_cx| StatusFileDragCarrier)
+}

--- a/crates/gitcomet-ui-gpui/src/view/dnd.rs
+++ b/crates/gitcomet-ui-gpui/src/view/dnd.rs
@@ -7,7 +7,7 @@
 
 use gitcomet_state::model::RepoId;
 use gpui::prelude::*;
-use gpui::{div, px, App, Entity, Render, Window};
+use gpui::{App, Entity, Render, Window, div, px};
 use std::path::PathBuf;
 
 /// Payload dragged from a worktree file row: the repo owning the file and the

--- a/crates/gitcomet-ui-gpui/src/view/mod.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod.rs
@@ -158,6 +158,7 @@ mod diff_preview;
 mod diff_text_model;
 mod diff_text_selection;
 mod diff_utils;
+mod dnd;
 mod file_diff_display;
 mod file_icons;
 mod fingerprint;

--- a/crates/gitcomet-ui-gpui/src/view/mod.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod.rs
@@ -1064,6 +1064,17 @@ impl GitCometView {
             "delete-tag" => {
                 // TODO: Implement delete tag
             }
+            "virtual-branches" => {
+                if let Some(repo_id) = self.active_repo_id()
+                    && let Some(window) = window
+                {
+                    self.open_popover_centered(
+                        PopoverKind::VirtualBranchesPrompt { repo_id },
+                        window,
+                        cx,
+                    );
+                }
+            }
             "add-remote" => {
                 if let Some(repo_id) = self.active_repo_id()
                     && let Some(window) = window

--- a/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
@@ -4370,6 +4370,16 @@ pub(super) enum PopoverKind {
         repo_id: RepoId,
         path: std::path::PathBuf,
     },
+    /// Prototype virtual-branch workspace panel: lists virtual branches with
+    /// their assigned paths and apply/unapply/commit actions.
+    VirtualBranchesPrompt {
+        repo_id: RepoId,
+    },
+    /// Pick the virtual branch to assign a worktree path to.
+    VirtualBranchPicker {
+        repo_id: RepoId,
+        path: std::path::PathBuf,
+    },
     PushSetUpstreamPrompt {
         repo_id: RepoId,
         remote: String,

--- a/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
@@ -4388,6 +4388,12 @@ pub(super) enum PopoverKind {
         patch: String,
         path: std::path::PathBuf,
     },
+    /// Confirms bulk removal of stale virtual branches (assigned paths with no
+    /// remaining worktree changes).
+    PruneVirtualBranchesConfirm {
+        repo_id: RepoId,
+        branch_ids: Vec<u64>,
+    },
     PushSetUpstreamPrompt {
         repo_id: RepoId,
         remote: String,

--- a/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
@@ -4380,6 +4380,14 @@ pub(super) enum PopoverKind {
         repo_id: RepoId,
         path: std::path::PathBuf,
     },
+    /// Pick the virtual branch to move a diff hunk into: the hunk's unified
+    /// patch is previewed and, on selection, reverse-applied to the worktree
+    /// and parked in the branch's stored patch collection.
+    VirtualBranchMovePicker {
+        repo_id: RepoId,
+        patch: String,
+        path: std::path::PathBuf,
+    },
     PushSetUpstreamPrompt {
         repo_id: RepoId,
         remote: String,

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -22,9 +22,9 @@ mod force_delete_branch_confirm;
 mod force_push_confirm;
 mod force_remove_worktree_confirm;
 mod merge_abort_confirm;
-mod prune_virtual_branches_confirm;
 mod picker_nav;
 mod picker_row_menu;
+mod prune_virtual_branches_confirm;
 mod pull_reconcile_prompt;
 mod push_set_upstream_prompt;
 mod rebase_onto_confirm;
@@ -1521,7 +1521,12 @@ impl PopoverHost {
             &virtual_branch_create_input,
             window,
             cx,
-            |this| matches!(this.popover, Some(PopoverKind::VirtualBranchesPrompt { .. })),
+            |this| {
+                matches!(
+                    this.popover,
+                    Some(PopoverKind::VirtualBranchesPrompt { .. })
+                )
+            },
             |this, _window, cx| this.submit_create_virtual_branch(cx),
         ));
         prompt_input_subscriptions.push(Self::prompt_enter_subscription(
@@ -2272,7 +2277,8 @@ impl PopoverHost {
         if name.is_empty() {
             return;
         }
-        self.store.dispatch(Msg::CreateVirtualBranch { repo_id, name });
+        self.store
+            .dispatch(Msg::CreateVirtualBranch { repo_id, name });
         self.virtual_branch_create_input.update(cx, |input, cx| {
             input.set_text("", cx);
         });

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -907,7 +907,8 @@ pub(in super::super) fn popover_width_spec(kind: &PopoverKind) -> Option<Popover
         }
         | PopoverKind::FileHistory { .. }
         | PopoverKind::VirtualBranchesPrompt { .. }
-        | PopoverKind::VirtualBranchPicker { .. } => Some(LARGE_PICKER_WIDTH),
+        | PopoverKind::VirtualBranchPicker { .. }
+        | PopoverKind::VirtualBranchMovePicker { .. } => Some(LARGE_PICKER_WIDTH),
         PopoverKind::AppMenu => Some(APP_MENU_WIDTH),
         PopoverKind::AddRepoMenu => Some(DEFAULT_CONTEXT_MENU_WIDTH),
         PopoverKind::TerminalShutdownConfirm(_) | PopoverKind::UnsavedFileEditsConfirm(_) => {
@@ -3217,7 +3218,8 @@ impl PopoverHost {
                         .read_with(cx, |input, _| input.focus_handle());
                     window.focus(&focus, cx);
                 }
-                PopoverKind::VirtualBranchPicker { .. } => {}
+                PopoverKind::VirtualBranchPicker { .. }
+                | PopoverKind::VirtualBranchMovePicker { .. } => {}
                 PopoverKind::CloneRepo => {
                     let theme = self.theme;
                     let url_text = self
@@ -4150,6 +4152,11 @@ impl PopoverHost {
             PopoverKind::VirtualBranchPicker { repo_id, path } => {
                 virtual_branch_picker::panel(self, repo_id, path, cx)
             }
+            PopoverKind::VirtualBranchMovePicker {
+                repo_id,
+                patch,
+                path,
+            } => virtual_branch_picker::move_panel(self, repo_id, patch, path, cx),
             PopoverKind::PushSetUpstreamPrompt { repo_id, remote } => {
                 push_set_upstream_prompt::panel(self, repo_id, remote, cx)
             }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -47,6 +47,8 @@ mod submodule_remove_confirm;
 mod submodule_trust_confirm;
 mod terminal_shutdown_confirm;
 mod unsaved_file_edits_confirm;
+mod virtual_branch_picker;
+mod virtual_branches_prompt;
 mod workspace_picker;
 mod worktree_add_prompt;
 mod worktree_picker;
@@ -270,6 +272,7 @@ pub(in super::super) struct PopoverHost {
     clone_repo_parent_dir_input: Entity<components::TextInput>,
     rebase_onto_input: Entity<components::TextInput>,
     create_tag_input: Entity<components::TextInput>,
+    virtual_branch_create_input: Entity<components::TextInput>,
     create_tag_message_input: Entity<components::TextInput>,
     create_tag_message_scroll: ScrollHandle,
     /// One `.gitignore` line per row. Multiline so a multi-file selection and a
@@ -902,7 +905,9 @@ pub(in super::super) fn popover_width_spec(kind: &PopoverKind) -> Option<Popover
                 ),
             ..
         }
-        | PopoverKind::FileHistory { .. } => Some(LARGE_PICKER_WIDTH),
+        | PopoverKind::FileHistory { .. }
+        | PopoverKind::VirtualBranchesPrompt { .. }
+        | PopoverKind::VirtualBranchPicker { .. } => Some(LARGE_PICKER_WIDTH),
         PopoverKind::AppMenu => Some(APP_MENU_WIDTH),
         PopoverKind::AddRepoMenu => Some(DEFAULT_CONTEXT_MENU_WIDTH),
         PopoverKind::TerminalShutdownConfirm(_) | PopoverKind::UnsavedFileEditsConfirm(_) => {
@@ -1187,6 +1192,17 @@ impl PopoverHost {
             components::TextInput::new(
                 components::TextInputOptions {
                     placeholder: "v1.0.0".into(),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
+
+        let virtual_branch_create_input = cx.new(|cx| {
+            components::TextInput::new(
+                components::TextInputOptions {
+                    placeholder: "New virtual branch name".into(),
                     ..Default::default()
                 },
                 window,
@@ -1498,6 +1514,13 @@ impl PopoverHost {
             |this, _window, cx| this.submit_create_tag(cx),
         ));
         prompt_input_subscriptions.push(Self::prompt_enter_subscription(
+            &virtual_branch_create_input,
+            window,
+            cx,
+            |this| matches!(this.popover, Some(PopoverKind::VirtualBranchesPrompt { .. })),
+            |this, _window, cx| this.submit_create_virtual_branch(cx),
+        ));
+        prompt_input_subscriptions.push(Self::prompt_enter_subscription(
             &create_branch_input,
             window,
             cx,
@@ -1736,6 +1759,7 @@ impl PopoverHost {
             clone_repo_parent_dir_input,
             rebase_onto_input,
             create_tag_input,
+            virtual_branch_create_input,
             create_tag_message_input,
             create_tag_message_scroll,
             gitignore_patterns_input,
@@ -2231,6 +2255,22 @@ impl PopoverHost {
     fn clear_truncated_tooltip(&self, cx: &mut gpui::Context<Self>) {
         let _ = self.tooltip_host.update(cx, |host, cx| {
             host.clear_tooltip(cx);
+        });
+    }
+
+    fn submit_create_virtual_branch(&mut self, cx: &mut gpui::Context<Self>) {
+        let Some(PopoverKind::VirtualBranchesPrompt { repo_id }) = self.popover.clone() else {
+            return;
+        };
+        let name = self
+            .virtual_branch_create_input
+            .read_with(cx, |input, _| input.text().trim().to_string());
+        if name.is_empty() {
+            return;
+        }
+        self.store.dispatch(Msg::CreateVirtualBranch { repo_id, name });
+        self.virtual_branch_create_input.update(cx, |input, cx| {
+            input.set_text("", cx);
         });
     }
 
@@ -3164,6 +3204,20 @@ impl PopoverHost {
                     let _ = self.ensure_stash_picker_search_input(window, cx);
                     self.stash_picker_prompt_selected_index = Some(0);
                 }
+                PopoverKind::VirtualBranchesPrompt { .. } => {
+                    let theme = self.theme;
+                    self.virtual_branch_create_input.update(cx, |input, cx| {
+                        input.clear_transient_key_presses();
+                        input.set_theme(theme, cx);
+                        input.set_text("", cx);
+                        cx.notify();
+                    });
+                    let focus = self
+                        .virtual_branch_create_input
+                        .read_with(cx, |input, _| input.focus_handle());
+                    window.focus(&focus, cx);
+                }
+                PopoverKind::VirtualBranchPicker { .. } => {}
                 PopoverKind::CloneRepo => {
                     let theme = self.theme;
                     let url_text = self
@@ -4089,6 +4143,12 @@ impl PopoverHost {
             },
             PopoverKind::FileHistory { repo_id, path } => {
                 file_history::panel(self, repo_id, path, cx)
+            }
+            PopoverKind::VirtualBranchesPrompt { repo_id } => {
+                virtual_branches_prompt::panel(self, repo_id, cx)
+            }
+            PopoverKind::VirtualBranchPicker { repo_id, path } => {
+                virtual_branch_picker::panel(self, repo_id, path, cx)
             }
             PopoverKind::PushSetUpstreamPrompt { repo_id, remote } => {
                 push_set_upstream_prompt::panel(self, repo_id, remote, cx)

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -22,6 +22,7 @@ mod force_delete_branch_confirm;
 mod force_push_confirm;
 mod force_remove_worktree_confirm;
 mod merge_abort_confirm;
+mod prune_virtual_branches_confirm;
 mod picker_nav;
 mod picker_row_menu;
 mod pull_reconcile_prompt;
@@ -520,6 +521,7 @@ fn popover_is_confirm_dialog(kind: &PopoverKind) -> bool {
             | PopoverKind::DiscardChangesConfirm { .. }
             | PopoverKind::AddToGitignorePrompt { .. }
             | PopoverKind::StageConflictMarkersConfirm { .. }
+            | PopoverKind::PruneVirtualBranchesConfirm { .. }
             | PopoverKind::ResetPrompt { .. }
             | PopoverKind::PullReconcilePrompt { .. }
             | PopoverKind::TerminalShutdownConfirm(_)
@@ -856,7 +858,8 @@ pub(in super::super) fn popover_width_spec(kind: &PopoverKind) -> Option<Popover
         | PopoverKind::ForceDeleteBranchConfirm { .. }
         | PopoverKind::DeleteBranchesConfirm { .. }
         | PopoverKind::DiscardChangesConfirm { .. }
-        | PopoverKind::StageConflictMarkersConfirm { .. } => Some(DIALOG_420_WIDTH),
+        | PopoverKind::StageConflictMarkersConfirm { .. }
+        | PopoverKind::PruneVirtualBranchesConfirm { .. } => Some(DIALOG_420_WIDTH),
         PopoverKind::PushSetUpstreamPrompt { .. } => Some(DIALOG_320_WIDTH),
         PopoverKind::ResetPrompt { .. }
         | PopoverKind::RebaseOntoConfirm { .. }
@@ -4163,6 +4166,10 @@ impl PopoverHost {
             PopoverKind::ForcePushConfirm { repo_id } => {
                 force_push_confirm::panel(self, repo_id, cx)
             }
+            PopoverKind::PruneVirtualBranchesConfirm {
+                repo_id,
+                branch_ids,
+            } => prune_virtual_branches_confirm::panel(self, repo_id, branch_ids, cx),
             PopoverKind::CherryPickCommitConfirm { repo_id, commit_id } => {
                 cherry_pick_commit_confirm::panel(self, repo_id, commit_id, cx)
             }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/diff_hunk.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/diff_hunk.rs
@@ -74,6 +74,7 @@ pub(super) fn model(this: &PopoverHost, repo_id: RepoId, src_ix: usize) -> Conte
             )
         });
     let patch = this.build_unified_patch_for_hunk_src_ix(repo_id, src_ix);
+    let move_patch = patch.clone();
 
     items.push(ContextMenuItem::Entry {
         label: "Discard hunk".into(),
@@ -84,6 +85,33 @@ pub(super) fn model(this: &PopoverHost, repo_id: RepoId, src_ix: usize) -> Conte
             repo_id,
             patch: patch.unwrap_or_default(),
             reverse: true,
+        }),
+    });
+
+    // Move the hunk into a virtual branch: the hunk is removed from the
+    // worktree and parked in the branch's stored patch collection (recoverable
+    // by applying the branch). Only available for unstaged worktree hunks.
+    let repo = this.state.repos.iter().find(|r| r.id == repo_id);
+    let has_branches = repo
+        .map(|r| !r.virtual_branches.is_empty())
+        .unwrap_or(false);
+    let move_path = repo
+        .and_then(|r| r.diff_state.diff_target.as_ref())
+        .and_then(|target| match target {
+            DiffTarget::WorkingTree { path, .. } => Some(path.clone()),
+            _ => None,
+        });
+    items.push(ContextMenuItem::Entry {
+        label: "Move hunk to virtual branch…".into(),
+        icon: Some("icons/git_branch.svg".into()),
+        shortcut: None,
+        disabled: !is_unstaged || move_patch.is_none() || move_path.is_none() || !has_branches,
+        action: Box::new(ContextMenuAction::OpenPopover {
+            kind: PopoverKind::VirtualBranchMovePicker {
+                repo_id,
+                patch: move_patch.unwrap_or_default(),
+                path: move_path.unwrap_or_default(),
+            },
         }),
     });
 

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/status_file.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/status_file.rs
@@ -423,6 +423,18 @@ pub(super) fn model(
         path,
         Some(secondary_shortcut("Shift+C").into()),
     );
+    items.push(ContextMenuItem::Entry {
+        label: "Assign to virtual branch…".into(),
+        icon: Some("icons/git_branch.svg".into()),
+        shortcut: None,
+        disabled: false,
+        action: Box::new(ContextMenuAction::OpenPopover {
+            kind: PopoverKind::VirtualBranchPicker {
+                repo_id,
+                path: path.to_path_buf(),
+            },
+        }),
+    });
 
     ContextMenuModel::new(items)
 }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
@@ -198,7 +198,9 @@ fn repo_for_popover<'a>(state: &'a AppState, popover: &PopoverKind) -> Option<&'
         | PopoverKind::TagRefMenu { repo_id, .. }
         | PopoverKind::HistoryBranchFilter { repo_id }
         | PopoverKind::HistoryAuthorFilter { repo_id }
-        | PopoverKind::CommitShaLinkMenu { repo_id, .. } => Some(*repo_id),
+        | PopoverKind::CommitShaLinkMenu { repo_id, .. }
+        | PopoverKind::VirtualBranchesPrompt { repo_id }
+        | PopoverKind::VirtualBranchPicker { repo_id, .. } => Some(*repo_id),
     }?;
 
     state.repos.iter().find(|r| r.id == repo_id)
@@ -400,6 +402,21 @@ fn hash_repo_for_popover<H: Hasher>(repo: &RepoState, popover: &PopoverKind, has
         | PopoverKind::RepoPicker
         | PopoverKind::CloneRepo
         | PopoverKind::CommitPrompt { .. } => {}
+
+        PopoverKind::VirtualBranchesPrompt { .. } | PopoverKind::VirtualBranchPicker { .. } => {
+            repo.virtual_branches.len().hash(hasher);
+            for branch in repo.virtual_branches.iter() {
+                branch.id.hash(hasher);
+                branch.name.hash(hasher);
+                branch.applied.hash(hasher);
+                branch.pending.hash(hasher);
+                branch.paths.len().hash(hasher);
+                for path in branch.paths.iter() {
+                    path.hash(hasher);
+                }
+                branch.stored_patch.as_ref().map(|p| p.len()).hash(hasher);
+            }
+        }
     }
 }
 
@@ -857,6 +874,15 @@ fn hash_popover_kind<H: Hasher>(kind: &PopoverKind, hasher: &mut H) {
         }
         PopoverKind::InteractiveRebaseAutosquashMenu => {
             79u8.hash(hasher);
+        }
+        PopoverKind::VirtualBranchesPrompt { repo_id } => {
+            80u8.hash(hasher);
+            repo_id.hash(hasher);
+        }
+        PopoverKind::VirtualBranchPicker { repo_id, path } => {
+            81u8.hash(hasher);
+            repo_id.hash(hasher);
+            path.hash(hasher);
         }
     }
 }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
@@ -175,6 +175,7 @@ fn repo_for_popover<'a>(state: &'a AppState, popover: &PopoverKind) -> Option<&'
         | PopoverKind::DiscardChangesConfirm { repo_id, .. }
         | PopoverKind::AddToGitignorePrompt { repo_id, .. }
         | PopoverKind::StageConflictMarkersConfirm { repo_id, .. }
+        | PopoverKind::PruneVirtualBranchesConfirm { repo_id, .. }
         | PopoverKind::PullReconcilePrompt { repo_id }
         | PopoverKind::RebaseOntoConfirm { repo_id, .. }
         | PopoverKind::CommitOptionsMenu { repo_id }
@@ -406,7 +407,8 @@ fn hash_repo_for_popover<H: Hasher>(repo: &RepoState, popover: &PopoverKind, has
 
         PopoverKind::VirtualBranchesPrompt { .. }
         | PopoverKind::VirtualBranchPicker { .. }
-        | PopoverKind::VirtualBranchMovePicker { .. } => {
+        | PopoverKind::VirtualBranchMovePicker { .. }
+        | PopoverKind::PruneVirtualBranchesConfirm { .. } => {
             repo.virtual_branches.len().hash(hasher);
             for branch in repo.virtual_branches.iter() {
                 branch.id.hash(hasher);
@@ -567,6 +569,14 @@ fn hash_popover_kind<H: Hasher>(kind: &PopoverKind, hasher: &mut H) {
         PopoverKind::ForcePushConfirm { repo_id } => {
             31u8.hash(hasher);
             repo_id.hash(hasher);
+        }
+        PopoverKind::PruneVirtualBranchesConfirm {
+            repo_id,
+            branch_ids,
+        } => {
+            102u8.hash(hasher);
+            repo_id.hash(hasher);
+            branch_ids.hash(hasher);
         }
         PopoverKind::CherryPickCommitConfirm { repo_id, commit_id } => {
             76u8.hash(hasher);

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
@@ -200,7 +200,8 @@ fn repo_for_popover<'a>(state: &'a AppState, popover: &PopoverKind) -> Option<&'
         | PopoverKind::HistoryAuthorFilter { repo_id }
         | PopoverKind::CommitShaLinkMenu { repo_id, .. }
         | PopoverKind::VirtualBranchesPrompt { repo_id }
-        | PopoverKind::VirtualBranchPicker { repo_id, .. } => Some(*repo_id),
+        | PopoverKind::VirtualBranchPicker { repo_id, .. }
+        | PopoverKind::VirtualBranchMovePicker { repo_id, .. } => Some(*repo_id),
     }?;
 
     state.repos.iter().find(|r| r.id == repo_id)
@@ -403,7 +404,9 @@ fn hash_repo_for_popover<H: Hasher>(repo: &RepoState, popover: &PopoverKind, has
         | PopoverKind::CloneRepo
         | PopoverKind::CommitPrompt { .. } => {}
 
-        PopoverKind::VirtualBranchesPrompt { .. } | PopoverKind::VirtualBranchPicker { .. } => {
+        PopoverKind::VirtualBranchesPrompt { .. }
+        | PopoverKind::VirtualBranchPicker { .. }
+        | PopoverKind::VirtualBranchMovePicker { .. } => {
             repo.virtual_branches.len().hash(hasher);
             for branch in repo.virtual_branches.iter() {
                 branch.id.hash(hasher);
@@ -882,6 +885,16 @@ fn hash_popover_kind<H: Hasher>(kind: &PopoverKind, hasher: &mut H) {
         PopoverKind::VirtualBranchPicker { repo_id, path } => {
             81u8.hash(hasher);
             repo_id.hash(hasher);
+            path.hash(hasher);
+        }
+        PopoverKind::VirtualBranchMovePicker {
+            repo_id,
+            patch,
+            path,
+        } => {
+            101u8.hash(hasher);
+            repo_id.hash(hasher);
+            patch.hash(hasher);
             path.hash(hasher);
         }
     }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/prune_virtual_branches_confirm.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/prune_virtual_branches_confirm.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+pub(super) fn panel(
+    this: &mut PopoverHost,
+    repo_id: RepoId,
+    branch_ids: Vec<u64>,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Div {
+    let theme = this.theme;
+    let repo = this.state.repos.iter().find(|r| r.id == repo_id);
+    let names: Vec<SharedString> = branch_ids
+        .iter()
+        .filter_map(|id| {
+            repo.and_then(|r| {
+                r.virtual_branches
+                    .iter()
+                    .find(|branch| branch.id == *id)
+                    .map(|branch| branch.name.clone().into())
+            })
+        })
+        .collect();
+
+    let list = if names.is_empty() {
+        SharedString::from("(no branches)")
+    } else {
+        names.join("\n").into()
+    };
+
+    ConfirmDialog::new("Remove stale virtual branches?", DIALOG_420_WIDTH)
+        .mono_value(theme, list)
+        .text(
+            theme,
+            "These branches have no worktree changes for their assigned paths and hold no parked patches.",
+        )
+        .note(
+            theme,
+            "Only their assignment is removed — committed or discarded work is untouched. Branches with parked hunks are kept.",
+        )
+        .render(
+            theme,
+            cancel_button("prune_virtual_branches_cancel", "prune_virtual_branches_cancel_hint", theme)
+                .on_click(theme, cx, move |this, _e, _w, cx| {
+                    this.close_popover(cx);
+                }),
+            components::Button::new("prune_virtual_branches_go", "Remove")
+                .style(components::ButtonStyle::Danger)
+                .on_click(theme, cx, move |this, _e, _w, cx| {
+                    this.store.dispatch(Msg::PruneVirtualBranches {
+                        repo_id,
+                        branch_ids: branch_ids.clone(),
+                    });
+                    this.close_popover(cx);
+                }),
+            cx,
+        )
+}

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branch_picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branch_picker.rs
@@ -4,8 +4,13 @@ use super::*;
 /// context menu) or move a hunk's patch into it (diff hunk context menu).
 #[derive(Clone)]
 enum BranchPick {
-    Assign { path: std::path::PathBuf },
-    Move { patch: String, path: std::path::PathBuf },
+    Assign {
+        path: std::path::PathBuf,
+    },
+    Move {
+        patch: String,
+        path: std::path::PathBuf,
+    },
 }
 
 fn branch_list(
@@ -59,13 +64,13 @@ fn branch_list(
                     .text_sm()
                     .whitespace_nowrap()
                     .line_clamp(1)
-                    .text_color(theme.colors.text)
+                    .text_color(theme.colors.foreground.primary)
                     .child(name),
             )
             .child(
                 div()
                     .text_xs()
-                    .text_color(theme.colors.text_muted)
+                    .text_color(theme.colors.foreground.secondary)
                     .child(format!("{count} file(s)")),
             )
             .on_click(cx.listener(move |this, _e: &ClickEvent, _w, cx| {
@@ -128,7 +133,7 @@ fn picker_shell(
             .flex_col()
             .w(width.preferred_px(ui_scale))
             .child(header)
-            .child(div().border_t_1().border_color(theme.colors.border))
+            .child(div().border_t_1().border_color(theme.colors.stroke.default))
             .child(body),
     )
 }
@@ -158,12 +163,12 @@ pub(super) fn panel(
         .child(
             div()
                 .text_xs()
-                .text_color(theme.colors.text_muted)
+                .text_color(theme.colors.foreground.secondary)
                 .line_height(scaled_px(14.0))
                 .child(
                     components::TruncatedText::path(path.display().to_string())
                         .id(("vb_picker_path", repo_id.0))
-                        .text_color(theme.colors.text_muted)
+                        .text_color(theme.colors.foreground.secondary)
                         .full_text_tooltip(this.tooltip_host.clone())
                         .render(cx),
                 ),
@@ -208,7 +213,7 @@ pub(super) fn move_panel(
                 .child(
                     components::TruncatedText::path(path.display().to_string())
                         .id(("vb_move_picker_path", repo_id.0))
-                        .text_color(theme.colors.text_muted)
+                        .text_color(theme.colors.foreground.secondary)
                         .full_text_tooltip(this.tooltip_host.clone())
                         .render(cx),
                 )
@@ -216,26 +221,34 @@ pub(super) fn move_panel(
                     div()
                         .text_xs()
                         .font_family(crate::font_preferences::EDITOR_MONOSPACE_FONT_FAMILY)
-                        .text_color(theme.colors.success)
+                        .text_color(theme.colors.status.success.foreground)
                         .child(format!("+{additions}")),
                 )
                 .child(
                     div()
                         .text_xs()
                         .font_family(crate::font_preferences::EDITOR_MONOSPACE_FONT_FAMILY)
-                        .text_color(theme.colors.danger)
+                        .text_color(theme.colors.status.danger.foreground)
                         .child(format!("-{deletions}")),
                 ),
         )
         .child(
             div()
                 .text_xs()
-                .text_color(theme.colors.text_muted)
+                .text_color(theme.colors.foreground.secondary)
                 .line_height(scaled_px(14.0))
-                .child("The hunk leaves the worktree and is parked in the branch until you apply it."),
+                .child(
+                    "The hunk leaves the worktree and is parked in the branch until you apply it.",
+                ),
         );
 
-    let body = branch_list(this, repo_id, scaled_px, BranchPick::Move { patch, path }, cx);
+    let body = branch_list(
+        this,
+        repo_id,
+        scaled_px,
+        BranchPick::Move { patch, path },
+        cx,
+    );
     picker_shell(this, header, body, cx)
 }
 
@@ -263,6 +276,9 @@ index 123..456 100644
     #[test]
     fn change_stats_ignores_binary_and_empty_patches() {
         assert_eq!(hunk_change_stats(""), (0, 0));
-        assert_eq!(hunk_change_stats("+++ b/x\n--- a/x\n@@ -0,0 +1 @@\n"), (0, 0));
+        assert_eq!(
+            hunk_change_stats("+++ b/x\n--- a/x\n@@ -0,0 +1 @@\n"),
+            (0, 0)
+        );
     }
 }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branch_picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branch_picker.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+pub(super) fn panel(
+    this: &mut PopoverHost,
+    repo_id: RepoId,
+    path: std::path::PathBuf,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Div {
+    let theme = this.theme;
+    let ui_scale = super::popover_ui_scale(cx);
+    let ui_scale_percent = ui_scale.percent();
+    let width = super::LARGE_PICKER_WIDTH;
+    let scaled_px = |value: f32| super::popover_scaled_px_from_percent(value, ui_scale_percent);
+    let repo = this.state.repos.iter().find(|r| r.id == repo_id);
+    let branches = repo
+        .map(|r| &r.virtual_branches)
+        .cloned()
+        .unwrap_or_default();
+
+    let header = div()
+        .px(scaled_px(8.0))
+        .py(scaled_px(4.0))
+        .flex()
+        .flex_col()
+        .min_w(px(0.0))
+        .child(
+            div()
+                .text_sm()
+                .font_weight(FontWeight::BOLD)
+                .child("Assign to virtual branch"),
+        )
+        .child(
+            div()
+                .text_xs()
+                .text_color(theme.colors.text_muted)
+                .line_height(scaled_px(14.0))
+                .child(
+                    components::TruncatedText::path(path.display().to_string())
+                        .id(("vb_picker_path", repo_id.0))
+                        .text_color(theme.colors.text_muted)
+                        .full_text_tooltip(this.tooltip_host.clone())
+                        .render(cx),
+                ),
+        );
+
+    let body: AnyElement = if branches.is_empty() {
+        components::context_menu_label(
+            theme,
+            ui_scale_percent,
+            "No virtual branches. Open the Virtual Branches panel to create one.",
+            Some(this.tooltip_host.clone()),
+            cx,
+        )
+        .into_any_element()
+    } else {
+        let mut list = div().flex().flex_col().w_full();
+        for branch in branches.iter() {
+            let branch_id = branch.id;
+            let name = branch.name.to_string();
+            let count = branch.paths.len();
+            let path_for_row = path.clone();
+            let row = div()
+                .id(("vb_picker_row", branch_id))
+                .debug_selector(move || format!("vb_picker_row_{branch_id}"))
+                .h(scaled_px(28.0))
+                .w_full()
+                .flex()
+                .items_center()
+                .gap(scaled_px(8.0))
+                .px(scaled_px(8.0))
+                .rounded(px(theme.radii.row))
+                .cursor(CursorStyle::PointingHand)
+                .hover(move |s| s.bg(theme.hover_overlay()))
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w(px(0.0))
+                        .text_sm()
+                        .whitespace_nowrap()
+                        .line_clamp(1)
+                        .text_color(theme.colors.text)
+                        .child(name),
+                )
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(theme.colors.text_muted)
+                        .child(format!("{count} file(s)")),
+                )
+                .on_click(cx.listener(move |this, _e: &ClickEvent, _w, cx| {
+                    this.store.dispatch(Msg::AssignPathToVirtualBranch {
+                        repo_id,
+                        branch_id,
+                        path: path_for_row.clone(),
+                    });
+                    this.close_popover(cx);
+                }));
+            list = list.child(row);
+        }
+        list.into_any_element()
+    };
+
+    components::context_menu(
+        theme,
+        div()
+            .flex()
+            .flex_col()
+            .w(width.preferred_px(ui_scale))
+            .child(header)
+            .child(div().border_t_1().border_color(theme.colors.border))
+            .child(body),
+    )
+}

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branch_picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branch_picker.rs
@@ -1,5 +1,138 @@
 use super::*;
 
+/// What picking a branch should do: assign a worktree path to it (file
+/// context menu) or move a hunk's patch into it (diff hunk context menu).
+#[derive(Clone)]
+enum BranchPick {
+    Assign { path: std::path::PathBuf },
+    Move { patch: String, path: std::path::PathBuf },
+}
+
+fn branch_list(
+    this: &mut PopoverHost,
+    repo_id: RepoId,
+    scaled_px: impl Fn(f32) -> gpui::Pixels + Copy,
+    pick: BranchPick,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> AnyElement {
+    let theme = this.theme;
+    let repo = this.state.repos.iter().find(|r| r.id == repo_id);
+    let branches = repo
+        .map(|r| &r.virtual_branches)
+        .cloned()
+        .unwrap_or_default();
+
+    if branches.is_empty() {
+        let ui_scale_percent = super::popover_ui_scale(cx).percent();
+        return components::context_menu_label(
+            theme,
+            ui_scale_percent,
+            "No virtual branches. Open the Virtual Branches panel to create one.",
+            Some(this.tooltip_host.clone()),
+            cx,
+        )
+        .into_any_element();
+    }
+
+    let mut list = div().flex().flex_col().w_full();
+    for branch in branches.iter() {
+        let branch_id = branch.id;
+        let name = branch.name.to_string();
+        let count = branch.paths.len();
+        let pick_for_row = pick.clone();
+        let row = div()
+            .id(("vb_picker_row", branch_id))
+            .debug_selector(move || format!("vb_picker_row_{branch_id}"))
+            .h(scaled_px(28.0))
+            .w_full()
+            .flex()
+            .items_center()
+            .gap(scaled_px(8.0))
+            .px(scaled_px(8.0))
+            .rounded(px(theme.radii.row))
+            .cursor(CursorStyle::PointingHand)
+            .hover(move |s| s.bg(theme.hover_overlay()))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .text_sm()
+                    .whitespace_nowrap()
+                    .line_clamp(1)
+                    .text_color(theme.colors.text)
+                    .child(name),
+            )
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(theme.colors.text_muted)
+                    .child(format!("{count} file(s)")),
+            )
+            .on_click(cx.listener(move |this, _e: &ClickEvent, _w, cx| {
+                match &pick_for_row {
+                    BranchPick::Assign { path } => {
+                        this.store.dispatch(Msg::AssignPathToVirtualBranch {
+                            repo_id,
+                            branch_id,
+                            path: path.clone(),
+                        });
+                    }
+                    BranchPick::Move { patch, path } => {
+                        this.store.dispatch(Msg::MoveHunkToVirtualBranch {
+                            repo_id,
+                            branch_id,
+                            patch: patch.clone(),
+                            path: path.clone(),
+                        });
+                    }
+                }
+                this.close_popover(cx);
+            }));
+        list = list.child(row);
+    }
+    list.into_any_element()
+}
+
+/// Counts `+`/`-` content lines in a unified patch (excluding the `---`/`+++`
+/// file headers and `@@` hunk headers) so the picker can preview the hunk.
+fn hunk_change_stats(patch: &str) -> (usize, usize) {
+    let mut additions = 0usize;
+    let mut deletions = 0usize;
+    for line in patch.lines() {
+        if let Some(rest) = line.strip_prefix('+') {
+            if !rest.starts_with("++") {
+                additions += 1;
+            }
+        } else if let Some(rest) = line.strip_prefix('-') {
+            if !rest.starts_with("--") {
+                deletions += 1;
+            }
+        }
+    }
+    (additions, deletions)
+}
+
+fn picker_shell(
+    this: &mut PopoverHost,
+    header: gpui::Div,
+    body: AnyElement,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Div {
+    let theme = this.theme;
+    let ui_scale = super::popover_ui_scale(cx);
+    let width = super::LARGE_PICKER_WIDTH;
+    components::context_menu(
+        theme,
+        div()
+            .flex()
+            .flex_col()
+            .w(width.preferred_px(ui_scale))
+            .child(header)
+            .child(div().border_t_1().border_color(theme.colors.border))
+            .child(body),
+    )
+}
+
 pub(super) fn panel(
     this: &mut PopoverHost,
     repo_id: RepoId,
@@ -7,15 +140,8 @@ pub(super) fn panel(
     cx: &mut gpui::Context<PopoverHost>,
 ) -> gpui::Div {
     let theme = this.theme;
-    let ui_scale = super::popover_ui_scale(cx);
-    let ui_scale_percent = ui_scale.percent();
-    let width = super::LARGE_PICKER_WIDTH;
+    let ui_scale_percent = super::popover_ui_scale(cx).percent();
     let scaled_px = |value: f32| super::popover_scaled_px_from_percent(value, ui_scale_percent);
-    let repo = this.state.repos.iter().find(|r| r.id == repo_id);
-    let branches = repo
-        .map(|r| &r.virtual_branches)
-        .cloned()
-        .unwrap_or_default();
 
     let header = div()
         .px(scaled_px(8.0))
@@ -43,71 +169,100 @@ pub(super) fn panel(
                 ),
         );
 
-    let body: AnyElement = if branches.is_empty() {
-        components::context_menu_label(
-            theme,
-            ui_scale_percent,
-            "No virtual branches. Open the Virtual Branches panel to create one.",
-            Some(this.tooltip_host.clone()),
-            cx,
+    let body = branch_list(this, repo_id, scaled_px, BranchPick::Assign { path }, cx);
+    picker_shell(this, header, body, cx)
+}
+
+/// Picker shown from the hunk context menu: previews the hunk that will be
+/// moved and lists the virtual branches to move it into.
+pub(super) fn move_panel(
+    this: &mut PopoverHost,
+    repo_id: RepoId,
+    patch: String,
+    path: std::path::PathBuf,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Div {
+    let theme = this.theme;
+    let ui_scale_percent = super::popover_ui_scale(cx).percent();
+    let scaled_px = |value: f32| super::popover_scaled_px_from_percent(value, ui_scale_percent);
+    let (additions, deletions) = hunk_change_stats(&patch);
+
+    let header = div()
+        .px(scaled_px(8.0))
+        .py(scaled_px(4.0))
+        .flex()
+        .flex_col()
+        .min_w(px(0.0))
+        .child(
+            div()
+                .text_sm()
+                .font_weight(FontWeight::BOLD)
+                .child("Move hunk to virtual branch"),
         )
-        .into_any_element()
-    } else {
-        let mut list = div().flex().flex_col().w_full();
-        for branch in branches.iter() {
-            let branch_id = branch.id;
-            let name = branch.name.to_string();
-            let count = branch.paths.len();
-            let path_for_row = path.clone();
-            let row = div()
-                .id(("vb_picker_row", branch_id))
-                .debug_selector(move || format!("vb_picker_row_{branch_id}"))
-                .h(scaled_px(28.0))
-                .w_full()
+        .child(
+            div()
                 .flex()
                 .items_center()
-                .gap(scaled_px(8.0))
-                .px(scaled_px(8.0))
-                .rounded(px(theme.radii.row))
-                .cursor(CursorStyle::PointingHand)
-                .hover(move |s| s.bg(theme.hover_overlay()))
+                .gap(scaled_px(6.0))
+                .min_w(px(0.0))
                 .child(
-                    div()
-                        .flex_1()
-                        .min_w(px(0.0))
-                        .text_sm()
-                        .whitespace_nowrap()
-                        .line_clamp(1)
-                        .text_color(theme.colors.text)
-                        .child(name),
+                    components::TruncatedText::path(path.display().to_string())
+                        .id(("vb_move_picker_path", repo_id.0))
+                        .text_color(theme.colors.text_muted)
+                        .full_text_tooltip(this.tooltip_host.clone())
+                        .render(cx),
                 )
                 .child(
                     div()
                         .text_xs()
-                        .text_color(theme.colors.text_muted)
-                        .child(format!("{count} file(s)")),
+                        .font_family(crate::font_preferences::EDITOR_MONOSPACE_FONT_FAMILY)
+                        .text_color(theme.colors.success)
+                        .child(format!("+{additions}")),
                 )
-                .on_click(cx.listener(move |this, _e: &ClickEvent, _w, cx| {
-                    this.store.dispatch(Msg::AssignPathToVirtualBranch {
-                        repo_id,
-                        branch_id,
-                        path: path_for_row.clone(),
-                    });
-                    this.close_popover(cx);
-                }));
-            list = list.child(row);
-        }
-        list.into_any_element()
-    };
+                .child(
+                    div()
+                        .text_xs()
+                        .font_family(crate::font_preferences::EDITOR_MONOSPACE_FONT_FAMILY)
+                        .text_color(theme.colors.danger)
+                        .child(format!("-{deletions}")),
+                ),
+        )
+        .child(
+            div()
+                .text_xs()
+                .text_color(theme.colors.text_muted)
+                .line_height(scaled_px(14.0))
+                .child("The hunk leaves the worktree and is parked in the branch until you apply it."),
+        );
 
-    components::context_menu(
-        theme,
-        div()
-            .flex()
-            .flex_col()
-            .w(width.preferred_px(ui_scale))
-            .child(header)
-            .child(div().border_t_1().border_color(theme.colors.border))
-            .child(body),
-    )
+    let body = branch_list(this, repo_id, scaled_px, BranchPick::Move { patch, path }, cx);
+    picker_shell(this, header, body, cx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn change_stats_counts_content_lines_only() {
+        let patch = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index 123..456 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,5 +1,6 @@
+ fn main() {
+-    let old = 1;
++    let new = 1;
++    let extra = 2;
+ }
+";
+        assert_eq!(hunk_change_stats(patch), (2, 1));
+    }
+
+    #[test]
+    fn change_stats_ignores_binary_and_empty_patches() {
+        assert_eq!(hunk_change_stats(""), (0, 0));
+        assert_eq!(hunk_change_stats("+++ b/x\n--- a/x\n@@ -0,0 +1 @@\n"), (0, 0));
+    }
 }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branches_prompt.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branches_prompt.rs
@@ -1,0 +1,200 @@
+use super::*;
+
+/// Stages the branch's assigned paths and opens the commit prompt so the user
+/// can commit only those changes to the current branch.
+fn commit_branch(
+    this: &mut PopoverHost,
+    repo_id: RepoId,
+    paths: Vec<std::path::PathBuf>,
+    window: &mut Window,
+    cx: &mut gpui::Context<PopoverHost>,
+) {
+    if !paths.is_empty() {
+        this.store.dispatch(Msg::StagePaths {
+            repo_id,
+            paths: paths.into(),
+        });
+    }
+    this.open_popover_centered(PopoverKind::CommitPrompt { repo_id }, window, cx);
+}
+
+fn branch_row(
+    this: &mut PopoverHost,
+    repo_id: RepoId,
+    branch: &gitcomet_core::domain::VirtualBranch,
+    scaled_px: impl Fn(f32) -> gpui::Pixels + Copy,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Div {
+    let theme = this.theme;
+    let branch_id = branch.id;
+    let name = branch.name.to_string();
+    let count = branch.paths.len();
+    let applied = branch.applied;
+    let pending = branch.pending;
+    let paths = branch.paths.clone();
+
+    let status_label = if pending {
+        "…"
+    } else if applied {
+        "applied"
+    } else {
+        "unapplied"
+    };
+    let status_color = if applied {
+        theme.colors.success
+    } else {
+        theme.colors.text_muted
+    };
+
+    let toggle_button = if applied {
+        components::Button::new(format!("vb_unapply_{branch_id}"), "Unapply")
+            .style(components::ButtonStyle::Outlined)
+            .disabled(pending || count == 0)
+            .on_click(theme, cx, move |this, _e, _w, _cx| {
+                this.store.dispatch(Msg::UnapplyVirtualBranch { repo_id, branch_id });
+            })
+    } else {
+        components::Button::new(format!("vb_apply_{branch_id}"), "Apply")
+            .style(components::ButtonStyle::Outlined)
+            .disabled(pending)
+            .on_click(theme, cx, move |this, _e, _w, _cx| {
+                this.store.dispatch(Msg::ApplyVirtualBranch { repo_id, branch_id });
+            })
+    };
+    let commit_button = components::Button::new(format!("vb_commit_{branch_id}"), "Commit")
+        .style(components::ButtonStyle::Outlined)
+        .disabled(count == 0)
+        .on_click(theme, cx, move |this, _e, window, cx| {
+            commit_branch(this, repo_id, paths.clone(), window, cx);
+        });
+    let delete_button =        components::Button::new(format!("vb_delete_{branch_id}"), "Delete")
+            .style(components::ButtonStyle::Outlined)
+            .disabled(pending)
+            .on_click(theme, cx, move |this, _e, _w, _cx| {
+                this.store.dispatch(Msg::DeleteVirtualBranch { repo_id, branch_id });
+            });
+
+    div()
+        .flex()
+        .items_center()
+        .gap(scaled_px(8.0))
+        .px(scaled_px(8.0))
+        .py(scaled_px(6.0))
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .min_w(px(0.0))
+                .flex_1()
+                .child(
+                    div()
+                        .text_sm()
+                        .font_weight(FontWeight::BOLD)
+                        .text_color(theme.colors.text)
+                        .child(name),
+                )
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(status_color)
+                        .child(format!("{status_label} · {count} file(s)")),
+                ),
+        )
+        .child(toggle_button)
+        .child(commit_button)
+        .child(delete_button)
+}
+
+pub(super) fn panel(
+    this: &mut PopoverHost,
+    repo_id: RepoId,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Div {
+    let theme = this.theme;
+    let ui_scale = super::popover_ui_scale(cx);
+    let ui_scale_percent = ui_scale.percent();
+    let width = super::LARGE_PICKER_WIDTH;
+    let scaled_px = |value: f32| super::popover_scaled_px_from_percent(value, ui_scale_percent);
+    let repo = this.state.repos.iter().find(|r| r.id == repo_id);
+    let branches = repo
+        .map(|r| &r.virtual_branches)
+        .cloned()
+        .unwrap_or_default();
+
+    let header = div()
+        .px(scaled_px(8.0))
+        .py(scaled_px(4.0))
+        .flex()
+        .items_center()
+        .justify_between()
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .min_w(px(0.0))
+                .child(
+                    div()
+                        .text_sm()
+                        .font_weight(FontWeight::BOLD)
+                        .child("Virtual Branches"),
+                )
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(theme.colors.text_muted)
+                        .line_height(scaled_px(14.0))
+                        .child("Group worktree changes and commit them separately"),
+                ),
+        )
+        .child(
+            components::Button::new("vb_close", "Close")
+                .style(components::ButtonStyle::Outlined)
+                .on_click(theme, cx, |this, _e, _w, cx| this.close_popover(cx)),
+        );
+
+    let list = if branches.is_empty() {
+        components::context_menu_label(
+            theme,
+            ui_scale_percent,
+            "No virtual branches yet. Right-click a changed file and pick “Assign to virtual branch…”.",
+            Some(this.tooltip_host.clone()),
+            cx,
+        )
+        .into_any_element()
+    } else {
+        let mut list = div().flex().flex_col().w_full();
+        for branch in branches.iter() {
+            list = list
+                .child(div().border_t_1().border_color(theme.colors.border_variant))
+                .child(branch_row(this, repo_id, branch, scaled_px, cx));
+        }
+        list.into_any_element()
+    };
+
+    let create_footer = div()
+        .border_t_1()
+        .border_color(theme.colors.border)
+        .px(scaled_px(8.0))
+        .py(scaled_px(6.0))
+        .flex()
+        .items_center()
+        .gap(scaled_px(6.0))
+        .child(this.virtual_branch_create_input.clone())
+        .child(
+            components::Button::new("vb_create_go", "Create")
+                .style(components::ButtonStyle::Filled)
+                .on_click(theme, cx, |this, _e, _w, cx| this.submit_create_virtual_branch(cx)),
+        );
+
+    components::context_menu(
+        theme,
+        div()
+            .flex()
+            .flex_col()
+            .w(width.preferred_px(ui_scale))
+            .child(header)
+            .child(div().border_t_1().border_color(theme.colors.border))
+            .child(list)
+            .child(create_footer),
+    )
+}

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branches_prompt.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branches_prompt.rs
@@ -41,9 +41,9 @@ fn branch_row(
         "unapplied"
     };
     let status_color = if applied {
-        theme.colors.success
+        theme.colors.status.success.foreground
     } else {
-        theme.colors.text_muted
+        theme.colors.foreground.secondary
     };
 
     let toggle_button = if applied {
@@ -51,14 +51,16 @@ fn branch_row(
             .style(components::ButtonStyle::Outlined)
             .disabled(pending || count == 0)
             .on_click(theme, cx, move |this, _e, _w, _cx| {
-                this.store.dispatch(Msg::UnapplyVirtualBranch { repo_id, branch_id });
+                this.store
+                    .dispatch(Msg::UnapplyVirtualBranch { repo_id, branch_id });
             })
     } else {
         components::Button::new(format!("vb_apply_{branch_id}"), "Apply")
             .style(components::ButtonStyle::Outlined)
             .disabled(pending)
             .on_click(theme, cx, move |this, _e, _w, _cx| {
-                this.store.dispatch(Msg::ApplyVirtualBranch { repo_id, branch_id });
+                this.store
+                    .dispatch(Msg::ApplyVirtualBranch { repo_id, branch_id });
             })
     };
     let commit_button = components::Button::new(format!("vb_commit_{branch_id}"), "Commit")
@@ -67,12 +69,13 @@ fn branch_row(
         .on_click(theme, cx, move |this, _e, window, cx| {
             commit_branch(this, repo_id, paths.clone(), window, cx);
         });
-    let delete_button =        components::Button::new(format!("vb_delete_{branch_id}"), "Delete")
-            .style(components::ButtonStyle::Outlined)
-            .disabled(pending)
-            .on_click(theme, cx, move |this, _e, _w, _cx| {
-                this.store.dispatch(Msg::DeleteVirtualBranch { repo_id, branch_id });
-            });
+    let delete_button = components::Button::new(format!("vb_delete_{branch_id}"), "Delete")
+        .style(components::ButtonStyle::Outlined)
+        .disabled(pending)
+        .on_click(theme, cx, move |this, _e, _w, _cx| {
+            this.store
+                .dispatch(Msg::DeleteVirtualBranch { repo_id, branch_id });
+        });
 
     div()
         .flex()
@@ -90,7 +93,7 @@ fn branch_row(
                     div()
                         .text_sm()
                         .font_weight(FontWeight::BOLD)
-                        .text_color(theme.colors.text)
+                        .text_color(theme.colors.foreground.primary)
                         .child(name),
                 )
                 .child(
@@ -146,7 +149,7 @@ pub(super) fn panel(
                 .child(
                     div()
                         .text_xs()
-                        .text_color(theme.colors.text_muted)
+                        .text_color(theme.colors.foreground.secondary)
                         .line_height(scaled_px(14.0))
                         .child("Group worktree changes and commit them separately"),
                 ),
@@ -199,7 +202,7 @@ pub(super) fn panel(
         let mut list = div().flex().flex_col().w_full();
         for branch in branches.iter() {
             list = list
-                .child(div().border_t_1().border_color(theme.colors.border_variant))
+                .child(div().border_t_1().border_color(theme.colors.stroke.subtle))
                 .child(branch_row(this, repo_id, branch, scaled_px, cx));
         }
         list.into_any_element()
@@ -207,7 +210,7 @@ pub(super) fn panel(
 
     let create_footer = div()
         .border_t_1()
-        .border_color(theme.colors.border)
+        .border_color(theme.colors.stroke.default)
         .px(scaled_px(8.0))
         .py(scaled_px(6.0))
         .flex()
@@ -217,7 +220,9 @@ pub(super) fn panel(
         .child(
             components::Button::new("vb_create_go", "Create")
                 .style(components::ButtonStyle::Filled)
-                .on_click(theme, cx, |this, _e, _w, cx| this.submit_create_virtual_branch(cx)),
+                .on_click(theme, cx, |this, _e, _w, cx| {
+                    this.submit_create_virtual_branch(cx)
+                }),
         );
 
     components::context_menu(
@@ -227,7 +232,7 @@ pub(super) fn panel(
             .flex_col()
             .w(width.preferred_px(ui_scale))
             .child(header)
-            .child(div().border_t_1().border_color(theme.colors.border))
+            .child(div().border_t_1().border_color(theme.colors.stroke.default))
             .child(list)
             .child(create_footer),
     )

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branches_prompt.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/virtual_branches_prompt.rs
@@ -120,6 +120,11 @@ pub(super) fn panel(
         .map(|r| &r.virtual_branches)
         .cloned()
         .unwrap_or_default();
+    let stale_ids = repo
+        .map(|r| gitcomet_state::model::stale_virtual_branch_ids(r))
+        .unwrap_or_default();
+    let has_stale = !stale_ids.is_empty();
+    let stale_ids_for_click = stale_ids.clone();
 
     let header = div()
         .px(scaled_px(8.0))
@@ -147,9 +152,38 @@ pub(super) fn panel(
                 ),
         )
         .child(
-            components::Button::new("vb_close", "Close")
-                .style(components::ButtonStyle::Outlined)
-                .on_click(theme, cx, |this, _e, _w, cx| this.close_popover(cx)),
+            div()
+                .flex()
+                .items_center()
+                .gap(scaled_px(6.0))
+                .child(
+                    components::Button::new("vb_prune_stale", "Clean up")
+                        .style(components::ButtonStyle::Outlined)
+                        .disabled(!has_stale)
+                        .on_click(theme, cx, move |this, _e, window, cx| {
+                            this.open_popover_centered(
+                                PopoverKind::PruneVirtualBranchesConfirm {
+                                    repo_id,
+                                    branch_ids: stale_ids_for_click.clone(),
+                                },
+                                window,
+                                cx,
+                            );
+                        })
+                        .gitcomet_tooltip(
+                            theme,
+                            if has_stale {
+                                "Remove branches whose assigned paths no longer have worktree changes".into()
+                            } else {
+                                "No stale branches".into()
+                            },
+                        ),
+                )
+                .child(
+                    components::Button::new("vb_close", "Close")
+                        .style(components::ButtonStyle::Outlined)
+                        .on_click(theme, cx, |this, _e, _w, cx| this.close_popover(cx)),
+                ),
         );
 
     let list = if branches.is_empty() {

--- a/crates/gitcomet-ui-gpui/src/view/panes/sidebar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panes/sidebar.rs
@@ -253,6 +253,10 @@ pub(in super::super) struct SidebarPaneView {
     /// When the request was made. Bounded so an unresolvable reveal expires
     /// instead of firing at some unrelated later moment.
     pending_file_browser_reveal_at: Option<std::time::Instant>,
+    /// Virtual branch row currently highlighted as a drop target while a worktree
+    /// file is dragged from the Changes panel. `None` when no drag hovers a
+    /// branch row.
+    pub(in super::super) virtual_branch_drop_hover: Option<u64>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -449,6 +453,7 @@ impl SidebarPaneView {
             collapsed_popover_section: None,
             pending_file_browser_reveal: None,
             pending_file_browser_reveal_at: None,
+            virtual_branch_drop_hover: None,
         };
         this.dispatch_sidebar_data_request_if_needed(cx);
         // Reflect any already-active repo's stored search query on first mount.

--- a/crates/gitcomet-ui-gpui/src/view/panes/sidebar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panes/sidebar.rs
@@ -2685,6 +2685,7 @@ fn is_section_header(row: &BranchSidebarRow) -> bool {
             | BranchSidebarRow::WorktreesHeader { .. }
             | BranchSidebarRow::SubmodulesHeader { .. }
             | BranchSidebarRow::StashHeader { .. }
+            | BranchSidebarRow::VirtualBranchesHeader { .. }
     )
 }
 

--- a/crates/gitcomet-ui-gpui/src/view/rows/benchmarks/repo_history.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/benchmarks/repo_history.rs
@@ -559,6 +559,27 @@ pub(in crate::view) fn hash_branch_sidebar_rows(rows: &[BranchSidebarRow]) -> u6
             BranchSidebarRow::PinnedHeader { collapsed, .. } => {
                 collapsed.hash(&mut h);
             }
+            BranchSidebarRow::VirtualBranchesHeader {
+                top_border,
+                collapsed,
+                ..
+            } => {
+                top_border.hash(&mut h);
+                collapsed.hash(&mut h);
+            }
+            BranchSidebarRow::VirtualBranchItem {
+                branch_id,
+                name,
+                path_count,
+                applied,
+                pending,
+            } => {
+                branch_id.hash(&mut h);
+                name.len().hash(&mut h);
+                path_count.hash(&mut h);
+                applied.hash(&mut h);
+                pending.hash(&mut h);
+            }
             BranchSidebarRow::SectionSpacer
             | BranchSidebarRow::WorktreesHeader { .. }
             | BranchSidebarRow::WorktreePlaceholder { .. }

--- a/crates/gitcomet-ui-gpui/src/view/rows/sidebar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/sidebar.rs
@@ -978,6 +978,10 @@ impl SidebarPaneView {
                     } else {
                         theme.colors.text_muted
                     };
+                    // Drop target for files dragged from the Changes panel:
+                    // assigning the file to this virtual branch. Highlight while
+                    // a file drag hovers the row.
+                    let drop_hover = this.virtual_branch_drop_hover == Some(branch_id);
                     div()
                         .id(("virtual_branch_item", branch_id))
                         .debug_selector(move || format!("virtual_branch_item_{branch_id}"))
@@ -989,6 +993,12 @@ impl SidebarPaneView {
                         .flex()
                         .items_center()
                         .gap(scaled_px(BRANCH_TREE_GAP_PX))
+                        .when(drop_hover, |d| {
+                            d.bg(with_alpha(
+                                theme.colors.accent,
+                                if theme.is_dark { 0.28 } else { 0.20 },
+                            ))
+                        })
                         .child(tree_icon_slot("icons/git_branch.svg", icon_muted, 12.0))
                         .child(
                             div()
@@ -1010,6 +1020,36 @@ impl SidebarPaneView {
                             theme,
                             format!("{name} — click to open the Virtual Branches workspace").into(),
                         )
+                        .can_drop(move |dragged, _window, _cx| {
+                            dragged.downcast_ref::<crate::view::dnd::StatusFileDrag>().is_some()
+                        })
+                        .on_drag_move(cx.listener(move |this, _e: &gpui::DragMoveEvent<
+                            crate::view::dnd::StatusFileDrag,
+                        >, _w, cx| {
+                            if this.virtual_branch_drop_hover != Some(branch_id) {
+                                this.virtual_branch_drop_hover = Some(branch_id);
+                                cx.notify();
+                            }
+                        }))
+                        .on_drop(cx.listener(
+                            move |this, drag: &crate::view::dnd::StatusFileDrag, _w, cx| {
+                                this.virtual_branch_drop_hover = None;
+                                if drag.repo_id == repo_id {
+                                    this.store.dispatch(Msg::AssignPathToVirtualBranch {
+                                        repo_id,
+                                        branch_id,
+                                        path: drag.path.clone(),
+                                    });
+                                }
+                                cx.notify();
+                            },
+                        ))
+                        .on_hover(cx.listener(move |this, hovering: &bool, _w, cx| {
+                            if !*hovering && this.virtual_branch_drop_hover == Some(branch_id) {
+                                this.virtual_branch_drop_hover = None;
+                                cx.notify();
+                            }
+                        }))
                         .on_click(cx.listener(move |this, e: &ClickEvent, window, cx| {
                             this.open_popover_at(
                                 PopoverKind::VirtualBranchesPrompt { repo_id },

--- a/crates/gitcomet-ui-gpui/src/view/rows/sidebar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/sidebar.rs
@@ -878,6 +878,148 @@ impl SidebarPaneView {
                         .gitcomet_tooltip(theme, tooltip.clone())
                         .into_any_element()
                 }
+                BranchSidebarRow::VirtualBranchesHeader {
+                    top_border,
+                    collapsed,
+                    collapse_key,
+                } => {
+                    let context_menu_invoker: SharedString =
+                        format!("virtual_branches_section_menu_{}", repo_id.0).into();
+                    let context_menu_active =
+                        this.active_context_menu_invoker.as_ref() == Some(&context_menu_invoker);
+                    let context_menu_invoker_for_right_click = context_menu_invoker.clone();
+                    let row_group: SharedString =
+                        format!("virtual_branches_section_row_{}", repo_id.0).into();
+                    let row_state =
+                        components::InteractiveRowState::default().open(context_menu_active);
+
+                    div()
+                        .id(("virtual_branches_section", ix))
+                        .debug_selector(move || format!("virtual_branches_section_{ix}"))
+                        .relative()
+                        .h(scaled_px(24.0))
+                        .w_full()
+                        .pl(indent_px(0))
+                        .pr_2()
+                        .group(row_group.clone())
+                        .flex()
+                        .items_center()
+                        .gap(scaled_px(BRANCH_TREE_GAP_PX))
+                        .interactive_row(row_style, row_state)
+                        .when(top_border, |d| {
+                            d.child(top_divider(theme.colors.border_variant))
+                        })
+                        .child(tree_toggle_slot(Some(collapsed)))
+                        .child(tree_icon_slot("icons/git_branch.svg", icon_primary, 14.0))
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w(px(0.0))
+                                .text_sm()
+                                .line_clamp(1)
+                                .whitespace_nowrap()
+                                .font_weight(FontWeight::BOLD)
+                                .text_color(theme.colors.text)
+                                .child("Virtual Branches"),
+                        )
+                        .gitcomet_tooltip(
+                            theme,
+                            "Virtual Branches (Right-click for actions)".into(),
+                        )
+                        .on_click(cx.listener(move |this, e: &ClickEvent, _w, cx| {
+                            if !e.standard_click() || e.click_count() != 1 {
+                                return;
+                            }
+                            this.toggle_active_repo_collapse_key(collapse_key.clone(), cx);
+                        }))
+                        .on_mouse_down(
+                            MouseButton::Right,
+                            cx.listener(move |this, e: &MouseDownEvent, window, cx| {
+                                cx.stop_propagation();
+                                this.activate_context_menu_invoker(
+                                    context_menu_invoker_for_right_click.clone(),
+                                    cx,
+                                );
+                                this.open_popover_at(
+                                    PopoverKind::VirtualBranchesPrompt { repo_id },
+                                    e.position,
+                                    window,
+                                    cx,
+                                );
+                            }),
+                        )
+                        .child(menu_dots_accessory(
+                            ix,
+                            "virtual_branches_section_dots",
+                            row_group.clone(),
+                            context_menu_invoker.clone(),
+                            PopoverKind::VirtualBranchesPrompt { repo_id },
+                            context_menu_active,
+                            cx,
+                        ))
+                        .into_any_element()
+                }
+                BranchSidebarRow::VirtualBranchItem {
+                    branch_id,
+                    name,
+                    path_count,
+                    applied,
+                    pending,
+                } => {
+                    let status = if pending {
+                        "…"
+                    } else if applied {
+                        "applied"
+                    } else {
+                        "unapplied"
+                    };
+                    let status_color = if applied {
+                        theme.colors.success
+                    } else {
+                        theme.colors.text_muted
+                    };
+                    div()
+                        .id(("virtual_branch_item", branch_id))
+                        .debug_selector(move || format!("virtual_branch_item_{branch_id}"))
+                        .relative()
+                        .h(scaled_px(22.0))
+                        .w_full()
+                        .pl(indent_px(1))
+                        .pr_2()
+                        .flex()
+                        .items_center()
+                        .gap(scaled_px(BRANCH_TREE_GAP_PX))
+                        .child(tree_icon_slot("icons/git_branch.svg", icon_muted, 12.0))
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w(px(0.0))
+                                .text_sm()
+                                .line_clamp(1)
+                                .whitespace_nowrap()
+                                .text_color(theme.colors.text)
+                                .child(name.clone()),
+                        )
+                        .child(
+                            div()
+                                .text_xs()
+                                .text_color(status_color)
+                                .child(format!("{status} · {path_count}")),
+                        )
+                        .gitcomet_tooltip(
+                            theme,
+                            format!("{name} — click to open the Virtual Branches workspace").into(),
+                        )
+                        .on_click(cx.listener(move |this, e: &ClickEvent, window, cx| {
+                            this.open_popover_at(
+                                PopoverKind::VirtualBranchesPrompt { repo_id },
+                                e.position(),
+                                window,
+                                cx,
+                            );
+                        }))
+                        .into_any_element()
+                }
                 BranchSidebarRow::Placeholder {
                     section: _,
                     message,

--- a/crates/gitcomet-ui-gpui/src/view/rows/sidebar.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/sidebar.rs
@@ -907,7 +907,7 @@ impl SidebarPaneView {
                         .gap(scaled_px(BRANCH_TREE_GAP_PX))
                         .interactive_row(row_style, row_state)
                         .when(top_border, |d| {
-                            d.child(top_divider(theme.colors.border_variant))
+                            d.child(top_divider(theme.colors.stroke.subtle))
                         })
                         .child(tree_toggle_slot(Some(collapsed)))
                         .child(tree_icon_slot("icons/git_branch.svg", icon_primary, 14.0))
@@ -919,7 +919,7 @@ impl SidebarPaneView {
                                 .line_clamp(1)
                                 .whitespace_nowrap()
                                 .font_weight(FontWeight::BOLD)
-                                .text_color(theme.colors.text)
+                                .text_color(theme.colors.foreground.primary)
                                 .child("Virtual Branches"),
                         )
                         .gitcomet_tooltip(
@@ -948,15 +948,6 @@ impl SidebarPaneView {
                                 );
                             }),
                         )
-                        .child(menu_dots_accessory(
-                            ix,
-                            "virtual_branches_section_dots",
-                            row_group.clone(),
-                            context_menu_invoker.clone(),
-                            PopoverKind::VirtualBranchesPrompt { repo_id },
-                            context_menu_active,
-                            cx,
-                        ))
                         .into_any_element()
                 }
                 BranchSidebarRow::VirtualBranchItem {
@@ -974,9 +965,9 @@ impl SidebarPaneView {
                         "unapplied"
                     };
                     let status_color = if applied {
-                        theme.colors.success
+                        theme.colors.status.success.foreground
                     } else {
-                        theme.colors.text_muted
+                        theme.colors.foreground.secondary
                     };
                     // Drop target for files dragged from the Changes panel:
                     // assigning the file to this virtual branch. Highlight while
@@ -995,7 +986,7 @@ impl SidebarPaneView {
                         .gap(scaled_px(BRANCH_TREE_GAP_PX))
                         .when(drop_hover, |d| {
                             d.bg(with_alpha(
-                                theme.colors.accent,
+                                theme.colors.accent.foreground,
                                 if theme.is_dark { 0.28 } else { 0.20 },
                             ))
                         })
@@ -1007,7 +998,7 @@ impl SidebarPaneView {
                                 .text_sm()
                                 .line_clamp(1)
                                 .whitespace_nowrap()
-                                .text_color(theme.colors.text)
+                                .text_color(theme.colors.foreground.primary)
                                 .child(name.clone()),
                         )
                         .child(
@@ -1021,16 +1012,21 @@ impl SidebarPaneView {
                             format!("{name} — click to open the Virtual Branches workspace").into(),
                         )
                         .can_drop(move |dragged, _window, _cx| {
-                            dragged.downcast_ref::<crate::view::dnd::StatusFileDrag>().is_some()
+                            dragged
+                                .downcast_ref::<crate::view::dnd::StatusFileDrag>()
+                                .is_some()
                         })
-                        .on_drag_move(cx.listener(move |this, _e: &gpui::DragMoveEvent<
-                            crate::view::dnd::StatusFileDrag,
-                        >, _w, cx| {
-                            if this.virtual_branch_drop_hover != Some(branch_id) {
-                                this.virtual_branch_drop_hover = Some(branch_id);
-                                cx.notify();
-                            }
-                        }))
+                        .on_drag_move(cx.listener(
+                            move |this,
+                                  _e: &gpui::DragMoveEvent<crate::view::dnd::StatusFileDrag>,
+                                  _w,
+                                  cx| {
+                                if this.virtual_branch_drop_hover != Some(branch_id) {
+                                    this.virtual_branch_drop_hover = Some(branch_id);
+                                    cx.notify();
+                                }
+                            },
+                        ))
                         .on_drop(cx.listener(
                             move |this, drag: &crate::view::dnd::StatusFileDrag, _w, cx| {
                                 this.virtual_branch_drop_hover = None;

--- a/crates/gitcomet-ui-gpui/src/view/rows/status.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/status.rs
@@ -619,6 +619,15 @@ fn status_row(
             }
         })
         .active(move |s| s.bg(theme.colors.interaction.pressed_background))
+        // Draggable onto virtual branch rows in the sidebar: dropping assigns
+        // the file to the branch (same as the context menu action).
+        .on_drag(
+            crate::view::dnd::StatusFileDrag {
+                repo_id,
+                path: entry.path.clone(),
+            },
+            crate::view::dnd::status_file_drag_carrier,
+        )
         .on_mouse_down(
             MouseButton::Right,
             cx.listener(move |this, e: &MouseDownEvent, window, cx| {


### PR DESCRIPTION
## Summary

This PR introduces a **virtual-branch workspace**: a way to work on several logically-separate changes in the working tree at the same time, *before* they become real Git commits/branches, by assigning individual files (or even individual diff hunks) in the working tree to lightweight, in-progress "virtual branches." It is a first, deliberately scoped prototype of a workflow popularized by tools like GitButler — applied here specifically to GitComet's own data model and UI, not a port of another tool's code.

## Why

Git's working tree is single-stream by construction: everything you've touched sits together in one undifferentiated pile of changes, and splitting that pile into several clean, independent commits/branches after the fact is manual, error-prone work — you have to remember which edit belonged to which idea, stage hunks by hand, and hope you don't accidentally mix two unrelated changes into the same commit.

In practice, this shows up constantly during normal development: you set out to fix one bug, and along the way you also touch a couple of unrelated files (a small cleanup here, an unrelated fix there) because that's where you happened to be working. At commit time you're now stuck manually untangling those changes with `git add -p` or a similar dance, or you give up and ship them together in one oversized, thematically-mixed commit — which then makes for a worse PR and a worse `git log`.

This feature moves that separation earlier and makes it continuous rather than a one-time cleanup step: as you edit, you assign each changed file (or a specific hunk within a file, see "Move hunk to virtual branch" below) to the virtual branch it conceptually belongs to, *while you're still working*, rather than reconstructing that grouping afterward from memory. When you're done, each virtual branch already represents one clean, coherent set of changes, ready to be committed and turned into a real branch/PR with no untangling step.

## What's included

This PR bundles five commits that build up the feature incrementally — each is a complete, working step on top of the previous one, and the branch is intended to be reviewed and merged as a whole (see "Why one PR" below), but the commit history is kept intact and readable rather than squashed:

1. **Virtual-branch workspace prototype with per-branch file assignment** — the foundational piece: a sidebar section listing virtual branches, a context-menu action on any changed file in the Status/Changes panel to assign it to a (new or existing) virtual branch, and the underlying state model (`gitcomet-state`) that tracks which paths belong to which virtual branch, independent of the actual Git index/worktree.
2. **Move hunk to virtual branch from the diff hunk context menu** — extends assignment down to sub-file granularity: a single unstaged hunk can be moved out of the working tree and parked in a virtual branch's own patch collection (the hunk's unified diff is captured and reverse-applied out of the worktree), so a file that mixes two unrelated changes no longer has to be assigned to just one branch as a whole.
3. **Cleanup of stale virtual branches with confirmation** — virtual branches that end up with no assigned paths and no parked patches left (e.g. because everything they held was moved elsewhere or reverted) are detected and offered up for removal, with a confirmation prompt, so the sidebar doesn't accumulate empty leftover branches over time.
4. **Drag & drop of worktree files onto virtual branches in the sidebar** — the same file-to-branch assignment from step 1, but via drag and drop: rows in the Changes panel become draggable, virtual branch rows in the sidebar become drop targets (with an accent highlight while a drag is hovering), for a faster assignment flow than opening the context menu every time.
5. **Persist virtual branches in session.json** — without this, the whole feature would only live in memory for the current app session. This adds serialization of the workspace's virtual-branch state (next-id allocator, per-branch path assignments, applied/unapplied state, parked unified patches) into the existing per-repo session file, saved on every mutation and restored when the repo is reopened or the session is restored — so virtual-branch assignments survive quitting and reopening GitComet, just like every other piece of session state already does.

## Scope and status

This is explicitly a **prototype-stage** feature: it covers the core loop (assign files/hunks to virtual branches, see them grouped in the sidebar, clean up empty ones, persist across sessions) but does not yet include turning a virtual branch into an actual Git commit/branch, or reconciling a virtual branch's parked patches against upstream changes — those are natural, separately-scoped follow-ups once this foundation is in. We think landing the foundation on its own, reviewable as one coherent unit, is preferable to holding it back until the entire end-to-end workflow is done.

## Why one PR for five commits

The five commits are sequentially dependent — each one only makes sense with the state model and UI surface the previous ones introduced (there is no clean intermediate state where, say, drag-and-drop assignment is useful without file-assignment already existing). Splitting them into five separate PRs would mean reviewing four of them in a state that doesn't build toward anything usable on its own. The commits are kept separate (rather than squashed into one) so each can still be reviewed and, if needed, bisected independently.

## Testing

- `cargo check --workspace` passes cleanly on the final state of the branch.
- `cargo fmt --all -- --check` passes cleanly.
- The `gitcomet-state` virtual-branch test suite passes in full: 22/22 tests (covering assignment, hunk-move/reverse-apply, stale-branch detection, and session persistence/restore round-trips).

## Notes for reviewers

This PR was prepared from a fork's branch that had diverged from `dev` for a while. Porting it forward required resolving real conflicts against upstream changes to several shared UI files (theme token renames, sidebar/status-row helpers that had since changed shape) — those adaptations are folded into the relevant commits so each one still compiles and passes its tests on its own, on top of current `dev`.
