### PR TITLE
Feat/nunjucks jinja2 and nix syntax highlight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,6 +2373,7 @@ dependencies = [
  "tree-sitter-html",
  "tree-sitter-java",
  "tree-sitter-javascript",
+ "tree-sitter-jinja-dialects",
  "tree-sitter-jsdoc",
  "tree-sitter-json",
  "tree-sitter-kotlin-sg",
@@ -7297,6 +7298,16 @@ name = "tree-sitter-javascript"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-jinja-dialects"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4035749204bb8f928ec08f67a1bb8c8a8de253966c5121ed5fe6d55645b5f9"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,6 +2380,7 @@ dependencies = [
  "tree-sitter-lua",
  "tree-sitter-make",
  "tree-sitter-md",
+ "tree-sitter-nix",
  "tree-sitter-objc",
  "tree-sitter-php",
  "tree-sitter-powershell",
@@ -7373,6 +7374,16 @@ dependencies = [
 name = "tree-sitter-md"
 version = "0.3.2"
 source = "git+https://github.com/tree-sitter-grammars/tree-sitter-markdown?rev=9a23c1a96c0513d8fc6520972beedd419a973539#9a23c1a96c0513d8fc6520972beedd419a973539"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-nix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4952a9733f3a98f6683a0ccd1035d84ab7a52f7e84eeed58548d86765ad92de3"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ tree-sitter-gowork = { git = "https://github.com/zed-industries/tree-sitter-go-w
 tree-sitter-html = "0.23.2"
 tree-sitter-javascript = "0.25.0"
 tree-sitter-java = "0.23.5"
+tree-sitter-jinja-dialects = "0.1.1"
 tree-sitter-jsdoc = "0.25.0"
 tree-sitter-json = "0.24.8"
 tree-sitter-kotlin-sg = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tree-sitter-kotlin-sg = "0.4.1"
 tree-sitter-lua = "0.5.0"
 tree-sitter-make = "1.1.1"
 tree-sitter-md = { git = "https://github.com/tree-sitter-grammars/tree-sitter-markdown", rev = "9a23c1a96c0513d8fc6520972beedd419a973539" }
+tree-sitter-nix = "0.3.0"
 tree-sitter-objc = "3.0.2"
 tree-sitter-php = "0.24.2"
 tree-sitter-powershell = "0.26.4"

--- a/crates/gitcomet-ui-gpui/Cargo.toml
+++ b/crates/gitcomet-ui-gpui/Cargo.toml
@@ -12,61 +12,13 @@ rust-version.workspace = true
 workspace = true
 
 [features]
-default = ["syntax-all"]
+default = []
 benchmarks = [
     "gitcomet-core/benchmarks",
     "gitcomet-state/benchmarks",
     "gitcomet-git-gix/benchmarks",
     "dep:gitcomet-git-gix",
     "gpui/test-support",
-]
-syntax-minimal = ["syntax-rust", "syntax-data", "syntax-shell"]
-syntax-common = ["syntax-minimal", "syntax-web", "syntax-python"]
-syntax-all = ["syntax-common", "syntax-go", "syntax-xml", "syntax-extra", "syntax-repo"]
-syntax-web = [
-    "dep:tree-sitter-css",
-    "dep:tree-sitter-html",
-    "dep:tree-sitter-javascript",
-    "dep:tree-sitter-jinja-dialects",
-    "dep:tree-sitter-jsdoc",
-    "dep:tree-sitter-regex",
-    "dep:tree-sitter-typescript",
-    "dep:tree-sitter-vue",
-]
-syntax-rust = ["dep:tree-sitter-rust"]
-syntax-python = ["dep:tree-sitter-python"]
-syntax-go = ["dep:tree-sitter-go"]
-syntax-data = ["dep:tree-sitter-json", "dep:tree-sitter-yaml"]
-syntax-shell = ["dep:tree-sitter-bash"]
-syntax-xml = ["dep:tree-sitter-xml"]
-syntax-extra = [
-    "dep:tree-sitter-bicep",
-    "dep:tree-sitter-c",
-    "dep:tree-sitter-c-sharp",
-    "dep:tree-sitter-cpp",
-    "dep:tree-sitter-dart",
-    "dep:tree-sitter-fsharp",
-    "dep:tree-sitter-java",
-    "dep:tree-sitter-kotlin-sg",
-    "dep:tree-sitter-lua",
-    "dep:tree-sitter-make",
-    "dep:tree-sitter-objc",
-    "dep:tree-sitter-php",
-    "dep:tree-sitter-powershell",
-    "dep:tree-sitter-r",
-    "dep:tree-sitter-ruby",
-    "dep:tree-sitter-scala",
-    "dep:tree-sitter-sequel",
-    "dep:tree-sitter-swift",
-    "dep:tree-sitter-toml-ng",
-    "dep:tree-sitter-zig",
-]
-syntax-repo = [
-    "dep:tree-sitter-diff",
-    "dep:tree-sitter-gitcommit",
-    "dep:tree-sitter-gomod",
-    "dep:tree-sitter-gowork",
-    "dep:tree-sitter-md",
 ]
 
 [dependencies]
@@ -98,46 +50,47 @@ stats_alloc = { workspace = true }
 sysinfo = { workspace = true }
 tempfile = { workspace = true }
 tree-sitter = { workspace = true }
-tree-sitter-bash = { workspace = true, optional = true }
-tree-sitter-bicep = { workspace = true, optional = true }
-tree-sitter-c = { workspace = true, optional = true }
-tree-sitter-c-sharp = { workspace = true, optional = true }
-tree-sitter-cpp = { workspace = true, optional = true }
-tree-sitter-css = { workspace = true, optional = true }
-tree-sitter-dart = { workspace = true, optional = true }
-tree-sitter-diff = { workspace = true, optional = true }
-tree-sitter-fsharp = { workspace = true, optional = true }
-tree-sitter-gitcommit = { workspace = true, optional = true }
-tree-sitter-go = { workspace = true, optional = true }
-tree-sitter-gomod = { workspace = true, optional = true }
-tree-sitter-gowork = { workspace = true, optional = true }
-tree-sitter-html = { workspace = true, optional = true }
-tree-sitter-jinja-dialects = { workspace = true, optional = true }
-tree-sitter-javascript = { workspace = true, optional = true }
-tree-sitter-java = { workspace = true, optional = true }
-tree-sitter-jsdoc = { workspace = true, optional = true }
-tree-sitter-json = { workspace = true, optional = true }
-tree-sitter-kotlin-sg = { workspace = true, optional = true }
-tree-sitter-lua = { workspace = true, optional = true }
-tree-sitter-make = { workspace = true, optional = true }
-tree-sitter-md = { workspace = true, optional = true }
-tree-sitter-objc = { workspace = true, optional = true }
-tree-sitter-php = { workspace = true, optional = true }
-tree-sitter-powershell = { workspace = true, optional = true }
-tree-sitter-python = { workspace = true, optional = true }
-tree-sitter-r = { workspace = true, optional = true }
-tree-sitter-regex = { workspace = true, optional = true }
-tree-sitter-ruby = { workspace = true, optional = true }
-tree-sitter-rust = { workspace = true, optional = true }
-tree-sitter-scala = { workspace = true, optional = true }
-tree-sitter-sequel = { workspace = true, optional = true }
-tree-sitter-swift = { workspace = true, optional = true }
-tree-sitter-toml-ng = { workspace = true, optional = true }
-tree-sitter-typescript = { workspace = true, optional = true }
-tree-sitter-vue = { workspace = true, optional = true }
-tree-sitter-xml = { workspace = true, optional = true }
-tree-sitter-yaml = { workspace = true, optional = true }
-tree-sitter-zig = { workspace = true, optional = true }
+tree-sitter-bash = { workspace = true }
+tree-sitter-bicep = { workspace = true }
+tree-sitter-c = { workspace = true }
+tree-sitter-c-sharp = { workspace = true }
+tree-sitter-cpp = { workspace = true }
+tree-sitter-css = { workspace = true }
+tree-sitter-dart = { workspace = true }
+tree-sitter-diff = { workspace = true }
+tree-sitter-fsharp = { workspace = true }
+tree-sitter-gitcommit = { workspace = true }
+tree-sitter-go = { workspace = true }
+tree-sitter-gomod = { workspace = true }
+tree-sitter-gowork = { workspace = true }
+tree-sitter-html = { workspace = true }
+tree-sitter-jinja-dialects = { workspace = true }
+tree-sitter-javascript = { workspace = true }
+tree-sitter-java = { workspace = true }
+tree-sitter-jsdoc = { workspace = true }
+tree-sitter-json = { workspace = true }
+tree-sitter-kotlin-sg = { workspace = true }
+tree-sitter-lua = { workspace = true }
+tree-sitter-make = { workspace = true }
+tree-sitter-md = { workspace = true }
+tree-sitter-nix = { workspace = true }
+tree-sitter-objc = { workspace = true }
+tree-sitter-php = { workspace = true }
+tree-sitter-powershell = { workspace = true }
+tree-sitter-python = { workspace = true }
+tree-sitter-r = { workspace = true }
+tree-sitter-regex = { workspace = true }
+tree-sitter-ruby = { workspace = true }
+tree-sitter-rust = { workspace = true }
+tree-sitter-scala = { workspace = true }
+tree-sitter-sequel = { workspace = true }
+tree-sitter-swift = { workspace = true }
+tree-sitter-toml-ng = { workspace = true }
+tree-sitter-typescript = { workspace = true }
+tree-sitter-vue = { workspace = true }
+tree-sitter-xml = { workspace = true }
+tree-sitter-yaml = { workspace = true }
+tree-sitter-zig = { workspace = true }
 unicode-segmentation = { workspace = true }
 url = { workspace = true }
 ureq = { workspace = true }
@@ -167,46 +120,6 @@ gitcomet-core = { workspace = true, features = ["test-support"] }
 gitcomet-state = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 criterion = { workspace = true }
-tree-sitter-bash = { workspace = true }
-tree-sitter-bicep = { workspace = true }
-tree-sitter-c = { workspace = true }
-tree-sitter-c-sharp = { workspace = true }
-tree-sitter-cpp = { workspace = true }
-tree-sitter-css = { workspace = true }
-tree-sitter-dart = { workspace = true }
-tree-sitter-diff = { workspace = true }
-tree-sitter-fsharp = { workspace = true }
-tree-sitter-gitcommit = { workspace = true }
-tree-sitter-go = { workspace = true }
-tree-sitter-gomod = { workspace = true }
-tree-sitter-gowork = { workspace = true }
-tree-sitter-html = { workspace = true }
-tree-sitter-jinja-dialects = { workspace = true }
-tree-sitter-javascript = { workspace = true }
-tree-sitter-java = { workspace = true }
-tree-sitter-jsdoc = { workspace = true }
-tree-sitter-json = { workspace = true }
-tree-sitter-kotlin-sg = { workspace = true }
-tree-sitter-lua = { workspace = true }
-tree-sitter-make = { workspace = true }
-tree-sitter-md = { workspace = true }
-tree-sitter-objc = { workspace = true }
-tree-sitter-php = { workspace = true }
-tree-sitter-powershell = { workspace = true }
-tree-sitter-python = { workspace = true }
-tree-sitter-r = { workspace = true }
-tree-sitter-regex = { workspace = true }
-tree-sitter-ruby = { workspace = true }
-tree-sitter-rust = { workspace = true }
-tree-sitter-scala = { workspace = true }
-tree-sitter-sequel = { workspace = true }
-tree-sitter-swift = { workspace = true }
-tree-sitter-toml-ng = { workspace = true }
-tree-sitter-typescript = { workspace = true }
-tree-sitter-vue = { workspace = true }
-tree-sitter-xml = { workspace = true }
-tree-sitter-yaml = { workspace = true }
-tree-sitter-zig = { workspace = true }
 
 [build-dependencies]
 resvg = { workspace = true }

--- a/crates/gitcomet-ui-gpui/Cargo.toml
+++ b/crates/gitcomet-ui-gpui/Cargo.toml
@@ -27,6 +27,7 @@ syntax-web = [
     "dep:tree-sitter-css",
     "dep:tree-sitter-html",
     "dep:tree-sitter-javascript",
+    "dep:tree-sitter-jinja-dialects",
     "dep:tree-sitter-jsdoc",
     "dep:tree-sitter-regex",
     "dep:tree-sitter-typescript",
@@ -111,6 +112,7 @@ tree-sitter-go = { workspace = true, optional = true }
 tree-sitter-gomod = { workspace = true, optional = true }
 tree-sitter-gowork = { workspace = true, optional = true }
 tree-sitter-html = { workspace = true, optional = true }
+tree-sitter-jinja-dialects = { workspace = true, optional = true }
 tree-sitter-javascript = { workspace = true, optional = true }
 tree-sitter-java = { workspace = true, optional = true }
 tree-sitter-jsdoc = { workspace = true, optional = true }
@@ -179,6 +181,7 @@ tree-sitter-go = { workspace = true }
 tree-sitter-gomod = { workspace = true }
 tree-sitter-gowork = { workspace = true }
 tree-sitter-html = { workspace = true }
+tree-sitter-jinja-dialects = { workspace = true }
 tree-sitter-javascript = { workspace = true }
 tree-sitter-java = { workspace = true }
 tree-sitter-jsdoc = { workspace = true }

--- a/crates/gitcomet-ui-gpui/assets/icons/file_icons/jinja.svg
+++ b/crates/gitcomet-ui-gpui/assets/icons/file_icons/jinja.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.15625 3C4.28125 3 4.28125 4.5 4.28125 5.5C4.28125 6.5 3.78125 7.50106 2.78125 8C3.78125 8.50106 4.28125 9.5 4.28125 10.5C4.28125 11.5 4.28125 13 6.15625 13" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.86719 3C11.7422 3 11.7422 4.5 11.7422 5.5C11.7422 6.5 12.2422 7.50106 13.2422 8C12.2422 8.50106 11.7422 9.5 11.7422 10.5C11.7422 11.5 11.7422 13 9.86719 13" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="8" cy="8" r="1.15" fill="black"/>
+</svg>

--- a/crates/gitcomet-ui-gpui/assets/icons/file_icons/nunjucks.svg
+++ b/crates/gitcomet-ui-gpui/assets/icons/file_icons/nunjucks.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.15625 3C4.28125 3 4.28125 4.5 4.28125 5.5C4.28125 6.5 3.78125 7.50106 2.78125 8C3.78125 8.50106 4.28125 9.5 4.28125 10.5C4.28125 11.5 4.28125 13 6.15625 13" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.86719 3C11.7422 3 11.7422 4.5 11.7422 5.5C11.7422 6.5 12.2422 7.50106 13.2422 8C12.2422 8.50106 11.7422 9.5 11.7422 10.5C11.7422 11.5 11.7422 13 9.86719 13" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.4 5.9L6.6 10.1" stroke="black" stroke-width="1.1" stroke-linecap="round"/>
+<circle cx="6.75" cy="6.35" r="0.75" fill="black"/>
+<circle cx="9.25" cy="9.65" r="0.75" fill="black"/>
+</svg>

--- a/crates/gitcomet-ui-gpui/assets/open_source_licenses.tsv
+++ b/crates/gitcomet-ui-gpui/assets/open_source_licenses.tsv
@@ -672,6 +672,7 @@ tree-sitter-gowork	0.0.1	MIT
 tree-sitter-html	0.23.2	MIT
 tree-sitter-java	0.23.5	MIT
 tree-sitter-javascript	0.25.0	MIT
+tree-sitter-jinja-dialects	0.1.1	MIT
 tree-sitter-jsdoc	0.25.0	MIT
 tree-sitter-json	0.24.8	MIT
 tree-sitter-kotlin-sg	0.4.1	MIT

--- a/crates/gitcomet-ui-gpui/assets/open_source_licenses.tsv
+++ b/crates/gitcomet-ui-gpui/assets/open_source_licenses.tsv
@@ -680,6 +680,7 @@ tree-sitter-language	0.1.7	MIT
 tree-sitter-lua	0.5.0	MIT
 tree-sitter-make	1.1.1	MIT
 tree-sitter-md	0.3.2	MIT
+tree-sitter-nix	0.3.0	MIT
 tree-sitter-objc	3.0.2	MIT
 tree-sitter-php	0.24.2	MIT
 tree-sitter-powershell	0.26.4	MIT

--- a/crates/gitcomet-ui-gpui/src/view/file_icons.rs
+++ b/crates/gitcomet-ui-gpui/src/view/file_icons.rs
@@ -127,6 +127,12 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     ("ipynb", &["ipynb"]),
     ("java", &["java"]),
     ("javascript", &["cjs", "js", "mjs"]),
+    // Not in Zed's icon theme: GitComet highlights Nunjucks/Jinja templates (see
+    // DiffSyntaxLanguage::Jinja) and a template file falling back to the generic
+    // page icon reads as "unknown type". The split between the two keys is
+    // cosmetic -- one grammar serves both -- but `.njk` and `.j2` come from
+    // different ecosystems and users sort by icon.
+    ("jinja", &["j2", "jinja", "jinja2", "twig", "dj"]),
     ("json", &["json", "jsonc"]),
     ("julia", &["jl"]),
     ("kdl", &["kdl"]),
@@ -139,6 +145,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     ("metal", &["metal"]),
     ("nim", &["nim", "nims", "nimble"]),
     ("nix", &["nix"]),
+    ("nunjucks", &["njk", "nunjucks"]), // see the `jinja` entry above
     ("ocaml", &["ml", "mli", "mlx"]),
     ("odin", &["odin"]),
     ("php", &["php"]),
@@ -299,6 +306,7 @@ const FILE_ICONS: &[(&str, &str)] = &[
     ("ipynb", "icons/file_icons/jupyter.svg"),
     ("java", "icons/file_icons/java.svg"),
     ("javascript", "icons/file_icons/javascript.svg"),
+    ("jinja", "icons/file_icons/jinja.svg"),
     ("json", "icons/file_icons/code.svg"),
     ("julia", "icons/file_icons/julia.svg"),
     ("kdl", "icons/file_icons/kdl.svg"),
@@ -311,6 +319,7 @@ const FILE_ICONS: &[(&str, &str)] = &[
     ("metal", "icons/file_icons/metal.svg"),
     ("nim", "icons/file_icons/nim.svg"),
     ("nix", "icons/file_icons/nix.svg"),
+    ("nunjucks", "icons/file_icons/nunjucks.svg"),
     ("ocaml", "icons/file_icons/ocaml.svg"),
     ("odin", "icons/file_icons/odin.svg"),
     ("phoenix", "icons/file_icons/phoenix.svg"),
@@ -476,6 +485,8 @@ pub fn file_icon_color(icon_path: &str, is_dark: bool) -> Option<gpui::Rgba> {
         "css" => (0x6BB4F0, 0x1572B6),
         "sass" => (0xE689B8, 0xBF5590),
         "vue" => (0x6BD3A0, 0x2F9668),
+        "nunjucks" => (0x7FBF6E, 0x3D8137),
+        "jinja" => (0xD86A6A, 0xB41717),
         "astro" => (0xF09668, 0xC6551A),
         "yaml" => (0xB8A2D8, 0x7A5C9E),
         "toml" => (0xC79378, 0x9C5B3C),

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/queries/jinja_highlights.scm
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/queries/jinja_highlights.scm
@@ -1,0 +1,81 @@
+; Derived from tree-sitter-jinja-dialects' queries/highlights.scm
+; (https://github.com/bennypowers/tree-sitter-jinja-dialects, MIT) at v0.1.1.
+;
+; The grammar parses the union of Jinja2, Nunjucks, Twig, Tera, Inja and Django
+; template syntax, so one query serves every extension in the `Jinja` arm of
+; diff_syntax_language_for_identifier.
+;
+; Local changes vs upstream:
+;   - the single `@keyword` list is split. Control flow becomes
+;     `@keyword.control`, which GitComet renders semibold (see
+;     syntax_highlight_style in ../build.rs); declarations and modifiers stay
+;     `@keyword`. Upstream has no reason to care -- the distinction only exists
+;     because this theme draws the two differently.
+;   - `@function.builtin` is kept rather than narrowed to `@function`: the
+;     capture-name table trims dotted suffixes progressively, so it already
+;     lands on Function, and keeping the upstream name means a future
+;     `function.builtin` colour needs no change here.
+;
+; Note the delimiters are captured on the anonymous tokens (`{{`, `{%-`, `#}`)
+; rather than on the enclosing `output`/`statement`/`comment` node. Capturing
+; the container would paint the whole tag, and `@none` cannot be used to punch
+; the interior back out -- it emits no token at all, so the outer capture simply
+; wins. vue_highlights.scm captures `{{`/`}}` for the same reason.
+
+(comment) @comment
+
+(string) @string
+(integer) @number
+(float) @number
+(boolean) @boolean
+(none) @constant.builtin
+
+(identifier) @variable
+
+(member_expression
+  property: (identifier) @property)
+
+(call_expression
+  function: (identifier) @function)
+
+(filter_expression
+  name: (identifier) @function.builtin)
+
+(test_expression
+  name: (identifier) @function.builtin)
+
+(keyword_argument
+  key: (identifier) @property)
+
+(pair
+  key: (identifier) @property)
+
+["{{" "{{-" "{{~" "}}" "-}}" "~}}"
+ "{%" "{%-" "{%~" "%}" "-%}" "~%}"
+ "{#" "{#-" "{#~" "#}" "-#}" "~#}"] @punctuation.special
+
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
+
+["," "." "|" "~"] @punctuation.delimiter
+
+["+" "-" "*" "/" "//" "%" "**"
+ "==" "!=" "<" ">" "<=" ">=" "===" "!=="
+ "??" "?." "?" ":"
+ "b-and" "b-or" "b-xor"] @operator
+
+; Control flow and the block terminators that pair with it.
+["if" "elif" "elseif" "else" "endif"
+ "for" "in" "endfor" "recursive"
+ "is" "not" "and" "or"] @keyword.control
+
+; Declarations, imports and tag modifiers.
+["block" "endblock" "extends"
+ "macro" "endmacro" "call" "endcall"
+ "filter" "endfilter" "raw" "endraw"
+ "set" "endset" "with" "endwith"
+ "include" "import" "from" "as"
+ "autoescape" "endautoescape"
+ "do"
+ "ignore" "missing" "scoped"
+ "verbatim" "endverbatim"
+ "context" "without"] @keyword

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/queries/jinja_injections.scm
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/queries/jinja_injections.scm
@@ -1,0 +1,31 @@
+; The template grammar is "template-first": it parses the `{{ }}` / `{% %}` /
+; `{# #}` tags and exposes everything between them as opaque `text` nodes. All
+; of the HTML in a `.njk` or `.j2` file lives in those nodes.
+;
+; `injection.combined` is what makes that work. Without it every text run would
+; be its own layer: an entry each in the 32-slot TS_INJECTION_CACHE, and an
+; independent HTML parse, so a `<ul>` opened before `{% for %}` would be unknown
+; by the time `<li>` appeared after it. Combined, the whole set is parsed once
+; with `set_included_ranges`, which is both one cache-free parse per window and a
+; single coherent HTML document. See apply_combined_injection_tokens in
+; ../syntax/prepared.rs.
+;
+; The target is a `#set!` literal rather than an `@injection.language` capture
+; on purpose: warm_reachable_highlight_specs (../syntax/language.rs) discovers
+; injection targets by reading literal `#set! injection.language` values off the
+; compiled query, so this is what gets the HTML spec compiled on the warm-up
+; thread instead of inline on the first draw.
+;
+; HTML is in the `syntax-web` feature bucket, and so is this grammar. Naming a
+; language from another bucket would resolve to no grammar under
+; `--features syntax-web` alone -- and `cfg(test)` force-enables every grammar,
+; so no test could catch it. queries/vue_injections.scm documents that trap at
+; length.
+;
+; TS_MAX_INJECTION_DEPTH is 1, so the HTML layer cannot itself inject: `<script>`
+; and `<style>` *bodies* inside a template stay uncoloured. Their tags and
+; attributes still highlight.
+
+((text) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.combined))

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/queries/nix_highlights.scm
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/queries/nix_highlights.scm
@@ -1,0 +1,159 @@
+; Derived from tree-sitter-nix' queries/highlights.scm
+; (https://github.com/nix-community/tree-sitter-nix, MIT) as bundled with the
+; v0.3.0 crate, so every node kind and field name here is known-valid against
+; the grammar this compiles against.
+;
+; REORDERED. Upstream is written for tree-sitter-highlight, where the *first*
+; matching pattern wins. This engine resolves overlaps differently
+; (`normalize_non_overlapping_tokens` in ../syntax/prepared.rs): it splits every
+; overlap into atomic slices and gives each slice to the **last containing
+; capture in emission order**. The query cursor emits captures in node start-byte
+; order, which makes that rule shake out as:
+;
+;   - different nodes -> the inner one wins on its own bytes, because it starts
+;     later. `(escape_sequence)` inside a `(string_expression)`, or the `${` of an
+;     interpolation, need no help from this file's ordering; they are handled by
+;     position no matter where their rules sit.
+;   - the *same* node captured by two patterns -> the start bytes tie, so the tie
+;     breaks on pattern index, i.e. **the later rule in this file wins**.
+;
+; Only the second case bites, and in this grammar it is entirely the `(identifier)`
+; family: upstream ends with a blanket `(identifier) @variable`, which under that
+; rule buries `@variable.builtin`, `@function.builtin`, `@variable.parameter` and
+; both `@property` rules -- every one of which captures an identifier too. So the
+; identifier rules run generic-first, specific-last:
+;
+;   `(identifier) @variable`  ->  property / parameter / function  ->  builtins
+;
+; `nix_specific_captures_survive_the_generic_identifier_rule` is the guard, and it
+; does fail against upstream's ordering. Anything re-synced from upstream has to
+; be re-sorted the same way.
+;
+; The non-identifier rules below are grouped for readability only; their order
+; carries no meaning.
+;
+; Local changes beyond the reordering:
+;   - upstream's bare `(identifier) @property` catch-all is dropped. It exists to
+;     catch attrpath positions that the `binding` / `select_expression` /
+;     `inherit_from` rules already name explicitly, and as a second generic
+;     fallback it just fights `(identifier) @variable` for every identifier in
+;     the file.
+;   - upstream's `(variable_expression (identifier)) @variable` is dropped as
+;     subsumed by the generic rule, which now runs first and assigns the same kind.
+;
+; Two upstream constructs are kept verbatim and are inert here by design:
+;   - `(#is-not? local)` needs a locals query, which GitComet does not implement.
+;     tree-sitter routes unknown predicates to `general_predicates` rather than
+;     failing to compile, so this neither breaks `Query::new` nor has any effect;
+;     the builtin rules simply always fire. That is what we want -- `builtins`,
+;     `map` and `import` stay coloured even where a local shadows them. `#offset!`
+;     is already ignored the same way elsewhere in the tree.
+;   - `(_) @embedded` marks the interpolated expression. `embedded` maps to `None`
+;     in `syntax_kind_for_capture_name` and the token loop skips `None` captures,
+;     so it emits nothing and leaves the interior to the rules above.
+
+; --- literals, keywords, operators, punctuation -----------------------------
+
+(comment) @comment
+
+[
+  "if"
+  "then"
+  "else"
+  "let"
+  "inherit"
+  "in"
+  "rec"
+  "with"
+  "assert"
+  "or"
+] @keyword
+
+[
+  (integer_expression)
+  (float_expression)
+] @number
+
+(unary_expression
+  operator: _ @operator)
+
+(binary_expression
+  operator: _ @operator)
+
+[
+  ";"
+  "."
+  ","
+  "="
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+; --- strings, and what nests inside them ------------------------------------
+
+[
+  (string_expression)
+  (indented_string_expression)
+] @string
+
+[
+  (path_expression)
+  (hpath_expression)
+  (spath_expression)
+] @string.special.path
+
+(uri_expression) @string.special.uri
+
+(escape_sequence) @escape
+(dollar_escape) @escape
+
+(interpolation
+  "${" @punctuation.special
+  (_) @embedded
+  "}" @punctuation.special)
+
+; --- identifiers: generic base ... -----------------------------------------
+
+(identifier) @variable
+
+; --- ... then structural roles ... ------------------------------------------
+
+(select_expression
+  attrpath: (attrpath (identifier)) @property)
+
+(binding
+  attrpath: (attrpath (identifier)) @property)
+
+(inherit_from attrs: (inherited_attrs attr: (identifier) @property) )
+
+(function_expression
+  universal: (identifier) @variable.parameter
+)
+
+(formal
+  name: (identifier) @variable.parameter
+  "?"? @punctuation.delimiter)
+
+(apply_expression
+  function: [
+    (variable_expression (identifier)) @function
+    (select_expression
+      attrpath: (attrpath
+        attr: (identifier) @function .))])
+
+; --- ... then builtins, which must win outright -----------------------------
+
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(__currentSystem|__currentTime|__langVersion|__nixPath|__nixVersion|__storeDir|builtins|false|null|true)$")
+ (#is-not? local))
+
+((identifier) @function.builtin
+ (#match? @function.builtin "^(__add|__addErrorContext|__all|__any|__appendContext|__attrNames|__attrValues|__bitAnd|__bitOr|__bitXor|__catAttrs|__ceil|__compareVersions|__concatLists|__concatMap|__concatStringsSep|__deepSeq|__div|__elem|__elemAt|__fetchurl|__filter|__filterSource|__findFile|__flakeRefToString|__floor|__foldl'|__fromJSON|__functionArgs|__genList|__genericClosure|__getAttr|__getContext|__getEnv|__getFlake|__groupBy|__hasAttr|__hasContext|__hashFile|__hashString|__head|__intersectAttrs|__isAttrs|__isBool|__isFloat|__isFunction|__isInt|__isList|__isPath|__isString|__length|__lessThan|__listToAttrs|__mapAttrs|__match|__mul|__parseDrvName|__parseFlakeRef|__partition|__path|__pathExists|__readDir|__readFile|__readFileType|__replaceStrings|__seq|__sort|__split|__splitVersion|__storePath|__stringLength|__sub|__substring|__tail|__toFile|__toJSON|__toPath|__toXML|__trace|__traceVerbose|__tryEval|__typeOf|__unsafeDiscardOutputDependency|__unsafeDiscardStringContext|__unsafeGetAttrPos|__zipAttrsWith|abort|baseNameOf|break|derivation|derivationStrict|dirOf|fetchGit|fetchMercurial|fetchTarball|fetchTree|fromTOML|import|isNull|map|placeholder|removeAttrs|scopedImport|throw|toString)$")
+ (#is-not? local))

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/queries/nix_injections.scm
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/queries/nix_injections.scm
@@ -1,0 +1,64 @@
+; Derived from tree-sitter-nix' queries/injections.scm
+; (https://github.com/nix-community/tree-sitter-nix, MIT) as bundled with the
+; v0.3.0 crate.
+;
+; Nix files carry shell script in indented strings all over the place -- every
+; `shellHook`, `buildPhase`, `preInstall`, `writeShellScript` -- and without this
+; the densest code in a derivation renders as one flat string.
+;
+; Every rule is `injection.combined`, and it matters for a reason unrelated to
+; how many bindings a file has: a single `''…''` is split by the grammar into
+; several `string_fragment` nodes wherever a `${…}` interpolation interrupts it.
+; Combined, they parse as one shell script; separately, each fragment is its own
+; document and a `if` opened before an interpolation never finds its `fi`.
+; See apply_combined_injection_tokens in ../syntax/prepared.rs.
+;
+; Local changes vs upstream:
+;   - upstream's first rule is dropped. It reads a language name out of a
+;     preceding comment through an `@injection.language` capture, which resolves
+;     arbitrary free text against the alias table, and -- being a capture rather
+;     than a `#set!` literal -- is invisible to `warm_reachable_highlight_specs`,
+;     so whatever it resolves to pays its query-compile cost on the draw path.
+;     The four `bash` rules below all name their target as a literal.
+;
+; TS_MAX_INJECTION_DEPTH is 1, so the bash layer cannot inject further: a
+; heredoc'd awk or python inside a shellHook stays plain.
+
+; pkg.buildPhase / preInstall / installPhase / *Script / *Hook / *.startup
+((binding
+   attrpath: (attrpath (identifier) @_path)
+   expression: (indented_string_expression
+     (string_fragment) @injection.content))
+ (#match? @_path "(^\\w*Phase|(pre|post)\\w*|(.*\\.)?\\w*([sS]cript|[hH]ook)|(.*\\.)?startup)$")
+ (#set! injection.language "bash")
+ (#set! injection.combined))
+
+; pkgs.writeShellScript "name" '' … ''
+((apply_expression
+   function: (apply_expression function: (_) @_func)
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_func "(^|\\.)writeShellScript(Bin)?$")
+ (#set! injection.language "bash")
+ (#set! injection.combined))
+
+; pkgs.runCommand "name" { … } '' … ''
+(apply_expression
+  (apply_expression
+    function: (apply_expression
+      function: ((_) @_func)))
+    argument: (indented_string_expression (string_fragment) @injection.content)
+  (#match? @_func "(^|\\.)runCommand(((No)?(CC))?(Local)?)?$")
+  (#set! injection.language "bash")
+  (#set! injection.combined))
+
+; pkgs.writeShellApplication { text = '' … ''; }
+(apply_expression
+  function: ((_) @_func)
+  argument: (_ (_)* (_ (_)* (binding
+    attrpath: (attrpath (identifier) @_path)
+     expression: (indented_string_expression
+       (string_fragment) @injection.content))))
+  (#match? @_func "(^|\\.)writeShellApplication$")
+  (#match? @_path "^text$")
+  (#set! injection.language "bash")
+  (#set! injection.combined))

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax.rs
@@ -31,79 +31,44 @@ pub(in crate::view) const PREPARED_DIFF_SYNTAX_DOCUMENT_MAX_TEXT_BYTES: usize = 
 const TS_PREPARED_DOCUMENT_MAX_TEXT_BYTES: usize = PREPARED_DIFF_SYNTAX_DOCUMENT_MAX_TEXT_BYTES;
 const TS_SHARED_DOCUMENT_SEED_MAX_ENTRIES: usize = 64;
 const TS_PENDING_PARSE_REQUEST_MAX_ENTRIES: usize = 8;
-#[cfg(any(test, feature = "syntax-shell"))]
 const BASH_HIGHLIGHTS_QUERY: &str = include_str!("queries/bash_highlights.scm");
-#[cfg(any(test, feature = "syntax-extra"))]
 const C_HIGHLIGHTS_QUERY: &str = include_str!("queries/c_highlights.scm");
-#[cfg(any(test, feature = "syntax-extra"))]
 const C_INJECTIONS_QUERY: &str = include_str!("queries/c_injections.scm");
-#[cfg(any(test, feature = "syntax-extra"))]
 const CSHARP_HIGHLIGHTS_QUERY: &str = include_str!("queries/csharp_highlights.scm");
-#[cfg(any(test, feature = "syntax-extra"))]
 const CPP_HIGHLIGHTS_QUERY: &str = include_str!("queries/cpp_highlights.scm");
-#[cfg(any(test, feature = "syntax-repo"))]
 const GITCOMMIT_HIGHLIGHTS_QUERY: &str = include_str!("queries/gitcommit_highlights.scm");
-#[cfg(any(test, feature = "syntax-repo"))]
 const GOMOD_HIGHLIGHTS_QUERY: &str = include_str!("queries/gomod_highlights.scm");
-#[cfg(any(test, feature = "syntax-repo"))]
 const GOWORK_HIGHLIGHTS_QUERY: &str = include_str!("queries/gowork_highlights.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const HTML_HIGHLIGHTS_QUERY: &str = include_str!("queries/html_highlights.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const HTML_INJECTIONS_QUERY: &str = include_str!("queries/html_injections.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const JINJA_HIGHLIGHTS_QUERY: &str = include_str!("queries/jinja_highlights.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const JINJA_INJECTIONS_QUERY: &str = include_str!("queries/jinja_injections.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const VUE_HIGHLIGHTS_QUERY: &str = include_str!("queries/vue_highlights.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const VUE_INJECTIONS_QUERY: &str = include_str!("queries/vue_injections.scm");
-#[cfg(any(test, feature = "syntax-repo"))]
 const MARKDOWN_HIGHLIGHTS_QUERY: &str = tree_sitter_md::HIGHLIGHT_QUERY_BLOCK;
-#[cfg(any(test, feature = "syntax-repo"))]
 const MARKDOWN_INJECTIONS_QUERY: &str = tree_sitter_md::INJECTION_QUERY_BLOCK;
-#[cfg(any(test, feature = "syntax-repo"))]
 const MARKDOWN_INLINE_HIGHLIGHTS_QUERY: &str = tree_sitter_md::HIGHLIGHT_QUERY_INLINE;
-#[cfg(any(test, feature = "syntax-web"))]
 const CSS_HIGHLIGHTS_QUERY: &str = include_str!("queries/css_highlights.scm");
-#[cfg(any(test, feature = "syntax-go"))]
 const GO_HIGHLIGHTS_QUERY: &str = include_str!("queries/go_highlights.scm");
-#[cfg(any(test, feature = "syntax-go"))]
 const GO_INJECTIONS_QUERY: &str = include_str!("queries/go_injections.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const JAVASCRIPT_HIGHLIGHTS_QUERY: &str = include_str!("queries/javascript_highlights.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const JAVASCRIPT_INJECTIONS_QUERY: &str = include_str!("queries/javascript_injections.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const JSDOC_HIGHLIGHTS_QUERY: &str = include_str!("queries/jsdoc_highlights.scm");
-#[cfg(any(test, feature = "syntax-data"))]
 const JSON_HIGHLIGHTS_QUERY: &str = include_str!("queries/json_highlights.scm");
-#[cfg(any(test, feature = "syntax-extra"))]
 const POWERSHELL_HIGHLIGHTS_QUERY: &str = tree_sitter_powershell::HIGHLIGHTS_QUERY;
-#[cfg(any(test, feature = "syntax-python"))]
 const PYTHON_HIGHLIGHTS_QUERY: &str = include_str!("queries/python_highlights.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const REGEX_HIGHLIGHTS_QUERY: &str = include_str!("queries/regex_highlights.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const TYPESCRIPT_HIGHLIGHTS_QUERY: &str = include_str!("queries/typescript_highlights.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const TYPESCRIPT_INJECTIONS_QUERY: &str = include_str!("queries/typescript_injections.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const TSX_HIGHLIGHTS_QUERY: &str = include_str!("queries/tsx_highlights.scm");
-#[cfg(any(test, feature = "syntax-web"))]
 const TSX_INJECTIONS_QUERY: &str = include_str!("queries/tsx_injections.scm");
-#[cfg(any(test, feature = "syntax-rust"))]
+const NIX_HIGHLIGHTS_QUERY: &str = include_str!("queries/nix_highlights.scm");
+const NIX_INJECTIONS_QUERY: &str = include_str!("queries/nix_injections.scm");
 const RUST_HIGHLIGHTS_QUERY: &str = include_str!("queries/rust_highlights.scm");
-#[cfg(any(test, feature = "syntax-rust"))]
 const RUST_INJECTIONS_QUERY: &str = include_str!("queries/rust_injections.scm");
-#[cfg(any(test, feature = "syntax-data"))]
 const YAML_HIGHLIGHTS_QUERY: &str = include_str!("queries/yaml_highlights.scm");
-#[cfg(any(test, feature = "syntax-data"))]
 const YAML_INJECTIONS_QUERY: &str = include_str!("queries/yaml_injections.scm");
-#[cfg(any(test, feature = "syntax-xml"))]
 const XML_HIGHLIGHTS_QUERY: &str = tree_sitter_xml::XML_HIGHLIGHT_QUERY;
-#[cfg(any(test, feature = "syntax-extra"))]
 const CPP_INJECTIONS_QUERY: &str = include_str!("queries/cpp_injections.scm");
 
 /// Maximum injection nesting depth. Root document = 0, first injection = 1.
@@ -229,6 +194,7 @@ pub(in crate::view) enum DiffSyntaxLanguage {
     Bicep,
     Lua,
     Makefile,
+    Nix,
     Kotlin,
     Zig,
     Rust,
@@ -1436,7 +1402,6 @@ mod tests {
         assert_eq!(ts_parser_set_language_call_count(), 2);
     }
 
-    #[cfg(any(test, feature = "syntax-xml"))]
     #[test]
     fn single_line_syntax_cache_isolated_by_mode_for_xml_markup() {
         reset_ts_parser_test_state();
@@ -1560,7 +1525,6 @@ mod tests {
         assert_eq!(html_again, html);
     }
 
-    #[cfg(any(test, feature = "syntax-xml"))]
     #[test]
     fn prepared_document_cache_isolated_by_language_for_same_script_markup() {
         reset_ts_parser_test_state();
@@ -1672,7 +1636,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn prepared_rust_document_highlights_macro_token_tree_via_injection() {
         let text = "test_macro!(value.field::<Vec<u32>>());";
@@ -1706,7 +1669,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn prepared_markdown_document_highlights_fenced_html_block_via_injection() {
         let doc = prepare_markdown_document(&["```html", "<div class=\"note\">ok</div>", "```"]);
@@ -1723,7 +1685,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn prepared_markdown_document_highlights_fenced_ruby_block_via_path_alias() {
         let doc = prepare_markdown_document(&["```foo/bar/baz.rb", "if @user", "end", "```"]);
@@ -1740,7 +1701,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn prepared_markdown_document_highlights_fenced_tsx_block_via_path_alias() {
         let doc = prepare_markdown_document(&[
@@ -1761,7 +1721,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-repo"))]
     #[test]
     fn prepared_markdown_document_highlights_fenced_gomod_block_via_filename_alias() {
         let line = "module example.com/project";
@@ -2060,7 +2019,6 @@ mod tests {
     /// interpolation became its own injected layer: ~5 per line here, which
     /// overruns TS_INJECTION_CACHE_MAX_ENTRIES (32) and evicts half the cache
     /// mid-render, so scrolling re-parses everything.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_plain_binding_directives_produce_no_injections() {
         TS_INJECTION_CACHE.with(|cache| cache.borrow_mut().clear());
@@ -2094,7 +2052,6 @@ mod tests {
 
     /// The other half of the guard above: skipping plain bindings must not cost
     /// highlighting for the expressions the injection actually exists to serve.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_expression_directives_still_inject_typescript() {
         let line = r#"  <button v-if="count > 10" @click="submit($event, 'now')">"#;
@@ -2120,7 +2077,6 @@ mod tests {
     /// engine, so the outer capture wins outright. That was invisible while
     /// every interpolation was injected -- the injection carved the body out --
     /// and became visible the moment plain interpolations stopped injecting.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_plain_interpolation_does_not_paint_its_expression_as_a_sigil() {
         let line = r#"  <p>{{ msg }}</p>"#;
@@ -2145,7 +2101,6 @@ mod tests {
     /// through both the @variable override and the injection, landing on the
     /// html `(attribute_value) @string` rule -- the exact miscolouring the
     /// override exists to prevent.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_unquoted_directive_value_is_not_coloured_as_a_string() {
         let line = r#"  <p v-if=ok>x</p>"#;
@@ -2167,7 +2122,6 @@ mod tests {
     /// duplicate by accident, but live.rs keeps both layers and interleaves
     /// their captures at equal depth, so the editor colours the block
     /// arbitrarily. The `lang` veto on the `type=` rules keeps it to one.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_script_with_both_type_and_lang_injects_exactly_one_language() {
         let text = "<script type=\"module\" lang=\"ts\">\nconst x: number = 1;\n</script>\n";
@@ -2217,7 +2171,6 @@ mod tests {
     /// those had to stop injecting unconditionally too. Inline `style=` was both
     /// the worst offender and actively wrong (the CSS grammar reads an attribute
     /// body as a stylesheet, making `color` a type selector), so it was dropped.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_static_inline_styles_do_not_flood_the_injection_cache() {
         TS_INJECTION_CACHE.with(|cache| cache.borrow_mut().clear());
@@ -2246,7 +2199,6 @@ mod tests {
 
     /// A skipped injection still has to leave the value coloured -- that is the
     /// premise the skip rests on.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_plain_binding_directives_are_still_coloured_by_the_host_grammar() {
         let line = r#"  <div :class="wrapperClass">{{ label }}</div>"#;
@@ -4147,7 +4099,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn vendored_rust_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
@@ -4156,7 +4107,6 @@ mod tests {
             .expect("vendored Rust highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_css_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_css::LANGUAGE.into();
@@ -4164,7 +4114,6 @@ mod tests {
         tree_sitter::Query::new(&lang, source).expect("vendored CSS highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-shell"))]
     #[test]
     fn vendored_bash_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_bash::LANGUAGE.into();
@@ -4172,7 +4121,6 @@ mod tests {
             .expect("vendored Bash highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_html_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_html::LANGUAGE.into();
@@ -4181,7 +4129,6 @@ mod tests {
             .expect("vendored HTML highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_html_injections_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_html::LANGUAGE.into();
@@ -4193,7 +4140,6 @@ mod tests {
     /// crates.io, so nothing external will tell us when it stops matching the
     /// workspace `tree-sitter`. It binds through `tree-sitter-language`, which
     /// means a tree-sitter upgrade only stays safe while this holds.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_vue_grammar_is_abi_compatible_with_workspace_tree_sitter() {
         let vue: tree_sitter::Language = tree_sitter_vue::LANGUAGE.into();
@@ -4215,7 +4161,6 @@ mod tests {
     // any routine `cargo update` that bumps an unrelated grammar into a red CI
     // while Vue still parses perfectly.
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_vue_grammar_parses_with_workspace_tree_sitter() {
         let source = concat!(
@@ -4245,7 +4190,6 @@ mod tests {
     /// repository actually ships a grammar for, or the injection silently
     /// no-ops. Reading the targets back off the compiled query keeps this
     /// honest when the query changes.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_injection_targets_resolve_to_working_grammars() {
         let lang: tree_sitter::Language = tree_sitter_vue::LANGUAGE.into();
@@ -4285,7 +4229,6 @@ mod tests {
     /// compiled query, so a query edit that moved TypeScript behind an
     /// `@injection.language` capture would silently stop warming it and put the
     /// stall back. Assert it stays reachable the way the warm-up can see it.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_spec_warmup_reaches_typescript_through_a_set_directive() {
         let lang: tree_sitter::Language = tree_sitter_vue::LANGUAGE.into();
@@ -4351,7 +4294,6 @@ mod tests {
     /// `diff_syntax_language_for_code_fence_info` alone would not do -- that is
     /// only half the path, and it would keep passing if the query rule that
     /// forwards the attribute were deleted.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_lang_attribute_values_highlight_their_block() {
         // (lang, block body, tag, kind the injected grammar must produce)
@@ -4444,7 +4386,6 @@ mod tests {
     /// by `#not-match? "\\slang\\s*="`, so a `lang` the vue rules do not handle
     /// used to lose the fallback *and* match nothing, leaving the block with no
     /// highlighting whatsoever.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_unknown_lang_attribute_does_not_silently_disable_highlighting() {
         // A value no grammar in this repo can serve: no injection is the correct
@@ -4473,7 +4414,6 @@ mod tests {
     /// The tree-sitter parser is a thread-local reused across languages, with a
     /// fast path that skips `set_language`. Adding a grammar that is loaded a
     /// different way (vendored, not from crates.io) should not disturb that.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_documents_interleave_with_other_language_documents() {
         let vue = prepare_vue_document(VUE_SFC_FIXTURE);
@@ -4498,7 +4438,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_vue_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_vue::LANGUAGE.into();
@@ -4506,7 +4445,6 @@ mod tests {
             .expect("vendored Vue highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_vue_injections_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_vue::LANGUAGE.into();
@@ -4524,7 +4462,6 @@ mod tests {
     /// so the html `(attribute_value) @string` rule has to come *before* the
     /// `@variable` directive override for the override to take effect. A
     /// per-line containment check would pass on a reordered copy.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_highlights_query_embeds_the_html_base_verbatim() {
         fn rules(query: &str) -> Vec<&str> {
@@ -4559,7 +4496,6 @@ mod tests {
     /// drops injections. The Vue injection query has the most patterns of any in
     /// the repo and anchors several on very common template nodes, which makes
     /// it the one most likely to hit the cap.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vue_injection_query_stays_under_the_match_limit_on_a_dense_template() {
         let mut lines = vec!["<template>".to_string(), "  <ul>".to_string()];
@@ -4609,7 +4545,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_javascript_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_javascript::LANGUAGE.into();
@@ -4617,7 +4552,6 @@ mod tests {
             .expect("vendored JavaScript highlights.scm should compile against JS grammar");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_javascript_injections_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_javascript::LANGUAGE.into();
@@ -4625,7 +4559,6 @@ mod tests {
             .expect("vendored JavaScript injections.scm should compile against JS grammar");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_typescript_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into();
@@ -4633,7 +4566,6 @@ mod tests {
             .expect("vendored TypeScript highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_typescript_injections_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into();
@@ -4641,7 +4573,6 @@ mod tests {
             .expect("vendored TypeScript injections.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_tsx_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_typescript::LANGUAGE_TSX.into();
@@ -4649,7 +4580,6 @@ mod tests {
             .expect("vendored TSX highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_tsx_injections_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_typescript::LANGUAGE_TSX.into();
@@ -4657,7 +4587,6 @@ mod tests {
             .expect("vendored TSX injections.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-go"))]
     #[test]
     fn vendored_go_queries_compile() {
         let lang: tree_sitter::Language = tree_sitter_go::LANGUAGE.into();
@@ -4667,7 +4596,6 @@ mod tests {
             .expect("vendored Go injections.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-data"))]
     #[test]
     fn vendored_json_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_json::LANGUAGE.into();
@@ -4675,7 +4603,6 @@ mod tests {
             .expect("vendored JSON highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-python"))]
     #[test]
     fn vendored_python_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_python::LANGUAGE.into();
@@ -4683,7 +4610,6 @@ mod tests {
             .expect("vendored Python highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-data"))]
     #[test]
     fn vendored_yaml_queries_compile() {
         let lang: tree_sitter::Language = tree_sitter_yaml::LANGUAGE.into();
@@ -4693,7 +4619,6 @@ mod tests {
             .expect("vendored YAML injections.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn vendored_csharp_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_c_sharp::LANGUAGE.into();
@@ -4701,7 +4626,6 @@ mod tests {
             .expect("vendored C# highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn vendored_c_queries_compile() {
         let lang: tree_sitter::Language = tree_sitter_c::LANGUAGE.into();
@@ -4711,7 +4635,6 @@ mod tests {
             .expect("vendored C injections.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn vendored_cpp_queries_compile() {
         let lang: tree_sitter::Language = tree_sitter_cpp::LANGUAGE.into();
@@ -4721,7 +4644,6 @@ mod tests {
             .expect("vendored C++ injections.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn vendored_injected_web_language_queries_compile() {
         let jsdoc_lang: tree_sitter::Language = tree_sitter_jsdoc::LANGUAGE.into();
@@ -4733,7 +4655,6 @@ mod tests {
             .expect("vendored regex highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-repo"))]
     #[test]
     fn vendored_repo_queries_compile() {
         let markdown_lang: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
@@ -4763,7 +4684,6 @@ mod tests {
             .expect("go.work highlights.scm should compile");
     }
 
-    #[cfg(any(test, feature = "syntax-xml"))]
     #[test]
     fn vendored_xml_query_compiles() {
         let lang: tree_sitter::Language = tree_sitter_xml::LANGUAGE_XML.into();
@@ -4771,7 +4691,6 @@ mod tests {
             .expect("XML highlights.scm should compile against XML grammar");
     }
 
-    #[cfg(any(test, feature = "syntax-xml"))]
     #[test]
     fn xml_treesitter_captures_tag_and_attribute() {
         let text = r#"<root attr="value">text</root>"#;
@@ -4790,7 +4709,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-xml"))]
     #[test]
     fn xml_treesitter_captures_comment() {
         let text = "<!-- a comment -->";
@@ -4801,7 +4719,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_treesitter_captures_function_and_keyword() {
         let text = "function foo() { return 42; }";
@@ -4824,7 +4741,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn typescript_treesitter_preserves_arrow_operator_inside_arrow_function() {
         let text = "const fn = (x: number): number => x + 1;";
@@ -4844,7 +4760,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn html_highlight_spec_compiles_injection_query() {
         let spec = tree_sitter_highlight_spec(DiffSyntaxLanguage::Html)
@@ -4855,7 +4770,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_highlight_spec_compiles_injection_query() {
         let spec = tree_sitter_highlight_spec(DiffSyntaxLanguage::JavaScript)
@@ -4892,199 +4806,157 @@ mod tests {
 
     #[test]
     fn vendored_capture_names_are_supported_or_ignored() {
-        #[cfg(any(test, feature = "syntax-rust"))]
         assert_capture_names_are_supported(
             tree_sitter_rust::LANGUAGE.into(),
             RUST_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-web"))]
         assert_capture_names_are_supported(
             tree_sitter_html::LANGUAGE.into(),
             HTML_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-web"))]
         assert_capture_names_are_supported(tree_sitter_vue::LANGUAGE.into(), VUE_HIGHLIGHTS_QUERY);
-        #[cfg(any(test, feature = "syntax-web"))]
         assert_capture_names_are_supported(tree_sitter_css::LANGUAGE.into(), CSS_HIGHLIGHTS_QUERY);
-        #[cfg(any(test, feature = "syntax-shell"))]
         assert_capture_names_are_supported(
             tree_sitter_bash::LANGUAGE.into(),
             BASH_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-web"))]
         assert_capture_names_are_supported(
             tree_sitter_javascript::LANGUAGE.into(),
             JAVASCRIPT_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-python"))]
         assert_capture_names_are_supported(
             tree_sitter_python::LANGUAGE.into(),
             PYTHON_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-go"))]
         assert_capture_names_are_supported(tree_sitter_go::LANGUAGE.into(), GO_HIGHLIGHTS_QUERY);
-        #[cfg(any(test, feature = "syntax-data"))]
         assert_capture_names_are_supported(
             tree_sitter_json::LANGUAGE.into(),
             JSON_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-data"))]
         assert_capture_names_are_supported(
             tree_sitter_yaml::LANGUAGE.into(),
             YAML_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-web"))]
         assert_capture_names_are_supported(
             tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
             TYPESCRIPT_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-web"))]
         assert_capture_names_are_supported(
             tree_sitter_typescript::LANGUAGE_TSX.into(),
             TSX_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-xml"))]
         assert_capture_names_are_supported(
             tree_sitter_xml::LANGUAGE_XML.into(),
             XML_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(tree_sitter_c::LANGUAGE.into(), C_HIGHLIGHTS_QUERY);
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(tree_sitter_cpp::LANGUAGE.into(), CPP_HIGHLIGHTS_QUERY);
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_c_sharp::LANGUAGE.into(),
             CSHARP_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_java::LANGUAGE.into(),
             tree_sitter_java::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_php::LANGUAGE_PHP.into(),
             tree_sitter_php::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_ruby::LANGUAGE.into(),
             tree_sitter_ruby::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_toml_ng::LANGUAGE.into(),
             tree_sitter_toml_ng::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_lua::LANGUAGE.into(),
             tree_sitter_lua::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_make::LANGUAGE.into(),
             tree_sitter_make::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_kotlin_sg::LANGUAGE.into(),
             tree_sitter_kotlin_sg::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_zig::LANGUAGE.into(),
             tree_sitter_zig::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_bicep::LANGUAGE.into(),
             tree_sitter_bicep::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_objc::LANGUAGE.into(),
             tree_sitter_objc::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_fsharp::LANGUAGE_FSHARP.into(),
             tree_sitter_fsharp::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_powershell::LANGUAGE.into(),
             POWERSHELL_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_swift::LANGUAGE.into(),
             tree_sitter_swift::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-web"))]
         assert_capture_names_are_supported(
             tree_sitter_jsdoc::LANGUAGE.into(),
             JSDOC_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-web"))]
         assert_capture_names_are_supported(
             tree_sitter_regex::LANGUAGE.into(),
             REGEX_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_r::LANGUAGE.into(),
             tree_sitter_r::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_dart::LANGUAGE.into(),
             tree_sitter_dart::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_scala::LANGUAGE.into(),
             tree_sitter_scala::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-extra"))]
         assert_capture_names_are_supported(
             tree_sitter_sequel::LANGUAGE.into(),
             tree_sitter_sequel::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-repo"))]
         assert_capture_names_are_supported(
             tree_sitter_md::LANGUAGE.into(),
             MARKDOWN_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-repo"))]
         assert_capture_names_are_supported(
             tree_sitter_md::INLINE_LANGUAGE.into(),
             MARKDOWN_INLINE_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-repo"))]
         assert_capture_names_are_supported(
             tree_sitter_diff::LANGUAGE.into(),
             tree_sitter_diff::HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-repo"))]
         assert_capture_names_are_supported(
             tree_sitter_gitcommit::LANGUAGE.into(),
             GITCOMMIT_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-repo"))]
         assert_capture_names_are_supported(
             tree_sitter_gomod::LANGUAGE.into(),
             GOMOD_HIGHLIGHTS_QUERY,
         );
-        #[cfg(any(test, feature = "syntax-repo"))]
         assert_capture_names_are_supported(
             tree_sitter_gowork::LANGUAGE.into(),
             GOWORK_HIGHLIGHTS_QUERY,
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_variable_parameter() {
         let text = "fn foo(bar: u32) {}";
@@ -5097,7 +4969,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_self_as_variable_special() {
         let text = "impl Widget { fn render(&self, item: Item) { self.draw(item); } }";
@@ -5108,7 +4979,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_type_builtin() {
         let text = "let x: u32 = 0;";
@@ -5121,7 +4991,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_macro_as_function_special() {
         let text = "println!(\"hello\");";
@@ -5134,7 +5003,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_keyword_function_type_and_string_families() {
         let text = r#"fn foo(bar: u32) { let x = "hi"; }"#;
@@ -5161,7 +5029,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_impl_family_as_preproc() {
         let impl_text = "impl Widget where T: Trait {}";
@@ -5201,7 +5068,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_use_roots_and_tails() {
         let type_text = "use foo::Bar;";
@@ -5242,7 +5108,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_keeps_use_middle_modules_neutral() {
         let type_text = "use foo::bar::Baz;";
@@ -5325,7 +5190,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_root_modules_before_functions_and_types() {
         let call_text = "let handler = foo::bar::baz();";
@@ -5408,7 +5272,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_constants_in_scoped_paths() {
         let constant_text = "let mode = NotForContentType::SSE;";
@@ -5513,7 +5376,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_captures_grouped_use_import_semantics() {
         let text = "use foo::{bar, baz::Qux};";
@@ -5564,7 +5426,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn rust_treesitter_keeps_use_aliases_neutral() {
         let text = "use foo::bar as baz;";
@@ -5587,7 +5448,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn tsx_treesitter_highlights_jsx_tag_and_attribute() {
         let text = "const node = <button disabled />;";
@@ -5602,7 +5462,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn css_treesitter_captures_property_and_keyword() {
         let text = "@media screen { .foo { color: red; } }";
@@ -5617,7 +5476,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_tagged_template_injects_css() {
         let document = prepare_test_document(
@@ -5632,7 +5490,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_tagged_template_injects_html() {
         let text = "const markup = html`<div class=\"note\">ok</div>`;";
@@ -5649,7 +5506,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_styled_member_template_injects_css() {
         let text = "const Button = styled.div`color: red;`;";
@@ -5662,7 +5518,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_styled_call_template_injects_css() {
         let text = "const Button = styled(Link)`color: red;`;";
@@ -5675,7 +5530,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_comment_prefixed_string_injects_html() {
         let text = r#"const markup = /* html */ "<div class='note'>ok</div>";"#;
@@ -5692,7 +5546,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_comment_prefixed_string_injects_css() {
         let text = r#"const styles = /* css */ "color: red;";"#;
@@ -5705,7 +5558,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_comment_prefixed_template_literal_injects_css() {
         let text = "const styles = /* css */ `color: red;`;";
@@ -5718,7 +5570,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn typescript_tagged_template_injects_yaml() {
         let text = "const workflow = yaml`enabled: true`;";
@@ -5735,7 +5586,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn typescript_tagged_template_injects_html() {
         let text = "const markup = html`<div class=\"note\">ok</div>`;";
@@ -5752,7 +5602,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn typescript_tagged_template_injects_sql() {
         let text = "const query = sql`select name from users`;";
@@ -5765,7 +5614,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn typescript_comment_prefixed_string_injects_css() {
         let text = r#"const styles = /* css */ "color: red;";"#;
@@ -5778,7 +5626,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn typescript_component_styles_array_template_injects_css() {
         let text = "Component({ styles: [`div { color: red; }`] });";
@@ -5791,7 +5638,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn tsx_tagged_template_injects_html() {
         let text = "const markup = html`<div class=\"note\">ok</div>`;";
@@ -5808,7 +5654,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-go"))]
     #[test]
     fn go_treesitter_captures_function_method_property_and_number() {
         let declaration = "func Hello(a B) C { return C{} }";
@@ -5877,7 +5722,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-go"))]
     #[test]
     fn go_comment_prefixed_strings_inject_supported_languages() {
         let cases = [
@@ -5924,7 +5768,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(test, feature = "syntax-data"))]
     #[test]
     fn yaml_github_actions_script_injects_javascript() {
         let text = [
@@ -5952,7 +5795,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-data"))]
     #[test]
     fn yaml_github_actions_inline_script_injects_javascript() {
         let text = [
@@ -5981,7 +5823,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn extra_languages_capture_basic_semantic_tokens() {
         let cases = [
@@ -6091,7 +5932,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(test, feature = "syntax-repo"))]
     #[test]
     fn repo_languages_capture_basic_semantic_tokens() {
         let cases = [
@@ -6126,7 +5966,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_treesitter_captures_regex_literal() {
         let text = "const re = /foo+/gi;";
@@ -6140,7 +5979,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn javascript_treesitter_captures_constructor_and_constant_builtin() {
         let constructor_tokens = syntax_tokens_for_line(
@@ -6168,7 +6006,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-go"))]
     #[test]
     fn go_treesitter_captures_namespace_package_identifier() {
         let tokens =
@@ -6179,7 +6016,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn lua_and_c_treesitter_capture_preprocessor_and_label() {
         let preproc = syntax_tokens_for_line(
@@ -6203,7 +6039,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn c_treesitter_uses_vendored_zed_query() {
         let preproc = syntax_tokens_for_line(
@@ -6233,7 +6068,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn cpp_treesitter_uses_vendored_zed_query() {
         let concept_text = "template <typename T> concept Addable = requires(T a, T b) { a + b; };";
@@ -6320,7 +6154,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn injected_web_helper_languages_capture_basic_tokens() {
         let regex_text = "(foo|bar)+";
@@ -6344,7 +6177,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-repo"))]
     #[test]
     fn gitcommit_treesitter_captures_diff_change_kinds() {
         let text = [
@@ -6380,7 +6212,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-repo"))]
     #[test]
     fn prepared_documents_capture_markup_specific_tokens() {
         let gitcommit =
@@ -6413,7 +6244,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-repo"))]
     #[test]
     fn markdown_inline_treesitter_captures_text_literal_and_markup_link() {
         let text = "[link](https://example.com) `code`";
@@ -6434,7 +6264,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-repo"))]
     #[test]
     fn markdown_prepared_document_captures_heading_marker_as_punctuation_special() {
         let document = prepare_test_document(DiffSyntaxLanguage::Markdown, "# Heading");
@@ -6448,7 +6277,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn ruby_and_swift_treesitter_capture_regex_aliases() {
         let cases = [
@@ -6467,7 +6295,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(test, feature = "syntax-repo"))]
     #[test]
     fn gitcommit_prepared_document_captures_path_symbol_and_trailer_tokens() {
         let text = [
@@ -6512,7 +6339,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-xml"))]
     #[test]
     fn xml_treesitter_captures_markup_link_via_system_literal() {
         let text = "<!DOCTYPE root SYSTEM \"https://example.com/schema.dtd\">";
@@ -6735,6 +6561,7 @@ mod tests {
             DiffSyntaxLanguage::Bicep,
             DiffSyntaxLanguage::Lua,
             DiffSyntaxLanguage::Makefile,
+            DiffSyntaxLanguage::Nix,
             DiffSyntaxLanguage::Kotlin,
             DiffSyntaxLanguage::Zig,
             DiffSyntaxLanguage::Rust,
@@ -6786,10 +6613,291 @@ mod tests {
         }
     }
 
+    // ---- Nix ------------------------------------------------------------------
+
+    const NIX_FIXTURE: &[&str] = &[
+        /*  0 */ "# Build a demo package.",
+        /*  1 */ "{ pkgs, lib ? pkgs.lib, ... }:",
+        /*  2 */ "let",
+        /*  3 */ "  inherit (pkgs) stdenv;",
+        /*  4 */ "  version = \"1.0\";",
+        /*  5 */ "  readme = builtins.readFile ./README.md;",
+        /*  6 */ "in",
+        /*  7 */ "stdenv.mkDerivation rec {",
+        /*  8 */ "  pname = \"demo\";",
+        /*  9 */ "  meta.description = \"demo v${version}\";",
+        /* 10 */ "  buildPhase = ''",
+        /* 11 */ "    export OUT=$out",
+        /* 12 */ "    if [ -d bin ]; then",
+        /* 13 */ "      cp -r bin \"$out/bin\"",
+        /* 14 */ "    fi",
+        /* 15 */ "  '';",
+        /* 16 */ "}",
+    ];
+
+    fn prepare_nix_document(lines: &[&str]) -> PreparedSyntaxDocument {
+        prepare_test_document(DiffSyntaxLanguage::Nix, &lines.join("\n"))
+    }
+
+    #[test]
+    fn nix_extension_is_supported() {
+        for path in ["flake.nix", "pkgs/demo/default.nix", "nix/modules/web.nix"] {
+            assert_eq!(
+                diff_syntax_language_for_path(path),
+                Some(DiffSyntaxLanguage::Nix),
+                "{path} should resolve to the Nix grammar"
+            );
+        }
+        assert_eq!(
+            diff_syntax_language_for_code_fence_info("nix"),
+            Some(DiffSyntaxLanguage::Nix),
+        );
+        // `flake.lock` is JSON and must keep resolving that way.
+        assert_eq!(
+            diff_syntax_language_for_path("flake.lock"),
+            Some(DiffSyntaxLanguage::Json),
+        );
+    }
+
+    #[test]
+    fn prepared_nix_document_highlights_core_syntax() {
+        let doc = prepare_nix_document(NIX_FIXTURE);
+
+        let comment = token_kinds_for_line_fragment(doc, 0, NIX_FIXTURE[0], "demo package");
+        assert!(
+            comment.contains(&SyntaxTokenKind::Comment),
+            "`# …` is a Nix line comment: {comment:?}"
+        );
+
+        for (line_ix, keyword) in [(2usize, "let"), (3, "inherit"), (6, "in"), (7, "rec")] {
+            let kinds = token_kinds_for_line_fragment(doc, line_ix, NIX_FIXTURE[line_ix], keyword);
+            assert!(
+                kinds.contains(&SyntaxTokenKind::Keyword),
+                "`{keyword}` should be a keyword: {kinds:?}"
+            );
+        }
+
+        let formal = token_kinds_for_line_fragment(doc, 1, NIX_FIXTURE[1], "pkgs");
+        assert!(
+            formal.contains(&SyntaxTokenKind::VariableParameter),
+            "`pkgs` is a formal in the function's argument set: {formal:?}"
+        );
+
+        let attr = token_kinds_for_line_fragment(doc, 8, NIX_FIXTURE[8], "pname");
+        assert!(
+            attr.contains(&SyntaxTokenKind::Property),
+            "a binding attrpath should read as a property: {attr:?}"
+        );
+
+        let string = token_kinds_for_line_fragment(doc, 8, NIX_FIXTURE[8], "\"demo\"");
+        assert!(
+            string.contains(&SyntaxTokenKind::String),
+            "`\"demo\"` should be a string: {string:?}"
+        );
+
+        let path = token_kinds_for_line_fragment(doc, 5, NIX_FIXTURE[5], "./README.md");
+        assert!(
+            path.contains(&SyntaxTokenKind::StringSpecial),
+            "a bare Nix path is `@string.special.path`: {path:?}"
+        );
+
+        let interpolation = token_kinds_for_line_fragment(doc, 9, NIX_FIXTURE[9], "${");
+        assert!(
+            interpolation.contains(&SyntaxTokenKind::PunctuationSpecial),
+            "`${{` opens an interpolation: {interpolation:?}"
+        );
+    }
+
+    /// The one real guard on the reordering in nix_highlights.scm.
+    ///
+    /// Two patterns capturing the *same* node tie on start byte, so the tiebreak is
+    /// pattern index — the later rule in the file wins. Upstream ends with a blanket
+    /// `(identifier) @variable`, which ported verbatim buries every specific
+    /// identifier rule. Confirmed to fail against upstream's ordering: `builtins`
+    /// comes back as `[Variable]`. If this fails after a re-sync, the query was not
+    /// re-sorted.
+    #[test]
+    fn nix_specific_captures_survive_the_generic_identifier_rule() {
+        let doc = prepare_nix_document(NIX_FIXTURE);
+
+        let builtins = token_kinds_for_line_fragment(doc, 5, NIX_FIXTURE[5], "builtins");
+        assert!(
+            builtins.contains(&SyntaxTokenKind::VariableBuiltin)
+                && !builtins.contains(&SyntaxTokenKind::Variable),
+            "`builtins` must keep its builtin colour rather than falling back to the \
+             blanket `(identifier) @variable` rule: {builtins:?}"
+        );
+
+        let applied = token_kinds_for_line_fragment(doc, 7, NIX_FIXTURE[7], "mkDerivation");
+        assert!(
+            applied.contains(&SyntaxTokenKind::Function)
+                && !applied.contains(&SyntaxTokenKind::Variable),
+            "an identifier in function-application position must read as a function: \
+             {applied:?}"
+        );
+
+        let inherited = token_kinds_for_line_fragment(doc, 3, NIX_FIXTURE[3], "stdenv");
+        assert!(
+            inherited.contains(&SyntaxTokenKind::Property),
+            "`inherit (pkgs) stdenv` names a property: {inherited:?}"
+        );
+    }
+
+    /// An escape inside a string keeps its own colour.
+    ///
+    /// Not an ordering guard, despite appearances: `normalize_non_overlapping_tokens`
+    /// hands each slice to the last *containing* capture in emission order, and the
+    /// cursor emits by node start byte, so a nested `(escape_sequence)` always beats
+    /// the `(string_expression)` around it whichever order their rules appear in.
+    /// Verified — this passes against upstream's ordering too. It is here to pin the
+    /// behaviour, not the query layout.
+    #[test]
+    fn nix_escape_sequences_outrank_the_string_rule() {
+        let lines = ["{ s = \"a\\nb\"; }"];
+        let doc = prepare_nix_document(&lines);
+        let escape = token_kinds_for_line_fragment(doc, 0, lines[0], "\\n");
+        assert!(
+            escape.contains(&SyntaxTokenKind::StringEscape),
+            "`\\n` inside a string must outrank the enclosing `@string` capture: {escape:?}"
+        );
+    }
+
+    /// The interior of `"demo v${version}"` is Nix code, not string text.
+    ///
+    /// Like the escape test above, this holds by node position rather than by rule
+    /// order — the interpolated expression starts after the string does, so it wins
+    /// its own bytes regardless.
+    #[test]
+    fn nix_interpolation_interior_is_not_flat_string() {
+        let doc = prepare_nix_document(NIX_FIXTURE);
+        let inner = token_kinds_for_line_fragment(doc, 9, NIX_FIXTURE[9], "version");
+        assert!(
+            !inner.is_empty() && !inner.contains(&SyntaxTokenKind::String),
+            "the expression inside `${{…}}` should be highlighted as code, not as part \
+             of the surrounding string: {inner:?}"
+        );
+    }
+
+    /// `buildPhase = '' … ''` is shell script, and the combined Bash injection is
+    /// what makes it read as one. Only the injected layer has a concept of `if`.
+    #[test]
+    fn nix_build_phase_is_highlighted_as_bash() {
+        let doc = prepare_nix_document(NIX_FIXTURE);
+
+        let conditional = token_kinds_for_line_fragment(doc, 12, NIX_FIXTURE[12], "if");
+        assert!(
+            conditional.contains(&SyntaxTokenKind::KeywordControl)
+                || conditional.contains(&SyntaxTokenKind::Keyword),
+            "`if` inside buildPhase should come from the injected Bash layer, not read \
+             as string text: {conditional:?}"
+        );
+
+        // And the injection stays inside the indented string: the Nix binding on
+        // the line above is still Nix.
+        let binding = token_kinds_for_line_fragment(doc, 10, NIX_FIXTURE[10], "buildPhase");
+        assert!(
+            binding.contains(&SyntaxTokenKind::Property),
+            "`buildPhase` is a Nix attrpath, not part of the shell script: {binding:?}"
+        );
+    }
+
+    #[test]
+    fn nix_injection_targets_resolve_to_working_grammars() {
+        let lang: tree_sitter::Language = tree_sitter_nix::LANGUAGE.into();
+        let query = tree_sitter::Query::new(&lang, NIX_INJECTIONS_QUERY)
+            .expect("nix_injections.scm should compile");
+        let mut checked = 0usize;
+        for pattern_ix in 0..query.pattern_count() {
+            for setting in query.property_settings(pattern_ix) {
+                if setting.key.as_ref() != "injection.language" {
+                    continue;
+                }
+                let Some(value) = setting.value.as_deref() else {
+                    continue;
+                };
+                let target = injection_language_from_name(value).unwrap_or_else(|| {
+                    panic!("nix_injections.scm names an unknown injection language {value:?}")
+                });
+                assert!(
+                    tree_sitter_highlight_spec(target).is_some(),
+                    "nix_injections.scm injects {value:?} but no grammar is wired for \
+                     {target:?}, so the injection would silently no-op"
+                );
+                checked += 1;
+            }
+        }
+        assert_eq!(
+            checked, 4,
+            "expected the four curated bash rules; upstream's comment-marked \
+             arbitrary-language rule is deliberately not ported"
+        );
+    }
+
+    #[test]
+    fn nix_spec_warmup_reaches_bash_through_a_set_directive() {
+        let spec = tree_sitter_highlight_spec(DiffSyntaxLanguage::Nix).expect("nix spec");
+        let injection_query = spec.injection_query.as_ref().expect("nix injection query");
+        let reaches_bash = (0..injection_query.pattern_count()).any(|pattern_ix| {
+            injection_query
+                .property_settings(pattern_ix)
+                .iter()
+                .filter(|setting| setting.key.as_ref() == "injection.language")
+                .any(|setting| {
+                    setting
+                        .value
+                        .as_deref()
+                        .and_then(injection_language_from_name)
+                        == Some(DiffSyntaxLanguage::Bash)
+                })
+        });
+        assert!(
+            reaches_bash,
+            "warm_reachable_highlight_specs must be able to see the bash target, or the \
+             Bash query compile lands on the draw path"
+        );
+    }
+
+    #[test]
+    fn nix_grammar_is_abi_compatible_with_workspace_tree_sitter() {
+        let nix: tree_sitter::Language = tree_sitter_nix::LANGUAGE.into();
+        let abi = nix.abi_version();
+        assert!(
+            (tree_sitter::MIN_COMPATIBLE_LANGUAGE_VERSION..=tree_sitter::LANGUAGE_VERSION)
+                .contains(&abi),
+            "tree-sitter-nix ABI {abi} is outside the range this tree-sitter supports \
+             ({}..={})",
+            tree_sitter::MIN_COMPATIBLE_LANGUAGE_VERSION,
+            tree_sitter::LANGUAGE_VERSION,
+        );
+    }
+
+    #[test]
+    fn nix_grammar_parses_a_flake() {
+        let source = concat!(
+            "{\n",
+            "  description = \"demo\";\n",
+            "  inputs.nixpkgs.url = \"github:NixOS/nixpkgs/nixos-unstable\";\n",
+            "  outputs = { self, nixpkgs }: {\n",
+            "    packages.x86_64-linux.default =\n",
+            "      nixpkgs.legacyPackages.x86_64-linux.hello;\n",
+            "  };\n",
+            "}\n",
+        );
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_nix::LANGUAGE.into())
+            .expect("nix grammar should load into the workspace tree-sitter");
+        let tree = parser.parse(source, None).expect("flake.nix should parse");
+        assert!(
+            !tree.root_node().has_error(),
+            "the nix grammar produced an ERROR node for a well-formed flake: {}",
+            tree.root_node().to_sexp(),
+        );
+    }
+
     // ---- Nunjucks / Jinja2 ----------------------------------------------------
 
     /// The `.njk` / `.j2` / `.jinja` fixture, shared by the tests below.
-    #[cfg(any(test, feature = "syntax-web"))]
     const JINJA_TEMPLATE_FIXTURE: &[&str] = &[
         /* 0 */ "{# page heading #}",
         /* 1 */ "<ul class=\"list\">",
@@ -6799,7 +6907,6 @@ mod tests {
         /* 5 */ "</ul>",
     ];
 
-    #[cfg(any(test, feature = "syntax-web"))]
     fn prepare_jinja_document(lines: &[&str]) -> PreparedSyntaxDocument {
         prepare_test_document(DiffSyntaxLanguage::Jinja, &lines.join("\n"))
     }
@@ -6831,7 +6938,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn prepared_jinja_document_highlights_template_tags() {
         let doc = prepare_jinja_document(JINJA_TEMPLATE_FIXTURE);
@@ -6876,7 +6982,6 @@ mod tests {
 
     /// The HTML half of a template comes from the combined injection, not the
     /// Jinja grammar -- which sees only opaque `text` nodes.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn prepared_jinja_document_highlights_html_via_the_combined_injection() {
         let doc = prepare_jinja_document(JINJA_TEMPLATE_FIXTURE);
@@ -6904,7 +7009,6 @@ mod tests {
 
     /// The injected HTML must stay off the template tags, which the Jinja
     /// grammar owns. See `combined_injection_gaps`.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn jinja_html_injection_does_not_bleed_onto_template_tags() {
         let doc = prepare_jinja_document(JINJA_TEMPLATE_FIXTURE);
@@ -6916,7 +7020,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn jinja_injection_targets_resolve_to_working_grammars() {
         let lang: tree_sitter::Language = tree_sitter_jinja_dialects::LANGUAGE.into();
@@ -6951,7 +7054,6 @@ mod tests {
     /// Warm-up reads targets off the compiled query, and only sees `#set!`
     /// literals. If the HTML target ever moved into an `@injection.language`
     /// capture, the ~0.5ms HTML spec compile would move back onto the draw path.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn jinja_spec_warmup_reaches_html_through_a_set_directive() {
         let spec = tree_sitter_highlight_spec(DiffSyntaxLanguage::Jinja).expect("jinja spec");
@@ -6978,7 +7080,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn jinja_injection_query_stays_under_the_match_limit_on_a_dense_template() {
         let mut lines = vec!["<ul>".to_string()];
@@ -7026,7 +7127,6 @@ mod tests {
 
     /// The grammar is a young crates.io release binding through
     /// `tree-sitter-language`, so a tree-sitter bump could outrun it.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn jinja_grammar_is_abi_compatible_with_workspace_tree_sitter() {
         let jinja: tree_sitter::Language = tree_sitter_jinja_dialects::LANGUAGE.into();
@@ -7041,7 +7141,6 @@ mod tests {
         );
     }
 
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn jinja_grammar_parses_every_dialect_it_claims() {
         let mut parser = tree_sitter::Parser::new();
@@ -7102,6 +7201,11 @@ mod tests {
             vec![
                 // queries/jinja_injections.scm -- the HTML around the template tags.
                 (DiffSyntaxLanguage::Jinja, 0),
+                // queries/nix_injections.scm -- bash in script/hook attributes.
+                (DiffSyntaxLanguage::Nix, 0),
+                (DiffSyntaxLanguage::Nix, 1),
+                (DiffSyntaxLanguage::Nix, 2),
+                (DiffSyntaxLanguage::Nix, 3),
                 // Upstream tree_sitter_fsharp::INJECTIONS_QUERY -- `xml_doc` lines.
                 (DiffSyntaxLanguage::FSharp, 3),
             ],
@@ -7168,7 +7272,6 @@ mod tests {
     /// HTML stands in for the eventual template grammar here so the test needs no
     /// new dependency. The ranges are the same shape a `(text) @injection.content`
     /// rule produces on a real template.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn combined_injection_parses_disjoint_ranges_as_one_document() {
         let text = "<ul>\n{% for x in xs %}<li>hi</li>{% endfor %}\n</ul>\n";
@@ -7195,7 +7298,6 @@ mod tests {
 
     /// The other half: nodes straddling two included ranges report a byte range
     /// covering the host bytes in between, so their captures have to be clipped.
-    #[cfg(any(test, feature = "syntax-web"))]
     #[test]
     fn combined_injection_tokens_do_not_bleed_into_the_gaps() {
         let text = "<ul>\n{% for x in xs %}<li>hi</li>{% endfor %}\n</ul>\n";
@@ -7243,7 +7345,6 @@ mod tests {
 
     /// Byte ranges of the HTML runs in the combined-injection fixture, i.e. what a
     /// template grammar's `(text)` nodes would capture.
-    #[cfg(any(test, feature = "syntax-web"))]
     fn combined_test_ranges(text: &str) -> Vec<Range<usize>> {
         let for_tag = text.find("{% for x in xs %}").expect("for tag");
         let li = text.find("<li>").expect("li");
@@ -7257,7 +7358,6 @@ mod tests {
     /// `xml_doc` is a per-line token, so before combined support each `///` line
     /// was its own XML document: `<summary>` on one line and `</summary>` on
     /// another never met, and each cost an entry in the 32-slot injection cache.
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn fsharp_xml_doc_comment_is_highlighted_as_one_xml_document() {
         let lines = [
@@ -7291,7 +7391,6 @@ mod tests {
     /// nothing and would evict the entries `vue_static_inline_styles_do_not_flood_
     /// the_injection_cache` depends on. Before this change, 200 `///` lines meant
     /// 200 entries into a 32-slot cache.
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn combined_injections_do_not_consume_the_per_node_injection_cache() {
         TS_INJECTION_CACHE.with(|cache| cache.borrow_mut().clear());
@@ -7327,7 +7426,6 @@ mod tests {
     /// forgot to clear them would truncate the *next* root parse on this thread —
     /// for any language, with no error anywhere. Asserted behaviourally so it
     /// survives tree-sitter API changes.
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn combined_injection_parse_clears_the_pooled_parsers_included_ranges() {
         let fsharp = ["/// <summary>", "/// x", "/// </summary>", "let x = 1"];
@@ -7354,7 +7452,6 @@ mod tests {
     /// most likely to overflow the in-progress match pool. Overflow is worse for a
     /// combined layer than a single one: tree-sitter discards matches silently, and
     /// a missing range changes the document the injected grammar assembles.
-    #[cfg(any(test, feature = "syntax-extra"))]
     #[test]
     fn fsharp_xml_doc_injection_stays_under_the_match_limit_on_a_long_doc_comment() {
         let mut lines = vec!["/// <summary>".to_string()];
@@ -7393,17 +7490,6 @@ mod tests {
         assert!(matched > 0, "the doc comment should produce matches at all");
     }
 
-    // There are deliberately no `disabled_*_grammars_fall_back_to_none` tests.
-    // Absence of a feature-gated grammar cannot be observed from `cargo test`:
-    // the grammar arms are gated `any(test, feature = ...)` precisely so tests
-    // see every language, and a `#[cfg(not(any(test, ...)))]` test placed inside
-    // `#[cfg(test)] mod tests` is stripped before it is even type-checked. The
-    // check that does bite is a build without the feature:
-    //   cargo build -p gitcomet-ui-gpui --no-default-features --features syntax-minimal
-    // Grammar/spec agreement per language is covered by
-    // `grammar_and_highlight_spec_agree_on_supported_languages` above.
-
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     fn highlight_spec_exposes_ts_language() {
         let spec = tree_sitter_highlight_spec(DiffSyntaxLanguage::Rust)
@@ -7412,7 +7498,6 @@ mod tests {
         with_ts_parser(&spec.ts_language, |_| ()).expect("should accept the spec's ts_language");
     }
 
-    #[cfg(any(test, feature = "syntax-rust"))]
     #[test]
     #[ignore]
     fn perf_treesitter_tokenization_smoke() {

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax.rs
@@ -77,18 +77,37 @@ const CPP_INJECTIONS_QUERY: &str = include_str!("queries/cpp_injections.scm");
 const TS_MAX_INJECTION_DEPTH: usize = 1;
 const TS_INJECTION_CACHE_MAX_ENTRIES: usize = 32;
 
-/// Ceilings for one `(#set! injection.combined)` layer.
+/// Ceilings for one `(#set! injection.combined)` layer in the *prepared* path.
 ///
-/// Deliberately hard limits rather than a time budget. Injected parses are
-/// unbudgeted today, and the prepared path has no stale/retry mechanism to repair
-/// a layer that a `ControlFlow::Break` dropped -- that exists only in `live.rs` --
-/// so a budgeted combined layer would appear and vanish with scroll timing.
-/// Skipping the group deterministically leaves the host grammar painting instead.
+/// Hard limits rather than a time budget: the prepared path cannot repair a layer
+/// dropped by a `ControlFlow::Break` -- that mechanism exists only in `live.rs` --
+/// so a budgeted layer would appear and vanish with scroll timing.
 ///
-/// The parse only lexes *included* bytes, so a 64-row window of template is a few
-/// KB; these are guards against pathological input, not the expected case.
-const TS_COMBINED_INJECTION_MAX_RANGES: usize = 512;
+/// Both are measured *after* the ranges are clipped by
+/// [`combined_injection_clip_region`], and that ordering is load-bearing. A
+/// template grammar hands out one `(text)` node per gap between tags, so an
+/// unclipped node is document-sized: a 1900-line `.njk` is a single 138KB range,
+/// which tripped the byte ceiling for every window and dropped HTML highlighting
+/// from the whole file.
+///
+/// The byte ceiling is the one that bounds cost, since a combined parse lexes only
+/// included bytes. The range ceiling is only an allocation guard on the
+/// `Vec<tree_sitter::Range>`, sized so template density cannot reach it -- at 512 an
+/// ordinary 8-column table row (~950 ranges in a clipped window) tripped it.
+///
+/// `live.rs` deliberately has no equivalent; see `parse_injection_layers`.
+const TS_COMBINED_INJECTION_MAX_RANGES: usize = 16_384;
 const TS_COMBINED_INJECTION_MAX_BYTES: usize = 128 * 1024;
+
+/// Context on each side of the rendered window that a combined injection is still
+/// parsed with.
+///
+/// Clipping to *exactly* the window is not output-preserving: a `<section` whose
+/// attributes run onto the next lines is cut in half, and the surviving half loses
+/// its captures to error recovery. Measured on that fixture: margin 0 differs on two
+/// lines, margin 1024 is byte-identical to an unclipped parse. 4KB is well past any
+/// realistic multi-line tag and still bounds the parse at window + 8KB.
+const TS_COMBINED_INJECTION_CONTEXT_MARGIN_BYTES: usize = 4 * 1024;
 
 thread_local! {
     static TS_PARSER: RefCell<tree_sitter::Parser> = RefCell::new(tree_sitter::Parser::new());
@@ -189,6 +208,10 @@ pub(in crate::view) enum DiffSyntaxLanguage {
     /// of all four dialects; the HTML around the tags arrives as a combined
     /// injection (see queries/jinja_injections.scm).
     Jinja,
+    /// The same grammar with the HTML injection removed, for templates whose body is
+    /// not markup: `values.yaml.j2`, `deploy.sh.j2`, `nginx.conf.j2`. Template tags
+    /// still highlight; only the injection is dropped.
+    JinjaText,
     Css,
     Hcl,
     Bicep,
@@ -1433,6 +1456,201 @@ mod tests {
         let auto_again =
             syntax_tokens_for_line(text, DiffSyntaxLanguage::Xml, DiffSyntaxMode::Auto);
         assert_eq!(auto_again, auto);
+    }
+
+    // ---- Heuristic fallback: Nix and Jinja ------------------------------------
+
+    fn heuristic_tokens(text: &str, language: DiffSyntaxLanguage) -> Vec<SyntaxToken> {
+        syntax_tokens_for_line(text, language, DiffSyntaxMode::HeuristicOnly).to_vec()
+    }
+
+    fn heuristic_string_spans(text: &str, language: DiffSyntaxLanguage) -> Vec<&str> {
+        heuristic_tokens(text, language)
+            .into_iter()
+            .filter(|token| token.kind == SyntaxTokenKind::String)
+            .map(|token| &text[token.range])
+            .collect()
+    }
+
+    /// Treating `'` as a quote painted the rest of the line as a string from the
+    /// tick in `foldl'` onward. HeuristicOnly is a production path for large diffs,
+    /// not just a fallback.
+    #[test]
+    fn nix_apostrophe_identifiers_do_not_open_a_string() {
+        for line in [
+            "  x = lib.foldl' add 0 xs;",
+            "  y = builtins.mapAttrs' (n: v: v) set;",
+            "  inherit (lib) foldl' concatMapAttrs';",
+        ] {
+            assert!(
+                heuristic_string_spans(line, DiffSyntaxLanguage::Nix).is_empty(),
+                "an apostrophe identifier opened a string in {line:?}: {:?}",
+                heuristic_tokens(line, DiffSyntaxLanguage::Nix)
+            );
+        }
+
+        // The tick is part of the identifier, so a keyword check sees the whole
+        // name rather than a truncated prefix.
+        let tokens = heuristic_tokens("  inherit' = 1;", DiffSyntaxLanguage::Nix);
+        assert!(
+            !tokens
+                .iter()
+                .any(|token| token.kind == SyntaxTokenKind::Keyword),
+            "`inherit'` is not the keyword `inherit`: {tokens:?}"
+        );
+
+        // Double-quoted strings are untouched by any of this.
+        assert_eq!(
+            heuristic_string_spans("  z = \"literal\";", DiffSyntaxLanguage::Nix),
+            vec!["\"literal\""]
+        );
+    }
+
+    /// The reason the Nix arm exists instead of reusing the Hcl one: `//` is Nix's
+    /// update operator, so Hcl's `//` line comment would grey out the rest of the
+    /// line. Nothing else guards it -- every other Nix test takes the tree-sitter
+    /// path -- so folding Nix back into the `Hcl | Php` arm would pass the suite.
+    #[test]
+    fn nix_update_operator_is_not_a_line_comment() {
+        let line = "  merged = { a = 1; } // { b = 2; };";
+        let tokens = heuristic_tokens(line, DiffSyntaxLanguage::Nix);
+        assert!(
+            !tokens
+                .iter()
+                .any(|token| token.kind == SyntaxTokenKind::Comment),
+            "the `//` update operator was greyed out as a comment: {tokens:?}"
+        );
+
+        // `#` still is one, and `/* */` too.
+        let hashed = heuristic_tokens("  a = 1; # note", DiffSyntaxLanguage::Nix);
+        assert!(
+            hashed
+                .iter()
+                .any(|token| token.kind == SyntaxTokenKind::Comment),
+            "`#` is Nix's line comment: {hashed:?}"
+        );
+        let blocked = heuristic_tokens("  a = /* note */ 1;", DiffSyntaxLanguage::Nix);
+        assert!(
+            blocked
+                .iter()
+                .any(|token| token.kind == SyntaxTokenKind::Comment),
+            "`/* */` is Nix's block comment: {blocked:?}"
+        );
+    }
+
+    /// Both new keyword tables, which nothing else reaches: every other Nix and
+    /// Jinja test goes through `prepare_test_document`, i.e. tree-sitter.
+    #[test]
+    fn nix_and_jinja_heuristic_keyword_tables_are_covered() {
+        fn keywords(text: &str, language: DiffSyntaxLanguage) -> Vec<&str> {
+            syntax_tokens_for_line(text, language, DiffSyntaxMode::HeuristicOnly)
+                .iter()
+                .filter(|token| {
+                    matches!(
+                        token.kind,
+                        SyntaxTokenKind::Keyword | SyntaxTokenKind::KeywordControl
+                    )
+                })
+                .map(|token| &text[token.range.clone()])
+                .collect()
+        }
+
+        let line = "  x = with pkgs; let y = 1; in rec { inherit y; }";
+        let found = keywords(line, DiffSyntaxLanguage::Nix);
+        for expected in ["with", "let", "in", "rec", "inherit"] {
+            assert!(
+                found.contains(&expected),
+                "Nix keyword `{expected}` missing from {found:?}"
+            );
+        }
+        assert!(
+            keywords("  buildInputs = [ pkgs.hello ];", DiffSyntaxLanguage::Nix).is_empty(),
+            "an ordinary Nix attribute name must not colour as a keyword"
+        );
+
+        // The Jinja table omits any identifier that could also be an HTML attribute
+        // name or an English word: the heuristic sees the whole line.
+        let found = keywords("{% endif %}{% extends 'base' %}", DiffSyntaxLanguage::Jinja);
+        for expected in ["endif", "extends"] {
+            assert!(
+                found.contains(&expected),
+                "Jinja keyword `{expected}` missing from {found:?}"
+            );
+        }
+        for prose in [
+            "  <label for=\"name\">Name</label>",
+            "  <p>Do it with care, and set it aside.</p>",
+        ] {
+            assert!(
+                keywords(prose, DiffSyntaxLanguage::Jinja).is_empty(),
+                "an HTML attribute or English word coloured as a Jinja keyword in \
+                 {prose:?}: {:?}",
+                keywords(prose, DiffSyntaxLanguage::Jinja)
+            );
+        }
+
+        // The text-bodied reading shares the table.
+        assert_eq!(
+            keywords("{% endif %}", DiffSyntaxLanguage::JinjaText),
+            keywords("{% endif %}", DiffSyntaxLanguage::Jinja),
+            "both Jinja readings must share one keyword table"
+        );
+    }
+
+    /// Templates are mostly prose, and an unconditional single-quote rule painted
+    /// the rest of the line from the first `It's`.
+    #[test]
+    fn markup_prose_apostrophes_do_not_open_a_string() {
+        for language in [
+            DiffSyntaxLanguage::Jinja,
+            DiffSyntaxLanguage::Html,
+            DiffSyntaxLanguage::Vue,
+            DiffSyntaxLanguage::Xml,
+        ] {
+            for line in [
+                "  <p>It's a test</p>",
+                "  <p>don't panic</p>",
+                "  <li>{{ user.name }}'s profile</li>",
+            ] {
+                assert!(
+                    heuristic_string_spans(line, language).is_empty(),
+                    "{language:?} treated a prose apostrophe as a quote in {line:?}: {:?}",
+                    heuristic_tokens(line, language)
+                );
+            }
+        }
+    }
+
+    /// ... while a `'` in value position is still a quote, which is why the rule is
+    /// positional rather than a flat "markup has no single quotes".
+    #[test]
+    fn markup_single_quoted_values_are_still_strings() {
+        assert_eq!(
+            heuristic_string_spans("  <div class='card'>", DiffSyntaxLanguage::Html),
+            vec!["'card'"]
+        );
+        assert_eq!(
+            heuristic_string_spans("  {{ x|default('n/a') }}", DiffSyntaxLanguage::Jinja),
+            vec!["'n/a'"]
+        );
+        assert_eq!(
+            heuristic_string_spans("  {% if y == 'z' %}", DiffSyntaxLanguage::Jinja),
+            vec!["'z'"]
+        );
+    }
+
+    /// The positional rule must not leak into languages where `'` really does open
+    /// a string anywhere -- Rust byte and char literals are the sharp case.
+    #[test]
+    fn non_markup_languages_keep_unconditional_single_quote_strings() {
+        assert_eq!(
+            heuristic_string_spans("let b = b'x';", DiffSyntaxLanguage::Rust),
+            vec!["'x'"]
+        );
+        assert_eq!(
+            heuristic_string_spans("s = 'it''s'", DiffSyntaxLanguage::Sql),
+            vec!["'it'", "'s'"]
+        );
     }
 
     /// Pins a deliberate limitation rather than an achievement.
@@ -6916,7 +7134,6 @@ mod tests {
         for path in [
             "templates/index.njk",
             "templates/base.html.j2",
-            "roles/web/templates/nginx.conf.j2",
             "templates/macros.jinja",
             "templates/macros.jinja2",
             "templates/page.twig",
@@ -6928,7 +7145,7 @@ mod tests {
                 "{path} should resolve to the Jinja grammar"
             );
         }
-        // The same table backs markdown fence info, so these come along for free.
+        // The same table backs markdown fence info.
         for fence in ["njk", "jinja", "jinja2", "twig", "nunjucks"] {
             assert_eq!(
                 diff_syntax_language_for_code_fence_info(fence),
@@ -6936,6 +7153,72 @@ mod tests {
                 "```{fence} should resolve to the Jinja grammar"
             );
         }
+    }
+
+    /// A `.j2` says the file is templated, not that it is markup. Resolving a shell
+    /// or config template to the HTML-injecting reading hands the HTML grammar
+    /// `cat <<EOF` and `2>&1`, which open bogus elements.
+    #[test]
+    fn text_bodied_jinja_templates_do_not_get_html_injected() {
+        for path in [
+            "roles/web/templates/nginx.conf.j2",
+            "charts/app/values.yaml.j2",
+            "deploy/deploy.sh.j2",
+            "docker-compose.yml.j2",
+            "config/settings.ini.jinja",
+            "db/schema.sql.j2",
+        ] {
+            assert_eq!(
+                diff_syntax_language_for_path(path),
+                Some(DiffSyntaxLanguage::JinjaText),
+                "{path} has a non-markup body, so it must not inject HTML"
+            );
+        }
+
+        let markup = tree_sitter_highlight_spec(DiffSyntaxLanguage::Jinja).expect("jinja spec");
+        let text = tree_sitter_highlight_spec(DiffSyntaxLanguage::JinjaText).expect("text spec");
+        assert!(
+            markup.injection_query.is_some(),
+            "the markup reading is the one that injects HTML"
+        );
+        assert!(
+            text.injection_query.is_none(),
+            "the text reading must have no injection query at all"
+        );
+        assert!(
+            !text.has_combined_injections,
+            "with no injection query there is no combined group to build"
+        );
+    }
+
+    /// The shell-template shape that motivated the split, end to end.
+    #[test]
+    fn shell_bodied_jinja_template_does_not_colour_redirects_as_tags() {
+        let lines = [
+            /* 0 */ "#!/bin/sh",
+            /* 1 */ "{% if debug %}",
+            /* 2 */ "cat <<EOF > {{ target }}",
+            /* 3 */ "  value=1",
+            /* 4 */ "EOF",
+            /* 5 */ "{% endif %}",
+            /* 6 */ "run --flag 2>&1 < input",
+        ];
+        let doc = prepare_test_document(DiffSyntaxLanguage::JinjaText, &lines.join("\n"));
+
+        for (line_ix, fragment) in [(2usize, "EOF"), (6, "input")] {
+            let kinds = token_kinds_for_line_fragment(doc, line_ix, lines[line_ix], fragment);
+            assert!(
+                !kinds.contains(&SyntaxTokenKind::Tag),
+                "`{fragment}` on line {line_ix} was coloured as an HTML tag: {kinds:?}"
+            );
+        }
+
+        // The template tags themselves still highlight -- only the injection is gone.
+        let endif = token_kinds_for_line_fragment(doc, 5, lines[5], "endif");
+        assert!(
+            endif.contains(&SyntaxTokenKind::KeywordControl),
+            "template keywords must survive the split: {endif:?}"
+        );
     }
 
     #[test]
@@ -7353,6 +7636,271 @@ mod tests {
         merge_sorted_injection_ranges(vec![0..for_tag, li..endfor, after_endfor..text.len()])
     }
 
+    // ---- Combined-injection scoping -------------------------------------------
+
+    /// A template dense enough to exercise the per-window ceilings, `rows` lines of
+    /// `cells` cells each wrapped in a block so the body is one big text run.
+    fn dense_jinja_table(rows: usize, cells: usize) -> String {
+        let mut lines = vec!["{% block body %}".to_string()];
+        for row in 0..rows {
+            let mut line = String::from("<tr>");
+            for cell in 0..cells {
+                line.push_str(&format!("<td>{{{{ r{row}.c{cell} }}}}</td>"));
+            }
+            line.push_str("</tr>");
+            lines.push(line);
+        }
+        lines.push("{% endblock %}".to_string());
+        lines.join("\n")
+    }
+
+    /// An 8-column table row used to produce 513 ranges in one 64-line chunk, one
+    /// over the ceiling, and the whole chunk lost its HTML.
+    #[test]
+    fn dense_table_template_keeps_its_html_highlighting() {
+        for cells in [4usize, 8, 16] {
+            let text = dense_jinja_table(200, cells);
+            let lines: Vec<&str> = text.lines().collect();
+            let doc = prepare_test_document(DiffSyntaxLanguage::Jinja, &text);
+
+            let kinds = token_kinds_for_line_fragment(doc, 100, lines[100], "<td>");
+            assert!(
+                kinds.contains(&SyntaxTokenKind::Tag),
+                "a {cells}-cell table row lost its HTML highlighting: {kinds:?}"
+            );
+        }
+    }
+
+    /// The byte ceiling had the same defect at an ordinary file size: all the HTML
+    /// between two template tags is ONE `(text)` node, so a ~1800-line template
+    /// tripped the 128KB ceiling in every window.
+    #[test]
+    fn large_template_with_one_huge_text_run_keeps_its_html_highlighting() {
+        let mut lines = vec!["{% block body %}".to_string()];
+        for ix in 0..2_400 {
+            lines.push(format!(
+                "  <span class=\"cell\" data-row=\"{ix}\">value {ix} padded out</span>"
+            ));
+        }
+        lines.push("{% endblock %}".to_string());
+        let text = lines.join("\n");
+        assert!(
+            text.len() > TS_COMBINED_INJECTION_MAX_BYTES,
+            "fixture must exceed the byte ceiling to be a regression test ({} bytes)",
+            text.len()
+        );
+
+        let line_refs: Vec<&str> = text.lines().collect();
+        let doc = prepare_test_document(DiffSyntaxLanguage::Jinja, &text);
+        for line_ix in [1usize, 700, 1_500, 2_300] {
+            let kinds = token_kinds_for_line_fragment(doc, line_ix, line_refs[line_ix], "span");
+            assert!(
+                kinds.contains(&SyntaxTokenKind::Tag),
+                "line {line_ix} of a {}-byte template lost its HTML: {kinds:?}",
+                text.len()
+            );
+        }
+    }
+
+    /// The property the whole optimisation rests on, and the reason for the margin:
+    /// a `<section` whose attributes run onto the next lines straddles the window
+    /// edge, and an exact clip cuts it in half. Asserted against an unclipped parse
+    /// so it stays honest if the margin is ever tuned.
+    #[test]
+    fn clipping_a_combined_layer_to_the_window_preserves_its_tokens() {
+        let mut lines = vec!["{% block body %}".to_string()];
+        for ix in 0..300 {
+            if ix == 62 || ix == 126 {
+                lines.push("  <section".to_string());
+                lines.push("     id=\"straddle\"".to_string());
+                lines.push("     class=\"wide\">body</section>".to_string());
+            } else {
+                lines.push(format!(
+                    "  <span class=\"c{ix}\" data-x='y'>row {ix}</span>"
+                ));
+            }
+        }
+        lines.push("{% endblock %}".to_string());
+        let text = lines.join("\n") + "\n";
+
+        let input = treesitter_document_input_from_text(&text);
+        let bytes = text.as_bytes();
+        let line_starts = input.line_starts.as_ref();
+        let jinja = tree_sitter_highlight_spec(DiffSyntaxLanguage::Jinja).expect("jinja spec");
+        let root = with_ts_parser_parse_result(&jinja.ts_language, |parser| {
+            parse_treesitter_tree(parser, bytes, None, None)
+        })
+        .expect("root parse");
+
+        let start_line_ix = 64usize;
+        let end_line_ix = start_line_ix + TS_DOCUMENT_LINE_TOKEN_CHUNK_ROWS;
+        let matches = collect_treesitter_injection_matches_for_line_window(
+            &root,
+            jinja,
+            bytes,
+            line_starts,
+            start_line_ix,
+            end_line_ix,
+        );
+        let group = matches.combined.first().expect("one combined html group");
+        assert_eq!(
+            group.ranges.len(),
+            1,
+            "the fixture's body must be one text run, or it is not testing the hard case"
+        );
+
+        let window_start = line_starts[start_line_ix];
+        let window_end = line_region_end_byte(line_starts, bytes.len(), end_line_ix - 1);
+        let html = tree_sitter_highlight_spec(DiffSyntaxLanguage::Html).expect("html spec");
+        let render = |ranges: &[Range<usize>]| -> Vec<Vec<SyntaxToken>> {
+            let tree = parse_combined_injection_tree(html, bytes, line_starts, ranges)
+                .expect("combined parse");
+            let mut injected = collect_treesitter_document_line_tokens_for_line_window(
+                &tree,
+                html,
+                bytes,
+                line_starts,
+                start_line_ix,
+                end_line_ix,
+            );
+            for gap in combined_injection_gaps(window_start..window_end, ranges) {
+                subtract_absolute_range_from_document_tokens(
+                    line_starts,
+                    bytes,
+                    start_line_ix,
+                    &mut injected,
+                    gap,
+                );
+            }
+            injected
+        };
+
+        let clip_region =
+            combined_injection_clip_region(line_starts, bytes.len(), start_line_ix, end_line_ix);
+        let clipped_ranges = clip_injection_ranges_to_region(&group.ranges, &clip_region);
+        let clipped_bytes: usize = clipped_ranges.iter().map(|r| r.end - r.start).sum();
+        let full_bytes: usize = group.ranges.iter().map(|r| r.end - r.start).sum();
+        assert!(
+            clipped_bytes < full_bytes,
+            "the clip must actually shrink the parse ({clipped_bytes} vs {full_bytes})"
+        );
+
+        assert_eq!(
+            render(&group.ranges),
+            render(&clipped_ranges),
+            "clipping to the window changed the tokens the window renders"
+        );
+    }
+
+    /// The clip region is the window plus a margin on both sides, and the margin is
+    /// load-bearing rather than decorative -- see the constant.
+    #[test]
+    fn combined_injection_clip_region_pads_the_window_on_both_sides() {
+        let text = dense_jinja_table(400, 2);
+        let input = treesitter_document_input_from_text(&text);
+        let line_starts = input.line_starts.as_ref();
+        let len = text.len();
+
+        let start_line_ix = 200usize;
+        let end_line_ix = start_line_ix + TS_DOCUMENT_LINE_TOKEN_CHUNK_ROWS;
+        let region = combined_injection_clip_region(line_starts, len, start_line_ix, end_line_ix);
+        let window_start = line_starts[start_line_ix];
+        let window_end = line_region_end_byte(line_starts, len, end_line_ix - 1);
+
+        assert!(
+            region.start < window_start && region.end > window_end,
+            "clip region {region:?} must strictly contain the window \
+             {window_start}..{window_end}"
+        );
+        assert_eq!(
+            window_start - region.start,
+            TS_COMBINED_INJECTION_CONTEXT_MARGIN_BYTES,
+            "leading margin"
+        );
+
+        // ... and still bounded, which is what makes the ceilings window-scoped.
+        assert!(
+            region.end - region.start
+                < window_end - window_start + 2 * TS_COMBINED_INJECTION_CONTEXT_MARGIN_BYTES + 1,
+            "clip region must not grow past window + 2 * margin"
+        );
+
+        // At the top of the document the margin runs out rather than underflowing.
+        let head = combined_injection_clip_region(line_starts, len, 0, 8);
+        assert_eq!(head.start, 0, "no underflow at the start of the document");
+    }
+
+    /// A cut that touches nothing must leave the line's tokens exactly as they were,
+    /// and must not reallocate to do it.
+    #[test]
+    fn subtracting_a_non_overlapping_range_leaves_line_tokens_untouched() {
+        let original = vec![
+            SyntaxToken {
+                range: 0..4,
+                kind: SyntaxTokenKind::Tag,
+            },
+            SyntaxToken {
+                range: 10..14,
+                kind: SyntaxTokenKind::String,
+            },
+        ];
+
+        // Entirely before, entirely after, and in the gap between the two tokens.
+        for cut in [20..30usize, 4..10, 100..200] {
+            let mut tokens = original.clone();
+            subtract_relative_range_from_line_tokens(&mut tokens, cut.clone());
+            assert_eq!(tokens, original, "cut {cut:?} must be a no-op");
+        }
+
+        // ... and a cut that does overlap still splits, so the fast path is not
+        // swallowing real work.
+        let mut tokens = original.clone();
+        subtract_relative_range_from_line_tokens(&mut tokens, 2..12);
+        assert_eq!(
+            tokens,
+            vec![
+                SyntaxToken {
+                    range: 0..2,
+                    kind: SyntaxTokenKind::Tag,
+                },
+                SyntaxToken {
+                    range: 12..14,
+                    kind: SyntaxTokenKind::String,
+                },
+            ]
+        );
+    }
+
+    /// Pins the ordering rather than a symptom: no in-tree grammar declares both
+    /// kinds over one span yet, but with combined applied first an overlapping
+    /// single would delete its tokens and repaint only part of the span.
+    #[test]
+    fn combined_injection_groups_are_applied_after_the_single_ones() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/view/rows/diff_text/syntax/prepared.rs"
+        ))
+        .expect("prepared.rs should be readable");
+        let body_start = source
+            .find("fn apply_injection_query_tokens_for_document")
+            .expect("the function that applies both kinds of layer");
+        let body = &source[body_start..];
+        let body_end = body.find("\n}\n").expect("the end of the function");
+        let body = &body[..body_end];
+
+        let singles_at = body
+            .find("for injection in &injections.singles")
+            .expect("the singles loop");
+        let combined_at = body
+            .find("for group in &injections.combined")
+            .expect("the combined loop");
+        assert!(
+            singles_at < combined_at,
+            "the singles loop must run before the combined one, or a single's \
+             subtraction erases combined tokens nothing repaints"
+        );
+    }
+
     /// F# XML doc comments are the one in-tree consumer of `injection.combined`.
     ///
     /// `xml_doc` is a per-line token, so before combined support each `///` line
@@ -7385,12 +7933,15 @@ mod tests {
 
     /// Combined layers must not touch the per-node injection cache at all.
     ///
-    /// The 32-slot LRU exists to share one injected parse across several line
-    /// windows. A combined layer is scoped to a single window and its result is
-    /// already memoised a level up in the chunk cache, so caching it would buy
-    /// nothing and would evict the entries `vue_static_inline_styles_do_not_flood_
-    /// the_injection_cache` depends on. Before this change, 200 `///` lines meant
-    /// 200 entries into a 32-slot cache.
+    /// The 32-slot LRU is keyed by a single node's content hash, which a combined
+    /// layer does not have -- its identity is a *set* of ranges. Feeding it one
+    /// entry per constituent node is what F# used to do: 200 `///` lines meant 200
+    /// entries into a 32-slot cache, evicting everything
+    /// `vue_static_inline_styles_do_not_flood_the_injection_cache` depends on.
+    ///
+    /// This is not a claim that combined parses are memoised elsewhere. They are
+    /// not: each of the N/64 chunks pays its own on first build, and clipping is
+    /// what keeps that cost proportional to the window.
     #[test]
     fn combined_injections_do_not_consume_the_per_node_injection_cache() {
         TS_INJECTION_CACHE.with(|cache| cache.borrow_mut().clear());
@@ -7411,9 +7962,10 @@ mod tests {
         let cached = TS_INJECTION_CACHE.with(|cache| cache.borrow().len());
         assert_eq!(
             cached, 0,
-            "a combined injection is parsed per window and memoised by the chunk cache, so \
-             it must not enter TS_INJECTION_CACHE (cap {TS_INJECTION_CACHE_MAX_ENTRIES}); \
-             {line_count} lines of xml doc comment created {cached} entries"
+            "a combined layer's identity is a set of ranges, not one node's content \
+             hash, so it must not enter TS_INJECTION_CACHE (cap \
+             {TS_INJECTION_CACHE_MAX_ENTRIES}); {line_count} lines of xml doc comment \
+             created {cached} entries"
         );
 
         TS_INJECTION_CACHE.with(|cache| cache.borrow_mut().clear());

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax.rs
@@ -52,6 +52,10 @@ const HTML_HIGHLIGHTS_QUERY: &str = include_str!("queries/html_highlights.scm");
 #[cfg(any(test, feature = "syntax-web"))]
 const HTML_INJECTIONS_QUERY: &str = include_str!("queries/html_injections.scm");
 #[cfg(any(test, feature = "syntax-web"))]
+const JINJA_HIGHLIGHTS_QUERY: &str = include_str!("queries/jinja_highlights.scm");
+#[cfg(any(test, feature = "syntax-web"))]
+const JINJA_INJECTIONS_QUERY: &str = include_str!("queries/jinja_injections.scm");
+#[cfg(any(test, feature = "syntax-web"))]
 const VUE_HIGHLIGHTS_QUERY: &str = include_str!("queries/vue_highlights.scm");
 #[cfg(any(test, feature = "syntax-web"))]
 const VUE_INJECTIONS_QUERY: &str = include_str!("queries/vue_injections.scm");
@@ -107,6 +111,19 @@ const CPP_INJECTIONS_QUERY: &str = include_str!("queries/cpp_injections.scm");
 /// itself contains an injection query.
 const TS_MAX_INJECTION_DEPTH: usize = 1;
 const TS_INJECTION_CACHE_MAX_ENTRIES: usize = 32;
+
+/// Ceilings for one `(#set! injection.combined)` layer.
+///
+/// Deliberately hard limits rather than a time budget. Injected parses are
+/// unbudgeted today, and the prepared path has no stale/retry mechanism to repair
+/// a layer that a `ControlFlow::Break` dropped -- that exists only in `live.rs` --
+/// so a budgeted combined layer would appear and vanish with scroll timing.
+/// Skipping the group deterministically leaves the host grammar painting instead.
+///
+/// The parse only lexes *included* bytes, so a 64-row window of template is a few
+/// KB; these are guards against pathological input, not the expected case.
+const TS_COMBINED_INJECTION_MAX_RANGES: usize = 512;
+const TS_COMBINED_INJECTION_MAX_BYTES: usize = 128 * 1024;
 
 thread_local! {
     static TS_PARSER: RefCell<tree_sitter::Parser> = RefCell::new(tree_sitter::Parser::new());
@@ -203,6 +220,10 @@ pub(in crate::view) enum DiffSyntaxLanguage {
     MarkdownInline,
     Html,
     Vue,
+    /// Nunjucks, Jinja2, Twig and Django templates. One grammar parses the union
+    /// of all four dialects; the HTML around the tags arrives as a combined
+    /// injection (see queries/jinja_injections.scm).
+    Jinja,
     Css,
     Hcl,
     Bicep,
@@ -6697,13 +6718,18 @@ mod tests {
         );
     }
 
-    #[test]
-    fn grammar_and_highlight_spec_agree_on_supported_languages() {
-        let all_languages = [
+    /// Every `DiffSyntaxLanguage` variant, listed by hand.
+    ///
+    /// Deliberately not derived from the enum: the point is that adding a variant
+    /// breaks a test until someone states what the new language does, rather than
+    /// being silently swept into whatever the loop asserts.
+    fn all_supported_languages() -> Vec<DiffSyntaxLanguage> {
+        Vec::from([
             DiffSyntaxLanguage::Markdown,
             DiffSyntaxLanguage::MarkdownInline,
             DiffSyntaxLanguage::Html,
             DiffSyntaxLanguage::Vue,
+            DiffSyntaxLanguage::Jinja,
             DiffSyntaxLanguage::Css,
             DiffSyntaxLanguage::Hcl,
             DiffSyntaxLanguage::Bicep,
@@ -6744,8 +6770,12 @@ mod tests {
             DiffSyntaxLanguage::GitCommit,
             DiffSyntaxLanguage::Bash,
             DiffSyntaxLanguage::Xml,
-        ];
-        for lang in all_languages {
+        ])
+    }
+
+    #[test]
+    fn grammar_and_highlight_spec_agree_on_supported_languages() {
+        for lang in all_supported_languages() {
             let has_grammar = tree_sitter_grammar(lang).is_some();
             let has_spec = tree_sitter_highlight_spec(lang).is_some();
             assert_eq!(
@@ -6754,6 +6784,613 @@ mod tests {
                  grammar={has_grammar}, spec={has_spec}"
             );
         }
+    }
+
+    // ---- Nunjucks / Jinja2 ----------------------------------------------------
+
+    /// The `.njk` / `.j2` / `.jinja` fixture, shared by the tests below.
+    #[cfg(any(test, feature = "syntax-web"))]
+    const JINJA_TEMPLATE_FIXTURE: &[&str] = &[
+        /* 0 */ "{# page heading #}",
+        /* 1 */ "<ul class=\"list\">",
+        /* 2 */ "  {% for item in items %}",
+        /* 3 */ "    <li>{{ item.name | upper }}</li>",
+        /* 4 */ "  {% endfor %}",
+        /* 5 */ "</ul>",
+    ];
+
+    #[cfg(any(test, feature = "syntax-web"))]
+    fn prepare_jinja_document(lines: &[&str]) -> PreparedSyntaxDocument {
+        prepare_test_document(DiffSyntaxLanguage::Jinja, &lines.join("\n"))
+    }
+
+    #[test]
+    fn jinja_extension_is_supported() {
+        for path in [
+            "templates/index.njk",
+            "templates/base.html.j2",
+            "roles/web/templates/nginx.conf.j2",
+            "templates/macros.jinja",
+            "templates/macros.jinja2",
+            "templates/page.twig",
+            "templates/page.html.dj",
+        ] {
+            assert_eq!(
+                diff_syntax_language_for_path(path),
+                Some(DiffSyntaxLanguage::Jinja),
+                "{path} should resolve to the Jinja grammar"
+            );
+        }
+        // The same table backs markdown fence info, so these come along for free.
+        for fence in ["njk", "jinja", "jinja2", "twig", "nunjucks"] {
+            assert_eq!(
+                diff_syntax_language_for_code_fence_info(fence),
+                Some(DiffSyntaxLanguage::Jinja),
+                "```{fence} should resolve to the Jinja grammar"
+            );
+        }
+    }
+
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn prepared_jinja_document_highlights_template_tags() {
+        let doc = prepare_jinja_document(JINJA_TEMPLATE_FIXTURE);
+
+        let comment = token_kinds_for_line_fragment(doc, 0, JINJA_TEMPLATE_FIXTURE[0], "heading");
+        assert!(
+            comment.contains(&SyntaxTokenKind::Comment),
+            "`{{# … #}}` is a Jinja comment: {comment:?}"
+        );
+
+        let open = token_kinds_for_line_fragment(doc, 2, JINJA_TEMPLATE_FIXTURE[2], "{%");
+        assert!(
+            open.contains(&SyntaxTokenKind::PunctuationSpecial),
+            "the `{{%` delimiter should be punctuation, not plain text: {open:?}"
+        );
+
+        for (line_ix, keyword) in [(2usize, "for"), (4, "endfor")] {
+            let kinds = token_kinds_for_line_fragment(
+                doc,
+                line_ix,
+                JINJA_TEMPLATE_FIXTURE[line_ix],
+                keyword,
+            );
+            assert!(
+                kinds.contains(&SyntaxTokenKind::KeywordControl),
+                "`{keyword}` is control flow and should render semibold: {kinds:?}"
+            );
+        }
+
+        let filter = token_kinds_for_line_fragment(doc, 3, JINJA_TEMPLATE_FIXTURE[3], "upper");
+        assert!(
+            filter.contains(&SyntaxTokenKind::Function),
+            "a filter name after `|` should read as a function: {filter:?}"
+        );
+
+        let property = token_kinds_for_line_fragment(doc, 3, JINJA_TEMPLATE_FIXTURE[3], "name");
+        assert!(
+            property.contains(&SyntaxTokenKind::Property),
+            "`item.name` should colour `name` as a property: {property:?}"
+        );
+    }
+
+    /// The HTML half of a template comes from the combined injection, not the
+    /// Jinja grammar -- which sees only opaque `text` nodes.
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn prepared_jinja_document_highlights_html_via_the_combined_injection() {
+        let doc = prepare_jinja_document(JINJA_TEMPLATE_FIXTURE);
+
+        let tag = token_kinds_for_line_fragment(doc, 1, JINJA_TEMPLATE_FIXTURE[1], "ul");
+        assert!(
+            tag.contains(&SyntaxTokenKind::Tag),
+            "`<ul>` should be tagged by the injected HTML layer: {tag:?}"
+        );
+        let attribute = token_kinds_for_line_fragment(doc, 1, JINJA_TEMPLATE_FIXTURE[1], "class");
+        assert!(
+            attribute.contains(&SyntaxTokenKind::Attribute),
+            "`class=` should be an HTML attribute: {attribute:?}"
+        );
+
+        // The whole point of the combined injection: `<li>` sits inside the loop
+        // body, in a different `text` node from `<ul>`, and still highlights.
+        let inner = token_kinds_for_line_fragment(doc, 3, JINJA_TEMPLATE_FIXTURE[3], "li");
+        assert!(
+            inner.contains(&SyntaxTokenKind::Tag),
+            "`<li>` is in a separate text run from `<ul>`; only a combined layer \
+             sees them as one document: {inner:?}"
+        );
+    }
+
+    /// The injected HTML must stay off the template tags, which the Jinja
+    /// grammar owns. See `combined_injection_gaps`.
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn jinja_html_injection_does_not_bleed_onto_template_tags() {
+        let doc = prepare_jinja_document(JINJA_TEMPLATE_FIXTURE);
+        let kinds = token_kinds_for_line_fragment(doc, 4, JINJA_TEMPLATE_FIXTURE[4], "endfor");
+        assert!(
+            !kinds.contains(&SyntaxTokenKind::Tag),
+            "`{{% endfor %}}` sits in a gap between two HTML ranges; an HTML element \
+             node spanning it must not colour it as a tag: {kinds:?}"
+        );
+    }
+
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn jinja_injection_targets_resolve_to_working_grammars() {
+        let lang: tree_sitter::Language = tree_sitter_jinja_dialects::LANGUAGE.into();
+        let query = tree_sitter::Query::new(&lang, JINJA_INJECTIONS_QUERY)
+            .expect("jinja_injections.scm should compile");
+        let mut checked = 0usize;
+        for pattern_ix in 0..query.pattern_count() {
+            for setting in query.property_settings(pattern_ix) {
+                if setting.key.as_ref() != "injection.language" {
+                    continue;
+                }
+                let Some(value) = setting.value.as_deref() else {
+                    continue;
+                };
+                let target = injection_language_from_name(value).unwrap_or_else(|| {
+                    panic!("jinja_injections.scm names an unknown injection language {value:?}")
+                });
+                assert!(
+                    tree_sitter_highlight_spec(target).is_some(),
+                    "jinja_injections.scm injects {value:?} but no grammar is wired for \
+                     {target:?}, so the injection would silently no-op"
+                );
+                checked += 1;
+            }
+        }
+        assert!(
+            checked > 0,
+            "expected at least one `#set! injection.language`"
+        );
+    }
+
+    /// Warm-up reads targets off the compiled query, and only sees `#set!`
+    /// literals. If the HTML target ever moved into an `@injection.language`
+    /// capture, the ~0.5ms HTML spec compile would move back onto the draw path.
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn jinja_spec_warmup_reaches_html_through_a_set_directive() {
+        let spec = tree_sitter_highlight_spec(DiffSyntaxLanguage::Jinja).expect("jinja spec");
+        let injection_query = spec
+            .injection_query
+            .as_ref()
+            .expect("jinja injection query");
+        let reaches_html = (0..injection_query.pattern_count()).any(|pattern_ix| {
+            injection_query
+                .property_settings(pattern_ix)
+                .iter()
+                .filter(|setting| setting.key.as_ref() == "injection.language")
+                .any(|setting| {
+                    setting
+                        .value
+                        .as_deref()
+                        .and_then(injection_language_from_name)
+                        == Some(DiffSyntaxLanguage::Html)
+                })
+        });
+        assert!(
+            reaches_html,
+            "warm_reachable_highlight_specs must be able to see the html target"
+        );
+    }
+
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn jinja_injection_query_stays_under_the_match_limit_on_a_dense_template() {
+        let mut lines = vec!["<ul>".to_string()];
+        for ix in 0..120 {
+            lines.push(format!(
+                "  {{% if show{ix} %}}<li class=\"r{ix}\">{{{{ row{ix}.label | title }}}}</li>{{% endif %}}"
+            ));
+        }
+        lines.push("</ul>".to_string());
+        let text = lines.join("\n");
+
+        let lang: tree_sitter::Language = tree_sitter_jinja_dialects::LANGUAGE.into();
+        let query = tree_sitter::Query::new(&lang, JINJA_INJECTIONS_QUERY)
+            .expect("jinja_injections.scm should compile");
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&lang)
+            .expect("jinja grammar should load");
+        let tree = parser
+            .parse(&text, None)
+            .expect("dense template should parse");
+
+        let mut cursor = tree_sitter::QueryCursor::new();
+        cursor.set_match_limit(TS_QUERY_MATCH_LIMIT);
+        let mut matched = 0usize;
+        {
+            let mut matches = cursor.matches(&query, tree.root_node(), text.as_bytes());
+            tree_sitter::StreamingIterator::advance(&mut matches);
+            while matches.get().is_some() {
+                matched += 1;
+                tree_sitter::StreamingIterator::advance(&mut matches);
+            }
+        }
+
+        assert!(
+            !cursor.did_exceed_match_limit(),
+            "the Jinja injection query overflowed the {TS_QUERY_MATCH_LIMIT}-match \
+             in-progress pool on a {}-line template. A combined group that loses ranges \
+             assembles a different HTML document, so the engine drops the whole group and \
+             the template renders with no HTML highlighting at all",
+            lines.len(),
+        );
+        assert!(matched > 0, "the dense template should produce matches");
+    }
+
+    /// The grammar is a young crates.io release binding through
+    /// `tree-sitter-language`, so a tree-sitter bump could outrun it.
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn jinja_grammar_is_abi_compatible_with_workspace_tree_sitter() {
+        let jinja: tree_sitter::Language = tree_sitter_jinja_dialects::LANGUAGE.into();
+        let abi = jinja.abi_version();
+        assert!(
+            (tree_sitter::MIN_COMPATIBLE_LANGUAGE_VERSION..=tree_sitter::LANGUAGE_VERSION)
+                .contains(&abi),
+            "tree-sitter-jinja-dialects ABI {abi} is outside the range this tree-sitter \
+             supports ({}..={})",
+            tree_sitter::MIN_COMPATIBLE_LANGUAGE_VERSION,
+            tree_sitter::LANGUAGE_VERSION,
+        );
+    }
+
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn jinja_grammar_parses_every_dialect_it_claims() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_jinja_dialects::LANGUAGE.into())
+            .expect("jinja grammar should load into the workspace tree-sitter");
+        // One sample per dialect the crate advertises, since a single grammar
+        // serving all of njk/j2/twig/dj is the reason it was chosen.
+        for (dialect, source) in [
+            ("jinja2", "{% for x in xs %}{{ x|e }}{% endfor %}\n"),
+            ("nunjucks", "{% set n = 1 %}{{ n + 1 }}\n"),
+            ("twig", "{% if a is not empty %}{{ a.b }}{% endif %}\n"),
+            (
+                "django",
+                "{% extends \"base.html\" %}{% block body %}{% endblock %}\n",
+            ),
+        ] {
+            let tree = parser
+                .parse(source, None)
+                .unwrap_or_else(|| panic!("{dialect} sample should parse"));
+            assert!(
+                !tree.root_node().has_error(),
+                "{dialect} sample produced an ERROR node: {}",
+                tree.root_node().to_sexp(),
+            );
+        }
+    }
+
+    // ---- `#set! injection.combined` ------------------------------------------
+
+    /// The inventory tripwire.
+    ///
+    /// Combined injections change how a grammar's whole document is assembled, so
+    /// a grammar bump that quietly introduces the directive must not slip through
+    /// review. F#'s `xml_doc` rule is the only one in the tree today; it arrived
+    /// with the upstream `tree_sitter_fsharp::INJECTIONS_QUERY` rather than being
+    /// written here.
+    #[test]
+    fn combined_injection_declarations_are_exactly_the_known_set() {
+        let mut declared = Vec::new();
+        for lang in all_supported_languages() {
+            let Some(spec) = tree_sitter_highlight_spec(lang) else {
+                continue;
+            };
+            for (pattern_ix, combined) in spec.injection_combined_patterns.iter().enumerate() {
+                if *combined {
+                    declared.push((lang, pattern_ix));
+                }
+            }
+            assert_eq!(
+                spec.has_combined_injections,
+                spec.injection_combined_patterns.iter().any(|c| *c),
+                "{lang:?} has a stale has_combined_injections flag"
+            );
+        }
+        assert_eq!(
+            declared,
+            vec![
+                // queries/jinja_injections.scm -- the HTML around the template tags.
+                (DiffSyntaxLanguage::Jinja, 0),
+                // Upstream tree_sitter_fsharp::INJECTIONS_QUERY -- `xml_doc` lines.
+                (DiffSyntaxLanguage::FSharp, 3),
+            ],
+            "the set of grammars declaring `#set! injection.combined` changed. Every entry \
+             here parses all its matches as one document via set_included_ranges, so a new \
+             one needs the gap-clipping and cache behaviour reviewed -- it is not a \
+             drop-in.\nfound: {declared:?}"
+        );
+    }
+
+    // The one-range cases are the point: a single included range is the shape
+    // every non-combined injection has, and both helpers have to leave it alone.
+    #[allow(clippy::single_range_in_vec_init)]
+    #[test]
+    fn merge_sorted_injection_ranges_normalises_for_set_included_ranges() {
+        // Empty stays empty: an empty slice is tree-sitter's "whole document"
+        // reset, which callers must detect rather than pass on.
+        assert!(merge_sorted_injection_ranges(Vec::new()).is_empty());
+        // Degenerate ranges are dropped, not kept as zero-width.
+        assert!(merge_sorted_injection_ranges(vec![5..5]).is_empty());
+        assert_eq!(merge_sorted_injection_ranges(vec![2..5]), vec![2..5]);
+        // Unsorted input is sorted: set_included_ranges rejects descending ranges.
+        assert_eq!(
+            merge_sorted_injection_ranges(vec![10..12, 2..5]),
+            vec![2..5, 10..12]
+        );
+        // Touching ranges coalesce, so the gap list carries no empty entries.
+        assert_eq!(merge_sorted_injection_ranges(vec![2..5, 5..9]), vec![2..9]);
+        // Overlapping ranges coalesce: set_included_ranges rejects overlap.
+        assert_eq!(merge_sorted_injection_ranges(vec![2..7, 5..9]), vec![2..9]);
+        // Fully contained range is absorbed rather than shortening the outer one.
+        assert_eq!(
+            merge_sorted_injection_ranges(vec![2..20, 5..9]),
+            vec![2..20]
+        );
+    }
+
+    // The one-range cases are the point: a single included range is the shape
+    // every non-combined injection has, and both helpers have to leave it alone.
+    #[allow(clippy::single_range_in_vec_init)]
+    #[test]
+    fn combined_injection_gaps_are_the_complement_within_the_window() {
+        assert_eq!(combined_injection_gaps(0..100, &[]), vec![0..100]);
+        assert!(combined_injection_gaps(0..100, &[0..100]).is_empty());
+        assert_eq!(
+            combined_injection_gaps(0..100, &[10..20, 30..40]),
+            vec![0..10, 20..30, 40..100]
+        );
+        // Range flush against each edge produces no leading/trailing gap.
+        assert_eq!(combined_injection_gaps(0..100, &[0..20]), vec![20..100]);
+        assert_eq!(combined_injection_gaps(0..100, &[80..100]), vec![0..80]);
+        // Ranges reaching outside the window are clipped to it, not extrapolated.
+        assert_eq!(combined_injection_gaps(20..80, &[0..30]), vec![30..80]);
+        assert_eq!(combined_injection_gaps(20..80, &[70..200]), vec![20..70]);
+        assert!(combined_injection_gaps(20..80, &[0..200]).is_empty());
+        // A range entirely outside contributes nothing and does not swallow the window.
+        assert_eq!(combined_injection_gaps(20..80, &[200..300]), vec![20..80]);
+    }
+
+    /// Two halves of an HTML element split across a host-grammar tag must parse as
+    /// one element, and the injected grammar must not colour the host bytes
+    /// between them.
+    ///
+    /// HTML stands in for the eventual template grammar here so the test needs no
+    /// new dependency. The ranges are the same shape a `(text) @injection.content`
+    /// rule produces on a real template.
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn combined_injection_parses_disjoint_ranges_as_one_document() {
+        let text = "<ul>\n{% for x in xs %}<li>hi</li>{% endfor %}\n</ul>\n";
+        let input = treesitter_document_input_from_text(text);
+        let bytes = text.as_bytes();
+        let ranges = combined_test_ranges(text);
+
+        let spec = tree_sitter_highlight_spec(DiffSyntaxLanguage::Html).expect("html spec");
+        let tree = parse_combined_injection_tree(spec, bytes, input.line_starts.as_ref(), &ranges)
+            .expect("combined parse should succeed");
+
+        assert_eq!(
+            tree.root_node().start_byte(),
+            ranges[0].start,
+            "a tree parsed with included_ranges reports document offsets"
+        );
+        assert!(
+            !tree.root_node().has_error(),
+            "the <ul> opened before `{{% for %}}` should close after `{{% endfor %}}` when the \
+             three text runs are parsed as one document: {}",
+            tree.root_node().to_sexp(),
+        );
+    }
+
+    /// The other half: nodes straddling two included ranges report a byte range
+    /// covering the host bytes in between, so their captures have to be clipped.
+    #[cfg(any(test, feature = "syntax-web"))]
+    #[test]
+    fn combined_injection_tokens_do_not_bleed_into_the_gaps() {
+        let text = "<ul>\n{% for x in xs %}<li>hi</li>{% endfor %}\n</ul>\n";
+        let input = treesitter_document_input_from_text(text);
+        let bytes = text.as_bytes();
+        let ranges = combined_test_ranges(text);
+        let line_starts = input.line_starts.as_ref();
+
+        let spec = tree_sitter_highlight_spec(DiffSyntaxLanguage::Html).expect("html spec");
+        let tree = parse_combined_injection_tree(spec, bytes, line_starts, &ranges)
+            .expect("combined parse should succeed");
+
+        let line_count = line_starts.len();
+        let mut tokens = collect_treesitter_document_line_tokens_for_line_window(
+            &tree,
+            spec,
+            bytes,
+            line_starts,
+            0,
+            line_count,
+        );
+        let window_end = line_region_end_byte(line_starts, bytes.len(), line_count - 1);
+        for gap in combined_injection_gaps(0..window_end, &ranges) {
+            subtract_absolute_range_from_document_tokens(line_starts, bytes, 0, &mut tokens, gap);
+        }
+
+        // Line 1 is `{% for x in xs %}<li>hi</li>{% endfor %}`. Only the `<li>hi</li>`
+        // slice belongs to HTML; both template tags are host-grammar bytes.
+        let line_start = line_starts[1];
+        let html_start = text.find("<li>").expect("li") - line_start;
+        let html_end = text.find("{% endfor %}").expect("endfor") - line_start;
+        for token in &tokens[1] {
+            assert!(
+                token.range.start >= html_start && token.range.end <= html_end,
+                "injected HTML token {:?} escaped its included range \
+                 ({html_start}..{html_end}) into a `{{% … %}}` gap",
+                token.range,
+            );
+        }
+        assert!(
+            !tokens[1].is_empty(),
+            "clipping should not have removed the genuine <li> tokens as well"
+        );
+    }
+
+    /// Byte ranges of the HTML runs in the combined-injection fixture, i.e. what a
+    /// template grammar's `(text)` nodes would capture.
+    #[cfg(any(test, feature = "syntax-web"))]
+    fn combined_test_ranges(text: &str) -> Vec<Range<usize>> {
+        let for_tag = text.find("{% for x in xs %}").expect("for tag");
+        let li = text.find("<li>").expect("li");
+        let endfor = text.find("{% endfor %}").expect("endfor");
+        let after_endfor = endfor + "{% endfor %}".len();
+        merge_sorted_injection_ranges(vec![0..for_tag, li..endfor, after_endfor..text.len()])
+    }
+
+    /// F# XML doc comments are the one in-tree consumer of `injection.combined`.
+    ///
+    /// `xml_doc` is a per-line token, so before combined support each `///` line
+    /// was its own XML document: `<summary>` on one line and `</summary>` on
+    /// another never met, and each cost an entry in the 32-slot injection cache.
+    #[cfg(any(test, feature = "syntax-extra"))]
+    #[test]
+    fn fsharp_xml_doc_comment_is_highlighted_as_one_xml_document() {
+        let lines = [
+            /* 0 */ "/// <summary>",
+            /* 1 */ "/// Adds two numbers.",
+            /* 2 */ "/// </summary>",
+            /* 3 */ "let add x y = x + y",
+        ];
+        let doc = prepare_test_document(DiffSyntaxLanguage::FSharp, &lines.join("\n"));
+
+        let closing = token_kinds_for_line_fragment(doc, 2, lines[2], "summary");
+        assert!(
+            closing.contains(&SyntaxTokenKind::Tag),
+            "`</summary>` closes a tag opened two lines earlier, which only parses \
+             when the three xml_doc lines are one document: {closing:?}"
+        );
+
+        // And the layer stays inside its own ranges: the following line is F#.
+        let keyword = token_kinds_for_line_fragment(doc, 3, lines[3], "let");
+        assert!(
+            keyword.contains(&SyntaxTokenKind::Keyword),
+            "the combined XML layer leaked past the doc comment onto `let`: {keyword:?}"
+        );
+    }
+
+    /// Combined layers must not touch the per-node injection cache at all.
+    ///
+    /// The 32-slot LRU exists to share one injected parse across several line
+    /// windows. A combined layer is scoped to a single window and its result is
+    /// already memoised a level up in the chunk cache, so caching it would buy
+    /// nothing and would evict the entries `vue_static_inline_styles_do_not_flood_
+    /// the_injection_cache` depends on. Before this change, 200 `///` lines meant
+    /// 200 entries into a 32-slot cache.
+    #[cfg(any(test, feature = "syntax-extra"))]
+    #[test]
+    fn combined_injections_do_not_consume_the_per_node_injection_cache() {
+        TS_INJECTION_CACHE.with(|cache| cache.borrow_mut().clear());
+
+        let mut lines = vec!["/// <summary>".to_string()];
+        for ix in 0..200 {
+            lines.push(format!("/// line {ix}"));
+        }
+        lines.push("/// </summary>".to_string());
+        lines.push("let add x y = x + y".to_string());
+        let line_count = lines.len();
+
+        let doc = prepare_test_document(DiffSyntaxLanguage::FSharp, &lines.join("\n"));
+        for line_ix in 0..line_count {
+            let _ = syntax_tokens_for_prepared_document_line(doc, line_ix);
+        }
+
+        let cached = TS_INJECTION_CACHE.with(|cache| cache.borrow().len());
+        assert_eq!(
+            cached, 0,
+            "a combined injection is parsed per window and memoised by the chunk cache, so \
+             it must not enter TS_INJECTION_CACHE (cap {TS_INJECTION_CACHE_MAX_ENTRIES}); \
+             {line_count} lines of xml doc comment created {cached} entries"
+        );
+
+        TS_INJECTION_CACHE.with(|cache| cache.borrow_mut().clear());
+    }
+
+    /// The failure this would cause is invisible and global.
+    ///
+    /// `TS_PARSER` is pooled and its included ranges are sticky; `with_ts_parser`
+    /// can skip `set_language` entirely on the fast path, so a combined parse that
+    /// forgot to clear them would truncate the *next* root parse on this thread —
+    /// for any language, with no error anywhere. Asserted behaviourally so it
+    /// survives tree-sitter API changes.
+    #[cfg(any(test, feature = "syntax-extra"))]
+    #[test]
+    fn combined_injection_parse_clears_the_pooled_parsers_included_ranges() {
+        let fsharp = ["/// <summary>", "/// x", "/// </summary>", "let x = 1"];
+        let _ = prepare_test_document(DiffSyntaxLanguage::FSharp, &fsharp.join("\n"));
+
+        let mut rust_lines = Vec::new();
+        for ix in 0..300 {
+            rust_lines.push(format!("fn f{ix}() -> u32 {{ {ix} }}"));
+        }
+        let last_ix = rust_lines.len() - 1;
+        let last_line = rust_lines[last_ix].clone();
+        let doc = prepare_test_document(DiffSyntaxLanguage::Rust, &rust_lines.join("\n"));
+
+        let kinds = token_kinds_for_line_fragment(doc, last_ix, &last_line, "fn");
+        assert!(
+            kinds.contains(&SyntaxTokenKind::Keyword),
+            "the last line of a 300-line Rust document lost its tokens after a combined \
+             injection ran on this thread -- the pooled parser's included ranges were not \
+             cleared, so the root parse was truncated: {kinds:?}"
+        );
+    }
+
+    /// A `(text)`-style combined rule fires once per node, so this is the query
+    /// most likely to overflow the in-progress match pool. Overflow is worse for a
+    /// combined layer than a single one: tree-sitter discards matches silently, and
+    /// a missing range changes the document the injected grammar assembles.
+    #[cfg(any(test, feature = "syntax-extra"))]
+    #[test]
+    fn fsharp_xml_doc_injection_stays_under_the_match_limit_on_a_long_doc_comment() {
+        let mut lines = vec!["/// <summary>".to_string()];
+        for ix in 0..200 {
+            lines.push(format!("/// line {ix}"));
+        }
+        lines.push("/// </summary>".to_string());
+        let text = lines.join("\n");
+
+        let lang: tree_sitter::Language = tree_sitter_fsharp::LANGUAGE_FSHARP.into();
+        let query = tree_sitter::Query::new(&lang, tree_sitter_fsharp::INJECTIONS_QUERY)
+            .expect("fsharp injections.scm should compile");
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang).expect("fsharp grammar");
+        let tree = parser.parse(&text, None).expect("doc comment should parse");
+
+        let mut cursor = tree_sitter::QueryCursor::new();
+        cursor.set_match_limit(TS_QUERY_MATCH_LIMIT);
+        let mut matched = 0usize;
+        {
+            let mut matches = cursor.matches(&query, tree.root_node(), text.as_bytes());
+            tree_sitter::StreamingIterator::advance(&mut matches);
+            while matches.get().is_some() {
+                matched += 1;
+                tree_sitter::StreamingIterator::advance(&mut matches);
+            }
+        }
+
+        assert!(
+            !cursor.did_exceed_match_limit(),
+            "the F# injection query overflowed the {TS_QUERY_MATCH_LIMIT}-match in-progress \
+             pool on a {}-line doc comment; a combined group that loses ranges assembles a \
+             different document, so the whole group is dropped when this happens",
+            lines.len(),
+        );
+        assert!(matched > 0, "the doc comment should produce matches at all");
     }
 
     // There are deliberately no `disabled_*_grammars_fall_back_to_none` tests.

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/heuristic.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/heuristic.rs
@@ -247,6 +247,16 @@ pub(super) fn heuristic_comment_config(language: DiffSyntaxLanguage) -> Heuristi
             block_comment: Some(HEURISTIC_C_BLOCK_COMMENT),
             visual_basic_line_comment: false,
         },
+        // Nix looks like the Hcl arm above but must NOT take its `//` line
+        // comment: `//` is Nix's attribute-set update operator, so
+        // `{ a = 1; } // { b = 2; }` would grey out from the operator to the end
+        // of the line. Nix comments are `#` and `/* */` only.
+        DiffSyntaxLanguage::Nix => HeuristicCommentConfig {
+            line_comment: None,
+            hash_comment: true,
+            block_comment: Some(HEURISTIC_C_BLOCK_COMMENT),
+            visual_basic_line_comment: false,
+        },
         DiffSyntaxLanguage::VisualBasic => HeuristicCommentConfig {
             line_comment: None,
             hash_comment: false,
@@ -295,6 +305,7 @@ fn heuristic_block_comment_kind(language: DiffSyntaxLanguage) -> Option<Heuristi
         | DiffSyntaxLanguage::Zig
         | DiffSyntaxLanguage::Bicep
         | DiffSyntaxLanguage::Hcl
+        | DiffSyntaxLanguage::Nix
         | DiffSyntaxLanguage::Php => Some(HeuristicBlockCommentKind::C),
         _ => None,
     }
@@ -1317,6 +1328,23 @@ fn is_keyword(language: DiffSyntaxLanguage, ident: &str) -> bool {
         DiffSyntaxLanguage::Hcl => matches!(
             ident,
             "true" | "false" | "null" | "for" | "in" | "if" | "else" | "endif" | "endfor"
+        ),
+        // The upstream grammar's keyword list plus the three literals it treats as
+        // builtin identifiers rather than keywords.
+        DiffSyntaxLanguage::Nix => matches!(
+            ident,
+            "if" | "then"
+                | "else"
+                | "let"
+                | "in"
+                | "inherit"
+                | "rec"
+                | "with"
+                | "assert"
+                | "or"
+                | "true"
+                | "false"
+                | "null"
         ),
         DiffSyntaxLanguage::Bicep => matches!(
             ident,

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/heuristic.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/heuristic.rs
@@ -162,14 +162,21 @@ pub(super) fn heuristic_comment_config(language: DiffSyntaxLanguage) -> Heuristi
         // Vue's root grammar is html-like, so it uses html comments here rather
         // than `//`: a template line such as `<img src="//cdn…">` must not be
         // greyed out as a comment.
-        DiffSyntaxLanguage::Html | DiffSyntaxLanguage::Xml | DiffSyntaxLanguage::Vue => {
-            HeuristicCommentConfig {
-                line_comment: None,
-                hash_comment: false,
-                block_comment: Some(HEURISTIC_HTML_BLOCK_COMMENT),
-                visual_basic_line_comment: false,
-            }
-        }
+        // Jinja joins the markup languages for the same reason Vue does, and
+        // takes `<!-- -->` rather than its own `{# #}`: the heuristic supports one
+        // block-comment spec, a `.njk`/`.j2` file is mostly HTML, and the
+        // tree-sitter path already colours `{# #}` as a `(comment)` node. This
+        // fallback only runs for lines past MAX_TREESITTER_LINE_BYTES or in
+        // HeuristicOnly mode.
+        DiffSyntaxLanguage::Html
+        | DiffSyntaxLanguage::Xml
+        | DiffSyntaxLanguage::Vue
+        | DiffSyntaxLanguage::Jinja => HeuristicCommentConfig {
+            line_comment: None,
+            hash_comment: false,
+            block_comment: Some(HEURISTIC_HTML_BLOCK_COMMENT),
+            visual_basic_line_comment: false,
+        },
         DiffSyntaxLanguage::FSharp => HeuristicCommentConfig {
             line_comment: None,
             hash_comment: false,
@@ -263,9 +270,10 @@ pub(super) fn heuristic_comment_config(language: DiffSyntaxLanguage) -> Heuristi
 
 fn heuristic_block_comment_kind(language: DiffSyntaxLanguage) -> Option<HeuristicBlockCommentKind> {
     match language {
-        DiffSyntaxLanguage::Html | DiffSyntaxLanguage::Xml | DiffSyntaxLanguage::Vue => {
-            Some(HeuristicBlockCommentKind::Html)
-        }
+        DiffSyntaxLanguage::Html
+        | DiffSyntaxLanguage::Xml
+        | DiffSyntaxLanguage::Vue
+        | DiffSyntaxLanguage::Jinja => Some(HeuristicBlockCommentKind::Html),
         DiffSyntaxLanguage::FSharp => Some(HeuristicBlockCommentKind::FSharp),
         DiffSyntaxLanguage::Lua => Some(HeuristicBlockCommentKind::Lua),
         DiffSyntaxLanguage::PowerShell => Some(HeuristicBlockCommentKind::PowerShell),
@@ -1272,6 +1280,37 @@ fn is_keyword(language: DiffSyntaxLanguage, ident: &str) -> bool {
         | DiffSyntaxLanguage::Vue
         | DiffSyntaxLanguage::Css
         | DiffSyntaxLanguage::Toml => matches!(ident, "true" | "false"),
+        // Only the identifiers that cannot also be an HTML attribute name or an
+        // ordinary English word. The heuristic is line-based and sees the whole
+        // line, tags and body text alike, so `if`, `for`, `in`, `is`, `not`,
+        // `and`, `or`, `as`, `set`, `block`, `with`, `call` and `do` are all left
+        // out -- colouring `<label for=…>` or the word "with" in prose as a
+        // keyword is worse than missing a real one. This is the same trade-off
+        // the markup arm above makes for Vue. The tree-sitter path colours the
+        // full keyword set from queries/jinja_highlights.scm.
+        DiffSyntaxLanguage::Jinja => matches!(
+            ident,
+            "endif"
+                | "endfor"
+                | "endblock"
+                | "endmacro"
+                | "endcall"
+                | "endfilter"
+                | "endraw"
+                | "endset"
+                | "endwith"
+                | "endautoescape"
+                | "endverbatim"
+                | "elif"
+                | "elseif"
+                | "extends"
+                | "macro"
+                | "autoescape"
+                | "verbatim"
+                | "true"
+                | "false"
+                | "none"
+        ),
         DiffSyntaxLanguage::Json | DiffSyntaxLanguage::Yaml => {
             matches!(ident, "true" | "false" | "null")
         }

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/heuristic.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/heuristic.rs
@@ -124,6 +124,7 @@ struct HeuristicOpenStateScanConfig {
     comment: HeuristicCommentConfig,
     block_comment_kind: Option<HeuristicBlockCommentKind>,
     allow_backtick_strings: bool,
+    single_quote: HeuristicSingleQuote,
 }
 
 impl HeuristicOpenStateScanConfig {
@@ -132,6 +133,7 @@ impl HeuristicOpenStateScanConfig {
             comment: heuristic_comment_config(language),
             block_comment_kind: heuristic_block_comment_kind(language),
             allow_backtick_strings: heuristic_allows_backtick_strings(language),
+            single_quote: heuristic_single_quote_role(language),
         }
     }
 }
@@ -175,6 +177,15 @@ pub(super) fn heuristic_comment_config(language: DiffSyntaxLanguage) -> Heuristi
             line_comment: None,
             hash_comment: false,
             block_comment: Some(HEURISTIC_HTML_BLOCK_COMMENT),
+            visual_basic_line_comment: false,
+        },
+        // A text-bodied template has no markup to comment, so `<!-- -->` would be
+        // wrong; its body is yaml, shell, nginx.conf or dotenv, and all four use
+        // `#`. That also lands on Jinja's own `{# … #}`, one byte late.
+        DiffSyntaxLanguage::JinjaText => HeuristicCommentConfig {
+            line_comment: None,
+            hash_comment: true,
+            block_comment: None,
             visual_basic_line_comment: false,
         },
         DiffSyntaxLanguage::FSharp => HeuristicCommentConfig {
@@ -579,6 +590,20 @@ fn advance_streamed_heuristic_open_state_ascii(
                 if matches!(byte, b'"' | b'\'')
                     || (scan_config.allow_backtick_strings && byte == b'`')
                 {
+                    // `potential_open_state_lead` over-approximates for `'`; this is
+                    // where a prose apostrophe or a Nix identifier tick is refused.
+                    if byte == b'\''
+                        && !heuristic_single_quote_opens_string(
+                            scan_config.single_quote,
+                            bytes,
+                            local,
+                        )
+                    {
+                        local += 1;
+                        *abs = abs.saturating_add(1);
+                        record_constant!(*abs, HeuristicOpenState::Normal);
+                        continue;
+                    }
                     local += 1;
                     *abs = abs.saturating_add(1);
                     *state = HeuristicOpenState::String {
@@ -919,6 +944,60 @@ fn heuristic_string_end(text: &str, start: usize, quote: char) -> usize {
     i.min(len)
 }
 
+/// What a `'` means to the heuristic scanner, which has no grammar to ask.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum HeuristicSingleQuote {
+    /// Opens a string anywhere. The C-family default, and what Rust byte and char
+    /// literals (`b'x'`, `'\n'`) need.
+    String,
+    /// Opens a string only where a value can start.
+    ///
+    /// Markup is mostly prose, and prose is full of apostrophes: an unconditional
+    /// rule painted the rest of the line from the first `It's`, and on the streamed
+    /// path the state then bled across lines. The preceding byte separates the two
+    /// uses -- a contraction follows what a value *ends* with, a word byte (`It's`)
+    /// or a closing delimiter (`{{ user.name }}'s`), while a quote follows an
+    /// operator, an opening delimiter or whitespace (`class='x'`,
+    /// `{{ x|default('n/a') }}`).
+    ValuePositionOnly,
+    /// Never a string; part of an identifier instead.
+    ///
+    /// Nix: `'` is a legal identifier character, so `lib.foldl'` and `mapAttrs'` are
+    /// one token each. Nix has no single-quoted string -- only `"..."` and the
+    /// indented `''...''` -- so nothing is lost. The `''...''` form is not
+    /// represented here and renders unhighlighted rather than mis-highlighted.
+    Identifier,
+}
+
+pub(super) fn heuristic_single_quote_role(language: DiffSyntaxLanguage) -> HeuristicSingleQuote {
+    match language {
+        DiffSyntaxLanguage::Nix => HeuristicSingleQuote::Identifier,
+        DiffSyntaxLanguage::Html
+        | DiffSyntaxLanguage::Xml
+        | DiffSyntaxLanguage::Vue
+        | DiffSyntaxLanguage::Jinja => HeuristicSingleQuote::ValuePositionOnly,
+        _ => HeuristicSingleQuote::String,
+    }
+}
+
+fn heuristic_single_quote_opens_string(
+    role: HeuristicSingleQuote,
+    bytes: &[u8],
+    index: usize,
+) -> bool {
+    match role {
+        HeuristicSingleQuote::String => true,
+        HeuristicSingleQuote::Identifier => false,
+        HeuristicSingleQuote::ValuePositionOnly => index
+            .checked_sub(1)
+            .and_then(|prev| bytes.get(prev))
+            .is_none_or(|prev| {
+                !prev.is_ascii_alphanumeric()
+                    && !matches!(prev, b'_' | b'}' | b')' | b']' | b'>' | b'"' | b'\'')
+            }),
+    }
+}
+
 fn heuristic_allows_backtick_strings(language: DiffSyntaxLanguage) -> bool {
     matches!(
         language,
@@ -1131,10 +1210,15 @@ pub(in super::super) fn syntax_tokens_for_line_heuristic_into(
     let mut i = 0usize;
     let comment_config = heuristic_comment_config(language);
     let allow_backtick_strings = heuristic_allows_backtick_strings(language);
+    let single_quote = heuristic_single_quote_role(language);
     let highlight_css_selectors = matches!(language, DiffSyntaxLanguage::Css);
 
     let is_ident_start = |byte: u8| byte == b'_' || byte.is_ascii_alphabetic();
-    let is_ident_continue = |byte: u8| byte == b'_' || byte.is_ascii_alphanumeric();
+    // `'` continues an identifier only where it is not a quote -- Nix's `foldl'`.
+    let ident_tick = single_quote == HeuristicSingleQuote::Identifier;
+    let is_ident_continue = move |byte: u8| {
+        byte == b'_' || byte.is_ascii_alphanumeric() || (ident_tick && byte == b'\'')
+    };
     let is_comment_lead = |byte: u8| {
         comment_config
             .line_comment
@@ -1203,7 +1287,10 @@ pub(in super::super) fn syntax_tokens_for_line_heuristic_into(
             continue;
         }
 
-        if matches!(byte, b'"' | b'\'') || (allow_backtick_strings && byte == b'`') {
+        if (byte == b'"'
+            || (byte == b'\'' && heuristic_single_quote_opens_string(single_quote, bytes, i)))
+            || (allow_backtick_strings && byte == b'`')
+        {
             let j = heuristic_string_end(text, i, byte as char);
             tokens.push(SyntaxToken {
                 range: i..j,
@@ -1299,7 +1386,7 @@ fn is_keyword(language: DiffSyntaxLanguage, ident: &str) -> bool {
         // keyword is worse than missing a real one. This is the same trade-off
         // the markup arm above makes for Vue. The tree-sitter path colours the
         // full keyword set from queries/jinja_highlights.scm.
-        DiffSyntaxLanguage::Jinja => matches!(
+        DiffSyntaxLanguage::Jinja | DiffSyntaxLanguage::JinjaText => matches!(
             ident,
             "endif"
                 | "endfor"
@@ -2268,4 +2355,73 @@ pub(super) fn syntax_tokens_for_line_markdown(text: &str) -> Vec<SyntaxToken> {
     }
 
     tokens
+}
+
+#[cfg(test)]
+mod streamed_open_state_tests {
+    use super::*;
+
+    fn tail_state(text: &str, language: DiffSyntaxLanguage) -> HeuristicOpenState {
+        let bytes = text.as_bytes();
+        let mut state = HeuristicOpenState::Normal;
+        let mut abs = 0usize;
+        let mut recorder: Option<HeuristicCheckpointRecorder<'_>> = None;
+        advance_streamed_heuristic_open_state_ascii(
+            bytes,
+            bytes.len(),
+            language,
+            &mut state,
+            &mut abs,
+            &mut recorder,
+        );
+        assert_eq!(abs, bytes.len(), "the scanner must consume the whole slice");
+        state
+    }
+
+    fn is_open_string(state: HeuristicOpenState) -> bool {
+        matches!(state, HeuristicOpenState::String { .. })
+    }
+
+    /// The nastier half of the apostrophe bug: the string state has no newline
+    /// reset, so once opened it stayed open across every following line until the
+    /// next stray `'`. A per-line assertion cannot see that.
+    #[test]
+    fn a_word_apostrophe_never_opens_the_streamed_string_state() {
+        for (language, text) in [
+            (
+                DiffSyntaxLanguage::Jinja,
+                "<p>It's a test</p>\n<div class=\"x\">plain</div>\n",
+            ),
+            (
+                DiffSyntaxLanguage::Html,
+                "<p>don't panic</p>\n<span>next line</span>\n",
+            ),
+            (
+                DiffSyntaxLanguage::Nix,
+                "  x = lib.foldl' add 0 xs;\n  y = 2;\n",
+            ),
+        ] {
+            assert!(
+                !is_open_string(tail_state(text, language)),
+                "{language:?} left the string state open across lines for {text:?}"
+            );
+        }
+    }
+
+    /// ... while a real unterminated quote still opens it.
+    #[test]
+    fn an_unterminated_value_quote_still_opens_the_streamed_string_state() {
+        assert!(
+            is_open_string(tail_state("<div class='card", DiffSyntaxLanguage::Html)),
+            "a genuine unterminated attribute quote must still open the state"
+        );
+        assert!(
+            !is_open_string(tail_state("<div class='card'>", DiffSyntaxLanguage::Html)),
+            "and close again at the matching quote"
+        );
+        assert!(
+            is_open_string(tail_state("let s = \"open", DiffSyntaxLanguage::Nix)),
+            "Nix double quotes are unaffected by the identifier rule"
+        );
+    }
 }

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/language.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/language.rs
@@ -19,6 +19,7 @@ fn diff_syntax_language_for_identifier(identifier: &str) -> Option<DiffSyntaxLan
         "hcl" | "tf" | "tfvars" => DiffSyntaxLanguage::Hcl,
         "bicep" => DiffSyntaxLanguage::Bicep,
         "lua" => DiffSyntaxLanguage::Lua,
+        "nix" => DiffSyntaxLanguage::Nix,
         "mk" | "make" | "makefile" | "gnumakefile" => DiffSyntaxLanguage::Makefile,
         "kt" | "kts" | "kotlin" => DiffSyntaxLanguage::Kotlin,
         "zig" => DiffSyntaxLanguage::Zig,
@@ -195,7 +196,6 @@ pub(super) fn tree_sitter_grammar(
     language: DiffSyntaxLanguage,
 ) -> Option<(tree_sitter::Language, TreesitterQueryAsset)> {
     match language {
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::Markdown => Some((
             tree_sitter_md::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(
@@ -203,32 +203,26 @@ pub(super) fn tree_sitter_grammar(
                 MARKDOWN_INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::MarkdownInline => Some((
             tree_sitter_md::INLINE_LANGUAGE.into(),
             TreesitterQueryAsset::highlights(MARKDOWN_INLINE_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Html => Some((
             tree_sitter_html::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(HTML_HIGHLIGHTS_QUERY, HTML_INJECTIONS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Jinja => Some((
             tree_sitter_jinja_dialects::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(JINJA_HIGHLIGHTS_QUERY, JINJA_INJECTIONS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Vue => Some((
             tree_sitter_vue::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(VUE_HIGHLIGHTS_QUERY, VUE_INJECTIONS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Css => Some((
             tree_sitter_css::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(CSS_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Bicep => Some((
             tree_sitter_bicep::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(
@@ -236,7 +230,10 @@ pub(super) fn tree_sitter_grammar(
                 tree_sitter_bicep::INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
+        DiffSyntaxLanguage::Nix => Some((
+            tree_sitter_nix::LANGUAGE.into(),
+            TreesitterQueryAsset::with_injections(NIX_HIGHLIGHTS_QUERY, NIX_INJECTIONS_QUERY),
+        )),
         DiffSyntaxLanguage::Lua => Some((
             tree_sitter_lua::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(
@@ -244,17 +241,14 @@ pub(super) fn tree_sitter_grammar(
                 tree_sitter_lua::INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Makefile => Some((
             tree_sitter_make::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_make::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Kotlin => Some((
             tree_sitter_kotlin_sg::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_kotlin_sg::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Zig => Some((
             tree_sitter_zig::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(
@@ -262,42 +256,34 @@ pub(super) fn tree_sitter_grammar(
                 tree_sitter_zig::INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-rust"))]
         DiffSyntaxLanguage::Rust => Some((
             tree_sitter_rust::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(RUST_HIGHLIGHTS_QUERY, RUST_INJECTIONS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-python"))]
         DiffSyntaxLanguage::Python => Some((
             tree_sitter_python::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(PYTHON_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-go"))]
         DiffSyntaxLanguage::Go => Some((
             tree_sitter_go::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(GO_HIGHLIGHTS_QUERY, GO_INJECTIONS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::GoMod => Some((
             tree_sitter_gomod::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(GOMOD_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::GoWork => Some((
             tree_sitter_gowork::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(GOWORK_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::C => Some((
             tree_sitter_c::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(C_HIGHLIGHTS_QUERY, C_INJECTIONS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Cpp => Some((
             tree_sitter_cpp::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(CPP_HIGHLIGHTS_QUERY, CPP_INJECTIONS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::ObjectiveC => Some((
             tree_sitter_objc::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(
@@ -305,12 +291,10 @@ pub(super) fn tree_sitter_grammar(
                 tree_sitter_objc::INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::CSharp => Some((
             tree_sitter_c_sharp::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(CSHARP_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::FSharp => Some((
             tree_sitter_fsharp::LANGUAGE_FSHARP.into(),
             TreesitterQueryAsset::with_injections(
@@ -318,12 +302,10 @@ pub(super) fn tree_sitter_grammar(
                 tree_sitter_fsharp::INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Java => Some((
             tree_sitter_java::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_java::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Php => Some((
             tree_sitter_php::LANGUAGE_PHP.into(),
             TreesitterQueryAsset::with_injections(
@@ -331,17 +313,14 @@ pub(super) fn tree_sitter_grammar(
                 tree_sitter_php::INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Ruby => Some((
             tree_sitter_ruby::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_ruby::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::PowerShell => Some((
             tree_sitter_powershell::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(POWERSHELL_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Swift => Some((
             tree_sitter_swift::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(
@@ -349,52 +328,42 @@ pub(super) fn tree_sitter_grammar(
                 tree_sitter_swift::INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::R => Some((
             tree_sitter_r::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_r::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Dart => Some((
             tree_sitter_dart::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_dart::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Scala => Some((
             tree_sitter_scala::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_scala::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-data"))]
         DiffSyntaxLanguage::Json => Some((
             tree_sitter_json::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(JSON_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Toml => Some((
             tree_sitter_toml_ng::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_toml_ng::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-data"))]
         DiffSyntaxLanguage::Yaml => Some((
             tree_sitter_yaml::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(YAML_HIGHLIGHTS_QUERY, YAML_INJECTIONS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Sql => Some((
             tree_sitter_sequel::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_sequel::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::Diff => Some((
             tree_sitter_diff::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(tree_sitter_diff::HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::GitCommit => Some((
             tree_sitter_gitcommit::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(GITCOMMIT_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::TypeScript => Some((
             tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
             TreesitterQueryAsset::with_injections(
@@ -402,12 +371,10 @@ pub(super) fn tree_sitter_grammar(
                 TYPESCRIPT_INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Tsx => Some((
             tree_sitter_typescript::LANGUAGE_TSX.into(),
             TreesitterQueryAsset::with_injections(TSX_HIGHLIGHTS_QUERY, TSX_INJECTIONS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::JavaScript => Some((
             tree_sitter_javascript::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(
@@ -415,22 +382,18 @@ pub(super) fn tree_sitter_grammar(
                 JAVASCRIPT_INJECTIONS_QUERY,
             ),
         )),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Jsdoc => Some((
             tree_sitter_jsdoc::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(JSDOC_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Regex => Some((
             tree_sitter_regex::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(REGEX_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-shell"))]
         DiffSyntaxLanguage::Bash => Some((
             tree_sitter_bash::LANGUAGE.into(),
             TreesitterQueryAsset::highlights(BASH_HIGHLIGHTS_QUERY),
         )),
-        #[cfg(any(test, feature = "syntax-xml"))]
         DiffSyntaxLanguage::Xml => Some((
             tree_sitter_xml::LANGUAGE_XML.into(),
             TreesitterQueryAsset::highlights(XML_HIGHLIGHTS_QUERY),
@@ -578,89 +541,48 @@ pub(super) fn tree_sitter_highlight_spec(
     language: DiffSyntaxLanguage,
 ) -> Option<&'static TreesitterHighlightSpec> {
     match language {
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::Markdown => highlight_spec_entry!(Markdown),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::MarkdownInline => highlight_spec_entry!(MarkdownInline),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Html => highlight_spec_entry!(Html),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Vue => highlight_spec_entry!(Vue),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Jinja => highlight_spec_entry!(Jinja),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Css => highlight_spec_entry!(Css),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Bicep => highlight_spec_entry!(Bicep),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Lua => highlight_spec_entry!(Lua),
-        #[cfg(any(test, feature = "syntax-extra"))]
+        DiffSyntaxLanguage::Nix => highlight_spec_entry!(Nix),
         DiffSyntaxLanguage::Makefile => highlight_spec_entry!(Makefile),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Kotlin => highlight_spec_entry!(Kotlin),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Zig => highlight_spec_entry!(Zig),
-        #[cfg(any(test, feature = "syntax-rust"))]
         DiffSyntaxLanguage::Rust => highlight_spec_entry!(Rust),
-        #[cfg(any(test, feature = "syntax-python"))]
         DiffSyntaxLanguage::Python => highlight_spec_entry!(Python),
-        #[cfg(any(test, feature = "syntax-go"))]
         DiffSyntaxLanguage::Go => highlight_spec_entry!(Go),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::GoMod => highlight_spec_entry!(GoMod),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::GoWork => highlight_spec_entry!(GoWork),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::C => highlight_spec_entry!(C),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Cpp => highlight_spec_entry!(Cpp),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::ObjectiveC => highlight_spec_entry!(ObjectiveC),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::CSharp => highlight_spec_entry!(CSharp),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::FSharp => highlight_spec_entry!(FSharp),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Java => highlight_spec_entry!(Java),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Php => highlight_spec_entry!(Php),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Ruby => highlight_spec_entry!(Ruby),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::PowerShell => highlight_spec_entry!(PowerShell),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Swift => highlight_spec_entry!(Swift),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::R => highlight_spec_entry!(R),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Dart => highlight_spec_entry!(Dart),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Scala => highlight_spec_entry!(Scala),
-        #[cfg(any(test, feature = "syntax-data"))]
         DiffSyntaxLanguage::Json => highlight_spec_entry!(Json),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Toml => highlight_spec_entry!(Toml),
-        #[cfg(any(test, feature = "syntax-data"))]
         DiffSyntaxLanguage::Yaml => highlight_spec_entry!(Yaml),
-        #[cfg(any(test, feature = "syntax-extra"))]
         DiffSyntaxLanguage::Sql => highlight_spec_entry!(Sql),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::Diff => highlight_spec_entry!(Diff),
-        #[cfg(any(test, feature = "syntax-repo"))]
         DiffSyntaxLanguage::GitCommit => highlight_spec_entry!(GitCommit),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::TypeScript => highlight_spec_entry!(TypeScript),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Tsx => highlight_spec_entry!(Tsx),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::JavaScript => highlight_spec_entry!(JavaScript),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Jsdoc => highlight_spec_entry!(Jsdoc),
-        #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Regex => highlight_spec_entry!(Regex),
-        #[cfg(any(test, feature = "syntax-shell"))]
         DiffSyntaxLanguage::Bash => highlight_spec_entry!(Bash),
-        #[cfg(any(test, feature = "syntax-xml"))]
         DiffSyntaxLanguage::Xml => highlight_spec_entry!(Xml),
         _ => None,
     }

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/language.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/language.rs
@@ -9,8 +9,8 @@ fn diff_syntax_language_for_identifier(identifier: &str) -> Option<DiffSyntaxLan
         "html" | "htm" => DiffSyntaxLanguage::Html,
         "vue" => DiffSyntaxLanguage::Vue,
         // The first six are the grammar's own declared file-types; `dj` is the
-        // Django addition. `diff_syntax_language_for_path` reads only the last
-        // extension, so `base.html.j2` and `page.html.dj` land here too.
+        // Django addition. The markup-bodied reading is the right default for a bare
+        // identifier; `diff_syntax_language_for_path` splits off the rest.
         "njk" | "nunjucks" | "j2" | "jinja" | "jinja2" | "twig" | "dj" => DiffSyntaxLanguage::Jinja,
         "xml" | "svg" | "xsl" | "xslt" | "xsd" | "xhtml" | "plist" | "csproj" | "fsproj"
         | "vbproj" | "sln" | "props" | "targets" | "resx" | "xaml" | "wsdl" | "rss" | "atom"
@@ -72,6 +72,33 @@ fn diff_syntax_language_for_identifier(identifier: &str) -> Option<DiffSyntaxLan
     })
 }
 
+/// Extensions whose body is HTML, so a template wrapping one keeps the injection.
+fn jinja_body_is_markup(inner_extension: &str) -> bool {
+    matches!(
+        inner_extension,
+        "" | "html" | "htm" | "xhtml" | "xml" | "svg" | "vue" | "hbs" | "mustache"
+    )
+}
+
+/// `foo.j2` alone says nothing about what is being templated: `base.html.j2` is
+/// HTML, `values.yaml.j2` and `deploy.sh.j2` are not, and injecting HTML into the
+/// latter makes the HTML grammar open elements on `<<EOF` and `2>&1`. The inner
+/// extension is the only signal available.
+fn jinja_language_for_path(p: &std::path::Path) -> DiffSyntaxLanguage {
+    let inner_extension = p
+        .file_stem()
+        .map(std::path::Path::new)
+        .and_then(|stem| stem.extension())
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    let inner_extension = ascii_lowercase_for_match(inner_extension);
+    if jinja_body_is_markup(inner_extension.as_ref()) {
+        DiffSyntaxLanguage::Jinja
+    } else {
+        DiffSyntaxLanguage::JinjaText
+    }
+}
+
 pub(in crate::view) fn diff_syntax_language_for_path(
     path: impl AsRef<std::path::Path>,
 ) -> Option<DiffSyntaxLanguage> {
@@ -81,10 +108,14 @@ pub(in crate::view) fn diff_syntax_language_for_path(
         return Some(DiffSyntaxLanguage::Cpp);
     }
     let ext = ascii_lowercase_for_match(ext);
-    diff_syntax_language_for_identifier(ext.as_ref()).or_else(|| {
+    let resolved = diff_syntax_language_for_identifier(ext.as_ref()).or_else(|| {
         let file_name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
         let file_name = ascii_lowercase_for_match(file_name);
         diff_syntax_language_for_identifier(file_name.as_ref())
+    })?;
+    Some(match resolved {
+        DiffSyntaxLanguage::Jinja => jinja_language_for_path(p),
+        other => other,
     })
 }
 
@@ -214,6 +245,10 @@ pub(super) fn tree_sitter_grammar(
         DiffSyntaxLanguage::Jinja => Some((
             tree_sitter_jinja_dialects::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(JINJA_HIGHLIGHTS_QUERY, JINJA_INJECTIONS_QUERY),
+        )),
+        DiffSyntaxLanguage::JinjaText => Some((
+            tree_sitter_jinja_dialects::LANGUAGE.into(),
+            TreesitterQueryAsset::highlights(JINJA_HIGHLIGHTS_QUERY),
         )),
         DiffSyntaxLanguage::Vue => Some((
             tree_sitter_vue::LANGUAGE.into(),
@@ -546,6 +581,7 @@ pub(super) fn tree_sitter_highlight_spec(
         DiffSyntaxLanguage::Html => highlight_spec_entry!(Html),
         DiffSyntaxLanguage::Vue => highlight_spec_entry!(Vue),
         DiffSyntaxLanguage::Jinja => highlight_spec_entry!(Jinja),
+        DiffSyntaxLanguage::JinjaText => highlight_spec_entry!(JinjaText),
         DiffSyntaxLanguage::Css => highlight_spec_entry!(Css),
         DiffSyntaxLanguage::Bicep => highlight_spec_entry!(Bicep),
         DiffSyntaxLanguage::Lua => highlight_spec_entry!(Lua),

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/language.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/language.rs
@@ -8,6 +8,10 @@ fn diff_syntax_language_for_identifier(identifier: &str) -> Option<DiffSyntaxLan
         "markdown-inline" | "markdown_inline" => DiffSyntaxLanguage::MarkdownInline,
         "html" | "htm" => DiffSyntaxLanguage::Html,
         "vue" => DiffSyntaxLanguage::Vue,
+        // The first six are the grammar's own declared file-types; `dj` is the
+        // Django addition. `diff_syntax_language_for_path` reads only the last
+        // extension, so `base.html.j2` and `page.html.dj` land here too.
+        "njk" | "nunjucks" | "j2" | "jinja" | "jinja2" | "twig" | "dj" => DiffSyntaxLanguage::Jinja,
         "xml" | "svg" | "xsl" | "xslt" | "xsd" | "xhtml" | "plist" | "csproj" | "fsproj"
         | "vbproj" | "sln" | "props" | "targets" | "resx" | "xaml" | "wsdl" | "rss" | "atom"
         | "opml" | "glade" | "ui" | "iml" => DiffSyntaxLanguage::Xml,
@@ -208,6 +212,11 @@ pub(super) fn tree_sitter_grammar(
         DiffSyntaxLanguage::Html => Some((
             tree_sitter_html::LANGUAGE.into(),
             TreesitterQueryAsset::with_injections(HTML_HIGHLIGHTS_QUERY, HTML_INJECTIONS_QUERY),
+        )),
+        #[cfg(any(test, feature = "syntax-web"))]
+        DiffSyntaxLanguage::Jinja => Some((
+            tree_sitter_jinja_dialects::LANGUAGE.into(),
+            TreesitterQueryAsset::with_injections(JINJA_HIGHLIGHTS_QUERY, JINJA_INJECTIONS_QUERY),
         )),
         #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Vue => Some((
@@ -445,11 +454,27 @@ fn init_highlight_spec(language: DiffSyntaxLanguage) -> TreesitterHighlightSpec 
     let injection_query = asset.injections.map(|source| {
         tree_sitter::Query::new(&ts_language, source).expect("injections.scm should compile")
     });
+    let injection_combined_patterns = injection_query
+        .as_ref()
+        .map(|injection_query| {
+            (0..injection_query.pattern_count())
+                .map(|pattern_ix| {
+                    injection_query
+                        .property_settings(pattern_ix)
+                        .iter()
+                        .any(|setting| setting.key.as_ref() == "injection.combined")
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let has_combined_injections = injection_combined_patterns.iter().any(|combined| *combined);
     TreesitterHighlightSpec {
         ts_language,
         query,
         capture_kinds,
         injection_query,
+        injection_combined_patterns,
+        has_combined_injections,
     }
 }
 
@@ -561,6 +586,8 @@ pub(super) fn tree_sitter_highlight_spec(
         DiffSyntaxLanguage::Html => highlight_spec_entry!(Html),
         #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Vue => highlight_spec_entry!(Vue),
+        #[cfg(any(test, feature = "syntax-web"))]
+        DiffSyntaxLanguage::Jinja => highlight_spec_entry!(Jinja),
         #[cfg(any(test, feature = "syntax-web"))]
         DiffSyntaxLanguage::Css => highlight_spec_entry!(Css),
         #[cfg(any(test, feature = "syntax-extra"))]

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/live.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/live.rs
@@ -244,6 +244,14 @@ struct LayerCapture {
 }
 
 /// Captures from one layer's tree that intersect `pass`, tagged with `depth`.
+/// `clip` is the layer's included ranges. With a single range (or none, for the
+/// root) a capture cannot escape the region, so the fast path pushes it whole.
+/// A *combined* layer is parsed over disjoint ranges and tree-sitter reports
+/// document offsets, so a node straddling two of them spans the host bytes in
+/// between — see `combined_injection_gaps` in `prepared.rs` for the same problem
+/// on the batch path. Those captures are split into their intersections with
+/// `clip`, all pieces keeping one `seq` so the query's own precedence survives
+/// the stable sort in `highlights_for_byte_range`.
 fn collect_layer_captures(
     spec: &TreesitterHighlightSpec,
     tree: &tree_sitter::Tree,
@@ -251,6 +259,7 @@ fn collect_layer_captures(
     pass: Range<usize>,
     text_len: usize,
     depth: u8,
+    clip: &[Range<usize>],
     out: &mut Vec<LayerCapture>,
 ) {
     catch_treesitter_query_panic(|| {
@@ -277,12 +286,37 @@ fn collect_layer_captures(
                 {
                     let range = clamp_to_len(capture.node.byte_range(), text_len);
                     if !range.is_empty() {
-                        out.push(LayerCapture {
-                            range,
-                            kind,
-                            depth,
-                            seq,
-                        });
+                        if clip.len() <= 1 {
+                            out.push(LayerCapture {
+                                range,
+                                kind,
+                                depth,
+                                seq,
+                            });
+                        } else {
+                            // `clip` is sorted and disjoint, so skip straight to
+                            // the first range that can intersect and stop at the
+                            // first that cannot. Scanning from the front instead
+                            // would be O(captures x ranges) on a template with
+                            // hundreds of text runs.
+                            let first =
+                                clip.partition_point(|clip_range| clip_range.end <= range.start);
+                            for clip_range in &clip[first..] {
+                                if clip_range.start >= range.end {
+                                    break;
+                                }
+                                let start = range.start.max(clip_range.start);
+                                let end = range.end.min(clip_range.end);
+                                if start < end {
+                                    out.push(LayerCapture {
+                                        range: start..end,
+                                        kind,
+                                        depth,
+                                        seq,
+                                    });
+                                }
+                            }
+                        }
                     }
                 }
                 seq = seq.saturating_add(1);
@@ -298,10 +332,16 @@ fn collect_layer_captures(
 /// The tree is parsed with `included_ranges` set to the injected span, so its
 /// node offsets are already *document* coordinates and merging its captures with
 /// the root's needs no remapping.
+///
+/// A `(#set! injection.combined)` pattern produces *one* layer covering every
+/// match of it, so `ranges` can hold more than one span. `range` is their hull,
+/// which is all the coarse overlap tests need; anything that has to know whether
+/// a specific byte belongs to the layer must consult `ranges`.
 pub(in crate::view) struct LiveSyntaxLayer {
     spec: &'static TreesitterHighlightSpec,
     tree: tree_sitter::Tree,
     range: Range<usize>,
+    ranges: Vec<Range<usize>>,
 }
 
 /// Depth-1 only. An injection inside an injection is not pursued: it is rare,
@@ -337,9 +377,15 @@ fn parse_injection_layers(
         .capture_index_for_name("injection.language")
         .or_else(|| query.capture_index_for_name("language"));
 
+    // The gate that keeps this a no-op for grammars with no combined pattern.
+    let has_combined = spec.has_combined_injections;
+
     // Collect first, parse second: the query cursor is a thread-local, so
     // parsing a layer while still holding it would re-enter the borrow.
     let mut found: Vec<(DiffSyntaxLanguage, Range<usize>)> = Vec::new();
+    let mut combined_ranges: HashMap<(DiffSyntaxLanguage, usize), Vec<Range<usize>>> =
+        HashMap::default();
+    let mut truncated = false;
     catch_treesitter_query_panic(|| {
         TS_CURSOR.with(|cursor| {
             let mut cursor = cursor.borrow_mut();
@@ -350,16 +396,33 @@ fn parse_injection_layers(
             tree_sitter::StreamingIterator::advance(&mut matches);
             while let Some(m) = matches.get() {
                 if let Some(language) = injection_language_for_match(rope, query, m, language_ix) {
+                    let pattern_ix = m.pattern_index;
+                    let is_combined = has_combined
+                        && spec
+                            .injection_combined_patterns
+                            .get(pattern_ix)
+                            .copied()
+                            .unwrap_or(false);
                     for capture in m.captures.iter().filter(|c| c.index == content_ix) {
                         if let Some(range) =
                             normalized_injection_content_byte_range(capture.node, rope.len())
                             && !range.is_empty()
                         {
-                            found.push((language, range));
+                            if is_combined {
+                                combined_ranges
+                                    .entry((language, pattern_ix))
+                                    .or_default()
+                                    .push(range);
+                            } else {
+                                found.push((language, range));
+                            }
                         }
                     }
                 }
                 tree_sitter::StreamingIterator::advance(&mut matches);
+            }
+            if has_combined {
+                truncated = cursor.did_exceed_match_limit();
             }
         });
     });
@@ -385,13 +448,60 @@ fn parse_injection_layers(
         // A layer that fails to parse is dropped: only its own span loses
         // highlighting, the document around it is untouched. `dropped` carries
         // that up so it can be repaired off-thread.
-        match parse_included_range(layer_spec, rope, mask, &range, deadline) {
+        match parse_included_range(
+            layer_spec,
+            rope,
+            mask,
+            std::slice::from_ref(&range),
+            deadline,
+        ) {
             Some(tree) => layers.push(LiveSyntaxLayer {
                 spec: layer_spec,
                 tree,
-                range,
+                range: range.clone(),
+                ranges: vec![range],
             }),
             None => dropped = true,
+        }
+    }
+
+    // One layer per combined pattern, covering every match of it. A truncated
+    // query means tree-sitter silently discarded matches; dropping a range out of
+    // a combined set changes the document the injected grammar sees, so the whole
+    // group is abandoned to the host grammar rather than parsed half-complete.
+    if has_combined && !truncated {
+        let mut groups: Vec<(DiffSyntaxLanguage, usize, Vec<Range<usize>>)> = combined_ranges
+            .into_iter()
+            .filter_map(|((language, pattern_ix), ranges)| {
+                let ranges = merge_sorted_injection_ranges(ranges);
+                (!ranges.is_empty()).then_some((language, pattern_ix, ranges))
+            })
+            .collect();
+        groups.sort_unstable_by_key(|(language, pattern_ix, _)| (*language, *pattern_ix));
+        for (language, _, ranges) in groups {
+            let Some(layer_spec) = tree_sitter_highlight_spec(language) else {
+                continue;
+            };
+            if ranges.len() > TS_COMBINED_INJECTION_MAX_RANGES {
+                continue;
+            }
+            let total_bytes: usize = ranges
+                .iter()
+                .map(|range| range.end.saturating_sub(range.start))
+                .sum();
+            if total_bytes > TS_COMBINED_INJECTION_MAX_BYTES {
+                continue;
+            }
+            let hull = ranges[0].start..ranges[ranges.len() - 1].end;
+            match parse_included_range(layer_spec, rope, mask, &ranges, deadline) {
+                Some(tree) => layers.push(LiveSyntaxLayer {
+                    spec: layer_spec,
+                    tree,
+                    range: hull,
+                    ranges,
+                }),
+                None => dropped = true,
+            }
         }
     }
     (layers, dropped)
@@ -438,29 +548,39 @@ fn injection_language_for_match(
         })
 }
 
-/// Parse `range` with `spec`'s grammar, leaving node offsets in document
+/// Parse `ranges` with `spec`'s grammar, leaving node offsets in document
 /// coordinates.
 ///
 /// `set_included_ranges` is what buys that: the parser still reads the whole
-/// (masked) document, but only builds nodes inside the range. The ranges are
+/// (masked) document, but only builds nodes inside the ranges. The ranges are
 /// cleared again before returning — the parser is pooled and its included
 /// ranges are sticky, so leaving them set would silently truncate the next
 /// root parse.
+///
+/// `ranges` must be sorted, non-overlapping and **non-empty**: an empty slice is
+/// tree-sitter's reset to "the whole document", which would silently promote the
+/// injected grammar to the entire file.
 fn parse_included_range(
     spec: &TreesitterHighlightSpec,
     rope: &Rope,
     mask: &[Range<usize>],
-    range: &Range<usize>,
+    ranges: &[Range<usize>],
     deadline: Option<Instant>,
 ) -> Option<tree_sitter::Tree> {
+    if ranges.is_empty() {
+        return None;
+    }
     with_ts_parser_parse_result(&spec.ts_language, |parser| {
-        let included = tree_sitter::Range {
-            start_byte: range.start,
-            end_byte: range.end,
-            start_point: rope_ts_point(rope, range.start),
-            end_point: rope_ts_point(rope, range.end),
-        };
-        if parser.set_included_ranges(&[included]).is_err() {
+        let included = ranges
+            .iter()
+            .map(|range| tree_sitter::Range {
+                start_byte: range.start,
+                end_byte: range.end,
+                start_point: rope_ts_point(rope, range.start),
+                end_point: rope_ts_point(rope, range.end),
+            })
+            .collect::<Vec<_>>();
+        if parser.set_included_ranges(&included).is_err() {
             let _ = parser.set_included_ranges(&[]);
             return None;
         }
@@ -736,6 +856,7 @@ impl LiveSyntaxDocument {
                     spec: layer.spec,
                     tree: layer.tree.clone(),
                     range: layer.range.clone(),
+                    ranges: layer.ranges.clone(),
                 })
                 .collect(),
             palette: syntax_highlight_palette(theme),
@@ -837,6 +958,7 @@ impl LiveSyntaxSnapshot {
                 pass.clone(),
                 text_len,
                 0,
+                &[],
                 &mut hits,
             );
             for layer in &inner.injections {
@@ -848,6 +970,7 @@ impl LiveSyntaxSnapshot {
                         pass.clone(),
                         text_len,
                         1,
+                        &layer.ranges,
                         &mut hits,
                     );
                 }
@@ -905,8 +1028,21 @@ impl LiveSyntaxSnapshot {
         // inner grammar's. Layer trees are parsed with `included_ranges`, so
         // their node offsets are already document coordinates.
         for layer in &inner.injections {
-            if layer.range.start <= offset
-                && offset <= layer.range.end
+            // Membership, not the hull: a caret sitting in a `{% … %}` gap between
+            // two ranges of a combined layer is host-grammar territory, and the
+            // combined tree has no nodes there to answer with.
+            if layer
+                .ranges
+                .binary_search_by(|range| {
+                    if offset < range.start {
+                        std::cmp::Ordering::Greater
+                    } else if offset > range.end {
+                        std::cmp::Ordering::Less
+                    } else {
+                        std::cmp::Ordering::Equal
+                    }
+                })
+                .is_ok()
                 && let Some(pair) = bracket_pair_in_tree(&layer.tree, offset)
             {
                 return Some(pair);
@@ -1931,6 +2067,126 @@ mod injection_tests {
             .filter(|(range, _)| range.start < span.end && range.end > span.start)
             .map(|(_, style)| style)
             .collect()
+    }
+
+    fn fsharp_document(text: &str) -> LiveSyntaxDocument {
+        LiveSyntaxDocument::new(
+            DiffSyntaxLanguage::FSharp,
+            Rope::from_str(text),
+            Vec::new().into(),
+            None,
+        )
+        .expect("fsharp live document should build")
+    }
+
+    /// F# XML doc comments are the tree's only `(#set! injection.combined)` rule.
+    /// `xml_doc` is a per-line token, so without combined support a three-line
+    /// doc comment produced three layers instead of one.
+    #[test]
+    fn combined_injection_produces_one_layer_covering_every_range() {
+        let text = "/// <summary>\n/// Adds.\n/// </summary>\nlet add x y = x + y\n";
+        let document = fsharp_document(text);
+
+        assert_eq!(
+            document.injections.len(),
+            1,
+            "three xml_doc lines belong to one combined layer, got {} layers",
+            document.injections.len()
+        );
+        let layer = &document.injections[0];
+        assert_eq!(
+            layer.ranges.len(),
+            3,
+            "the combined layer should carry one range per xml_doc line: {:?}",
+            layer.ranges
+        );
+        assert_eq!(
+            layer.range,
+            layer.ranges[0].start..layer.ranges[2].end,
+            "`range` is the hull of `ranges`"
+        );
+        assert!(
+            layer.range.end <= text.find("let add").expect("let binding"),
+            "the layer must not reach the F# code below it: {:?}",
+            layer.range
+        );
+    }
+
+    /// A node straddling two included ranges reports a byte range covering the
+    /// host bytes between them, so its captures have to be split. Here the XML
+    /// element spans all three `///` lines, and the `/// ` prefixes are F#.
+    #[test]
+    fn combined_layer_captures_are_clipped_to_its_ranges() {
+        let text = "/// <summary>\n/// Adds.\n/// </summary>\nlet add x y = x + y\n";
+        let document = fsharp_document(text);
+        let layer = &document.injections[0];
+        let ranges = layer.ranges.clone();
+
+        let snapshot = document.snapshot(AppTheme::gitcomet_dark());
+        let highlights = snapshot.highlights_for_byte_range(0..text.len());
+
+        let gap_start = ranges[0].end;
+        let gap_end = ranges[1].start;
+        assert!(
+            gap_start < gap_end,
+            "fixture should have a real gap between the first two ranges"
+        );
+        for (range, _) in &highlights {
+            assert!(
+                range.start >= gap_end || range.end <= gap_start,
+                "highlight {range:?} crosses into the host-grammar gap \
+                 {gap_start}..{gap_end} between two combined ranges"
+            );
+        }
+    }
+
+    /// A caret in a gap belongs to the host grammar; the combined tree has no
+    /// nodes there and must not be consulted for it.
+    #[test]
+    fn bracket_pair_at_ignores_a_combined_layer_gap() {
+        let text = "/// <summary>\n/// Adds.\n/// </summary>\nlet add x y = x + y\n";
+        let document = fsharp_document(text);
+        let ranges = document.injections[0].ranges.clone();
+        let gap = ranges[0].end..ranges[1].start;
+        let snapshot = document.snapshot(AppTheme::gitcomet_dark());
+
+        // Only asserts it does not answer *from the combined layer*; the host
+        // grammar may legitimately have no pair here either.
+        if let Some((open, close)) = snapshot.bracket_pair_at(gap.start) {
+            let in_layer = |offset: usize| {
+                ranges
+                    .iter()
+                    .any(|range| range.start <= offset && offset <= range.end)
+            };
+            assert!(
+                !(in_layer(open.start) && in_layer(close.start)),
+                "a caret in the host-grammar gap {gap:?} was answered by the combined \
+                 XML layer: {open:?}/{close:?}"
+            );
+        }
+    }
+
+    /// The clip path must be inert for ordinary single-range layers, which is
+    /// every injection in the tree except F#'s.
+    #[test]
+    fn single_range_layers_are_unaffected_by_the_clip_parameter() {
+        let text = "<html>\n<script>\nconst answer = 42;\n</script>\n</html>\n";
+        let document = html_document(text);
+        let layer = &document.injections[0];
+        assert_eq!(
+            layer.ranges.len(),
+            1,
+            "an ordinary injection is one range, so collect_layer_captures takes \
+             the unsplit fast path"
+        );
+        assert_eq!(layer.ranges[0], layer.range);
+
+        let snapshot = document.snapshot(AppTheme::gitcomet_dark());
+        let highlights = snapshot.highlights_for_byte_range(0..text.len());
+        assert!(
+            !styles_for(&highlights, text, "const").is_empty(),
+            "clipping must not have eaten the injected JavaScript keyword"
+        );
     }
 
     #[test]

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/live.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/live.rs
@@ -334,14 +334,26 @@ fn collect_layer_captures(
 /// the root's needs no remapping.
 ///
 /// A `(#set! injection.combined)` pattern produces *one* layer covering every
-/// match of it, so `ranges` can hold more than one span. `range` is their hull,
-/// which is all the coarse overlap tests need; anything that has to know whether
-/// a specific byte belongs to the layer must consult `ranges`.
+/// match of it, so `ranges` can hold more than one span. [`Self::hull`] spans
+/// them all, which is what the coarse overlap tests want; anything that has to
+/// know whether a specific byte belongs to the layer must consult `ranges`.
 pub(in crate::view) struct LiveSyntaxLayer {
     spec: &'static TreesitterHighlightSpec,
     tree: tree_sitter::Tree,
-    range: Range<usize>,
     ranges: Vec<Range<usize>>,
+}
+
+impl LiveSyntaxLayer {
+    /// The span covering every range in the layer.
+    ///
+    /// Derived rather than stored: as a field it had to be kept in step by hand at
+    /// three construction sites, and a hull that stopped covering its members would
+    /// show up only as a layer silently skipped by the overlap gate below.
+    fn hull(&self) -> Range<usize> {
+        let start = self.ranges.first().map(|range| range.start).unwrap_or(0);
+        let end = self.ranges.last().map(|range| range.end).unwrap_or(0);
+        start..end.max(start)
+    }
 }
 
 /// Depth-1 only. An injection inside an injection is not pursued: it is rare,
@@ -397,12 +409,7 @@ fn parse_injection_layers(
             while let Some(m) = matches.get() {
                 if let Some(language) = injection_language_for_match(rope, query, m, language_ix) {
                     let pattern_ix = m.pattern_index;
-                    let is_combined = has_combined
-                        && spec
-                            .injection_combined_patterns
-                            .get(pattern_ix)
-                            .copied()
-                            .unwrap_or(false);
+                    let is_combined = spec.is_combined_injection_pattern(pattern_ix);
                     for capture in m.captures.iter().filter(|c| c.index == content_ix) {
                         if let Some(range) =
                             normalized_injection_content_byte_range(capture.node, rope.len())
@@ -458,7 +465,6 @@ fn parse_injection_layers(
             Some(tree) => layers.push(LiveSyntaxLayer {
                 spec: layer_spec,
                 tree,
-                range: range.clone(),
                 ranges: vec![range],
             }),
             None => dropped = true,
@@ -470,34 +476,22 @@ fn parse_injection_layers(
     // a combined set changes the document the injected grammar sees, so the whole
     // group is abandoned to the host grammar rather than parsed half-complete.
     if has_combined && !truncated {
-        let mut groups: Vec<(DiffSyntaxLanguage, usize, Vec<Range<usize>>)> = combined_ranges
-            .into_iter()
-            .filter_map(|((language, pattern_ix), ranges)| {
-                let ranges = merge_sorted_injection_ranges(ranges);
-                (!ranges.is_empty()).then_some((language, pattern_ix, ranges))
-            })
-            .collect();
-        groups.sort_unstable_by_key(|(language, pattern_ix, _)| (*language, *pattern_ix));
+        let groups = combined_injection_groups_in_apply_order(combined_ranges);
+        // No TS_COMBINED_INJECTION_MAX_* ceiling here, deliberately, and do not add
+        // one. Those are the prepared path's stand-in for a budget and are measured
+        // against a 64-row window; this path is not windowed -- `set_byte_range`
+        // above is the whole rope -- so here they capped on document size, costing a
+        // 600-line `.njk` all of its HTML while the diff pane still highlighted it.
+        // `deadline` already bounds this parse, and a layer it drops sets `dropped`
+        // so the off-thread reparse restores it.
         for (language, _, ranges) in groups {
             let Some(layer_spec) = tree_sitter_highlight_spec(language) else {
                 continue;
             };
-            if ranges.len() > TS_COMBINED_INJECTION_MAX_RANGES {
-                continue;
-            }
-            let total_bytes: usize = ranges
-                .iter()
-                .map(|range| range.end.saturating_sub(range.start))
-                .sum();
-            if total_bytes > TS_COMBINED_INJECTION_MAX_BYTES {
-                continue;
-            }
-            let hull = ranges[0].start..ranges[ranges.len() - 1].end;
             match parse_included_range(layer_spec, rope, mask, &ranges, deadline) {
                 Some(tree) => layers.push(LiveSyntaxLayer {
                     spec: layer_spec,
                     tree,
-                    range: hull,
                     ranges,
                 }),
                 None => dropped = true,
@@ -580,13 +574,13 @@ fn parse_included_range(
                 end_point: rope_ts_point(rope, range.end),
             })
             .collect::<Vec<_>>();
-        if parser.set_included_ranges(&included).is_err() {
-            let _ = parser.set_included_ranges(&[]);
-            return None;
-        }
+        // RAII rather than a clear per exit path: a panic in the progress callback or
+        // in `masked_read` would otherwise leave the pooled parser's sticky ranges
+        // set, truncating every later root parse on this thread.
+        let mut guard = IncludedRangesGuard::set(parser, &included)?;
         let mut read = masked_read(rope, mask);
-        let parsed = match deadline {
-            None => parser.parse_with_options(&mut read, None, None),
+        match deadline {
+            None => guard.parser().parse_with_options(&mut read, None, None),
             Some(deadline) => {
                 let mut progress = |_state: &tree_sitter::ParseState| {
                     if Instant::now() >= deadline {
@@ -596,11 +590,11 @@ fn parse_included_range(
                     }
                 };
                 let options = tree_sitter::ParseOptions::new().progress_callback(&mut progress);
-                parser.parse_with_options(&mut read, None, Some(options))
+                guard
+                    .parser()
+                    .parse_with_options(&mut read, None, Some(options))
             }
-        };
-        let _ = parser.set_included_ranges(&[]);
-        parsed
+        }
     })
 }
 
@@ -855,7 +849,6 @@ impl LiveSyntaxDocument {
                 .map(|layer| LiveSyntaxLayer {
                     spec: layer.spec,
                     tree: layer.tree.clone(),
-                    range: layer.range.clone(),
                     ranges: layer.ranges.clone(),
                 })
                 .collect(),
@@ -962,7 +955,8 @@ impl LiveSyntaxSnapshot {
                 &mut hits,
             );
             for layer in &inner.injections {
-                if layer.range.start < pass.end && layer.range.end > pass.start {
+                let hull = layer.hull();
+                if hull.start < pass.end && hull.end > pass.start {
                     collect_layer_captures(
                         layer.spec,
                         &layer.tree,
@@ -2101,14 +2095,14 @@ mod injection_tests {
             layer.ranges
         );
         assert_eq!(
-            layer.range,
+            layer.hull(),
             layer.ranges[0].start..layer.ranges[2].end,
             "`range` is the hull of `ranges`"
         );
         assert!(
-            layer.range.end <= text.find("let add").expect("let binding"),
+            layer.hull().end <= text.find("let add").expect("let binding"),
             "the layer must not reach the F# code below it: {:?}",
-            layer.range
+            layer.hull()
         );
     }
 
@@ -2179,7 +2173,7 @@ mod injection_tests {
             "an ordinary injection is one range, so collect_layer_captures takes \
              the unsplit fast path"
         );
-        assert_eq!(layer.ranges[0], layer.range);
+        assert_eq!(layer.ranges[0], layer.hull());
 
         let snapshot = document.snapshot(AppTheme::gitcomet_dark());
         let highlights = snapshot.highlights_for_byte_range(0..text.len());
@@ -2229,16 +2223,16 @@ mod injection_tests {
 
         let body_start = text.find("\nconst").expect("script body") + 1;
         assert!(
-            layer.range.start <= body_start && layer.range.end >= body_start + "const".len(),
+            layer.hull().start <= body_start && layer.hull().end >= body_start + "const".len(),
             "layer {:?} should cover the script body at {body_start}",
-            layer.range
+            layer.hull()
         );
         assert!(
-            layer.range.start > text.find("<script>").expect("open tag"),
+            layer.hull().start > text.find("<script>").expect("open tag"),
             "the layer must not swallow the opening tag"
         );
         assert!(
-            layer.range.end <= text.find("</script>").expect("close tag"),
+            layer.hull().end <= text.find("</script>").expect("close tag"),
             "the layer must not swallow the closing tag"
         );
     }
@@ -2263,6 +2257,178 @@ mod injection_tests {
         assert!(
             !covering.is_empty(),
             "the injected keyword should be highlighted at its real offset {keyword_at}"
+        );
+    }
+
+    fn jinja_document(text: &str) -> LiveSyntaxDocument {
+        LiveSyntaxDocument::new(
+            DiffSyntaxLanguage::Jinja,
+            Rope::from_str(text),
+            Vec::new().into(),
+            None,
+        )
+        .expect("jinja live document should build")
+    }
+
+    fn dense_jinja_table(rows: usize, cells: usize) -> String {
+        let mut lines = vec!["{% block body %}".to_string()];
+        for row in 0..rows {
+            let mut line = String::from("<tr>");
+            for cell in 0..cells {
+                line.push_str(&format!("<td>{{{{ r{row}.c{cell} }}}}</td>"));
+            }
+            line.push_str("</tr>");
+            lines.push(line);
+        }
+        lines.push("{% endblock %}".to_string());
+        lines.join("\n")
+    }
+
+    /// This path is not windowed, so the prepared path's ceilings must not reach it:
+    /// applied here they capped on document size, and a 600-line `.njk` lost all of
+    /// its HTML in the editor while the diff pane still highlighted it.
+    #[test]
+    fn combined_layer_survives_a_template_past_the_prepared_range_ceiling() {
+        let text = dense_jinja_table(600, 4);
+        let document = jinja_document(&text);
+
+        // Pinned as a literal, not read from the prepared path's constant: the point
+        // is that a document of this density used to be dropped.
+        const CEILING_THAT_USED_TO_APPLY: usize = 512;
+        let layer = document
+            .injections
+            .iter()
+            .find(|layer| layer.ranges.len() > CEILING_THAT_USED_TO_APPLY)
+            .unwrap_or_else(|| {
+                panic!(
+                    "fixture must produce more than {CEILING_THAT_USED_TO_APPLY} combined \
+                     ranges to be a regression test; layers: {:?}",
+                    document
+                        .injections
+                        .iter()
+                        .map(|layer| layer.ranges.len())
+                        .collect::<Vec<_>>()
+                )
+            });
+        assert!(
+            layer.hull().end > 0,
+            "the combined html layer must actually cover the template"
+        );
+
+        let snapshot = document.snapshot(AppTheme::gitcomet_dark());
+        let probe = text.find("<td>").expect("a table cell");
+        let highlights = snapshot.highlights_for_byte_range(probe..probe + "<td>".len());
+        assert!(
+            !highlights.is_empty(),
+            "the editor dropped HTML highlighting that the diff pane keeps"
+        );
+    }
+
+    /// Same defect on the byte ceiling: `live_syntax_document_supported` admits
+    /// documents up to 8MB, so a 200KB template is valid but used to lose all its
+    /// HTML to the 128KB ceiling.
+    #[test]
+    fn combined_layer_survives_a_template_past_the_prepared_byte_ceiling() {
+        let mut lines = vec!["{% block body %}".to_string()];
+        for ix in 0..3_000 {
+            lines.push(format!(
+                "  <span class=\"cell\" data-row=\"{ix}\">value {ix} padded out</span>"
+            ));
+        }
+        lines.push("{% endblock %}".to_string());
+        let text = lines.join("\n");
+        assert!(
+            text.len() > TS_COMBINED_INJECTION_MAX_BYTES,
+            "fixture must exceed the byte ceiling ({} bytes)",
+            text.len()
+        );
+        assert!(
+            live_syntax_document_supported(DiffSyntaxLanguage::Jinja, text.len()),
+            "and must still be a document the live path accepts"
+        );
+
+        let document = jinja_document(&text);
+        assert!(
+            document
+                .injections
+                .iter()
+                .any(|layer| layer.ranges.len() > 1
+                    || layer.hull().end - layer.hull().start > TS_COMBINED_INJECTION_MAX_BYTES),
+            "the combined html layer must cover a span past the prepared byte ceiling"
+        );
+
+        let snapshot = document.snapshot(AppTheme::gitcomet_dark());
+        let probe = text.rfind("<span").expect("a span near the end");
+        let highlights = snapshot.highlights_for_byte_range(probe..probe + "<span".len());
+        assert!(
+            !highlights.is_empty(),
+            "a {}-byte template lost its HTML highlighting in the editor",
+            text.len()
+        );
+    }
+
+    /// A root parse must not inherit an injected layer's clipping. `TS_PARSER` is
+    /// pooled and its included ranges are sticky, so ranges left set would silently
+    /// truncate the next root parse on this thread, for any language.
+    #[test]
+    fn an_included_range_parse_leaves_the_pooled_parser_unclipped() {
+        let html = tree_sitter_highlight_spec(DiffSyntaxLanguage::Html).expect("html spec");
+        let rope = Rope::from_str("<div class=\"a\">text</div>\n");
+        let head: Range<usize> = 0..5;
+        let _ = parse_included_range(html, &rope, &[], std::slice::from_ref(&head), None);
+
+        let text = "fn main() { let value = 1; }\n";
+        let document = LiveSyntaxDocument::new(
+            DiffSyntaxLanguage::Rust,
+            Rope::from_str(text),
+            Vec::new().into(),
+            None,
+        )
+        .expect("rust live document should build");
+        assert_eq!(
+            document.tree.root_node().end_byte(),
+            text.len(),
+            "the next root parse was truncated to the previous layer's ranges"
+        );
+    }
+
+    /// The half of that contract a successful parse cannot exercise. Neither the
+    /// parser nor `masked_read` has a panic a test can inject, so the unwind path is
+    /// pinned on the guard directly; what binds it to `parse_included_range` is that
+    /// there is no other way for that function to set ranges.
+    #[test]
+    fn the_included_ranges_guard_clears_them_on_unwind() {
+        let html = tree_sitter_highlight_spec(DiffSyntaxLanguage::Html).expect("html spec");
+        let rope = Rope::from_str("<div class=\"a\">text</div>\n");
+
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_ts_parser_parse_result(&html.ts_language, |parser| {
+                let included = [tree_sitter::Range {
+                    start_byte: 0,
+                    end_byte: 5,
+                    start_point: rope_ts_point(&rope, 0),
+                    end_point: rope_ts_point(&rope, 5),
+                }];
+                let _guard = IncludedRangesGuard::set(parser, &included)?;
+                panic!("simulated parse panic");
+                #[allow(unreachable_code)]
+                None::<tree_sitter::Tree>
+            })
+        }));
+        assert!(unwound.is_err(), "the probe must actually unwind");
+
+        let text = "fn main() { let value = 1; }\n";
+        let document = LiveSyntaxDocument::new(
+            DiffSyntaxLanguage::Rust,
+            Rope::from_str(text),
+            Vec::new().into(),
+            None,
+        )
+        .expect("rust live document should build");
+        assert_eq!(
+            document.tree.root_node().end_byte(),
+            text.len(),
+            "an unwinding parse left its included ranges set on the pooled parser"
         );
     }
 
@@ -2357,9 +2523,9 @@ mod injection_tests {
             .expect("expected the layer to survive the edit");
         let body_start = after.find("\nconst").expect("script body") + 1;
         assert!(
-            layer.range.start <= body_start && layer.range.end >= body_start,
+            layer.hull().start <= body_start && layer.hull().end >= body_start,
             "layer {:?} should have moved with the edit to cover {body_start}",
-            layer.range
+            layer.hull()
         );
 
         let snapshot = document.snapshot(AppTheme::gitcomet_dark());

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/prepared.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/prepared.rs
@@ -2547,6 +2547,18 @@ pub(super) struct TreesitterHighlightSpec {
     pub(super) query: tree_sitter::Query,
     pub(super) capture_kinds: Vec<Option<SyntaxTokenKind>>,
     pub(super) injection_query: Option<tree_sitter::Query>,
+    /// One flag per injection-query pattern: `true` when the pattern carries
+    /// `(#set! injection.combined)`, meaning every match of it belongs to one
+    /// shared layer rather than getting a layer each.
+    ///
+    /// Computed once in `init_highlight_spec` so the hot match loop never has to
+    /// walk `property_settings`.
+    pub(super) injection_combined_patterns: Vec<bool>,
+    /// `injection_combined_patterns.iter().any(|&c| c)`, hoisted so the whole
+    /// combined path can be skipped with one branch. This is the gate that keeps
+    /// the feature a no-op for every grammar that does not declare it -- today
+    /// that is all of them except F#, whose `xml_doc` rule is combined upstream.
+    pub(super) has_combined_injections: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2852,7 +2864,11 @@ fn configure_query_cursor(
 
 /// Byte offset where the region for line `line_ix` ends (start of next line, or `input_len`).
 /// Replaces the old `line_query_end_byte(line_starts[i], line_lengths[i], input_len)`.
-fn line_region_end_byte(line_starts: &[usize], input_len: usize, line_ix: usize) -> usize {
+pub(super) fn line_region_end_byte(
+    line_starts: &[usize],
+    input_len: usize,
+    line_ix: usize,
+) -> usize {
     line_starts
         .get(line_ix + 1)
         .copied()
@@ -3060,7 +3076,12 @@ fn apply_injection_query_tokens_for_document(
         context.start_line_ix,
         context.end_line_ix,
     );
-    for injection in injections {
+    if !injections.truncated {
+        for group in &injections.combined {
+            apply_combined_injection_tokens(group, input, context);
+        }
+    }
+    for injection in injections.singles {
         let Some(injected_tokens) = collect_injected_tokens_for_parent_line_window(
             input,
             context.line_starts,
@@ -3094,6 +3115,176 @@ fn apply_injection_query_tokens_for_document(
     }
 }
 
+/// Parses `ranges` as one document with `spec`'s grammar, leaving node offsets in
+/// *document* coordinates.
+///
+/// `set_included_ranges` is what buys that: the parser reads the whole input but
+/// only builds nodes inside the ranges, so no coordinate remapping is needed on
+/// the way out -- unlike the per-injection path, which slices the text and maps
+/// injection-local offsets back in `collect_injected_tokens_for_parent_line_window`.
+///
+/// The ranges are cleared again on every exit path. `TS_PARSER` is pooled, its
+/// included ranges are sticky, and `with_ts_parser`'s fast path can skip
+/// `set_language` entirely -- leaving them set would silently truncate the next
+/// root parse on this thread, for any language. `IncludedRangesGuard` makes that
+/// unconditional rather than relying on each `return` remembering.
+pub(super) fn parse_combined_injection_tree(
+    spec: &TreesitterHighlightSpec,
+    input: &[u8],
+    line_starts: &[usize],
+    ranges: &[Range<usize>],
+) -> Option<tree_sitter::Tree> {
+    // Never call `set_included_ranges` with an empty slice: that is tree-sitter's
+    // reset to "the whole document", so a window whose group collapsed to nothing
+    // would highlight the entire file with the injected grammar.
+    if ranges.is_empty() {
+        return None;
+    }
+    let ts_ranges = ranges
+        .iter()
+        .map(|range| tree_sitter::Range {
+            start_byte: range.start,
+            end_byte: range.end,
+            start_point: treesitter_point_for_byte(line_starts, input, range.start),
+            end_point: treesitter_point_for_byte(line_starts, input, range.end),
+        })
+        .collect::<Vec<_>>();
+
+    with_ts_parser_parse_result(&spec.ts_language, |parser| {
+        let mut guard = IncludedRangesGuard::set(parser, &ts_ranges)?;
+        parse_treesitter_tree(guard.parser(), input, None, None)
+    })
+}
+
+/// Clears a parser's included ranges on drop.
+struct IncludedRangesGuard<'parser>(&'parser mut tree_sitter::Parser);
+
+impl<'parser> IncludedRangesGuard<'parser> {
+    fn set(
+        parser: &'parser mut tree_sitter::Parser,
+        ranges: &[tree_sitter::Range],
+    ) -> Option<Self> {
+        if parser.set_included_ranges(ranges).is_err() {
+            let _ = parser.set_included_ranges(&[]);
+            return None;
+        }
+        Some(Self(parser))
+    }
+
+    fn parser(&mut self) -> &mut tree_sitter::Parser {
+        self.0
+    }
+}
+
+impl Drop for IncludedRangesGuard<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.set_included_ranges(&[]);
+    }
+}
+
+/// Parses one combined group and splices its tokens into `context.per_line`.
+fn apply_combined_injection_tokens(
+    group: &CombinedInjectionGroup,
+    input: &[u8],
+    context: &mut DocumentTokenCollectionContext<'_>,
+) {
+    if group.ranges.len() > TS_COMBINED_INJECTION_MAX_RANGES {
+        return;
+    }
+    let total_bytes: usize = group
+        .ranges
+        .iter()
+        .map(|range| range.end.saturating_sub(range.start))
+        .sum();
+    if total_bytes > TS_COMBINED_INJECTION_MAX_BYTES {
+        return;
+    }
+    let Some(spec) = tree_sitter_highlight_spec(group.language) else {
+        return;
+    };
+    let Some(tree) = parse_combined_injection_tree(spec, input, context.line_starts, &group.ranges)
+    else {
+        return;
+    };
+
+    let mut injected = collect_treesitter_document_line_tokens_for_line_window(
+        &tree,
+        spec,
+        input,
+        context.line_starts,
+        context.start_line_ix,
+        context.end_line_ix,
+    );
+    if injected.len() != context.per_line.len() {
+        return;
+    }
+
+    // Clip the injected tokens back to the ranges the injected grammar actually
+    // owns; see `combined_injection_gaps`.
+    let window_start = context
+        .line_starts
+        .get(context.start_line_ix)
+        .copied()
+        .unwrap_or(0);
+    let window_end = line_region_end_byte(
+        context.line_starts,
+        input.len(),
+        context.end_line_ix.saturating_sub(1),
+    );
+    for gap in combined_injection_gaps(window_start..window_end, &group.ranges) {
+        subtract_absolute_range_from_document_tokens(
+            context.line_starts,
+            input,
+            context.start_line_ix,
+            &mut injected,
+            gap,
+        );
+    }
+
+    // ... and drop the host grammar's tokens from the bytes the injection took over.
+    for range in &group.ranges {
+        subtract_absolute_range_from_document_tokens(
+            context.line_starts,
+            input,
+            context.start_line_ix,
+            context.per_line,
+            range.clone(),
+        );
+    }
+
+    for (line_tokens, tokens) in context.per_line.iter_mut().zip(injected) {
+        line_tokens.extend(tokens);
+    }
+}
+
+/// Every match of one `(#set! injection.combined)` pattern, gathered into the
+/// single layer the directive asks for.
+///
+/// `ranges` is sorted, non-overlapping and non-empty by the time this leaves
+/// [`collect_treesitter_injection_matches_for_line_window`] -- all three are hard
+/// requirements of `Parser::set_included_ranges`, and an *empty* slice is
+/// tree-sitter's "reset to the whole document" rather than "parse nothing".
+struct CombinedInjectionGroup {
+    language: DiffSyntaxLanguage,
+    ranges: Vec<Range<usize>>,
+}
+
+struct TreesitterInjectionMatches {
+    /// One layer per match, the pre-existing behaviour. Unchanged for every
+    /// grammar that does not declare `injection.combined`.
+    singles: Vec<TreesitterInjectionMatch>,
+    combined: Vec<CombinedInjectionGroup>,
+    /// The query cursor overflowed `TS_QUERY_MATCH_LIMIT` somewhere in this
+    /// window, so tree-sitter silently dropped matches.
+    ///
+    /// Only the combined groups act on this. Losing one *single* injection costs
+    /// that node its highlighting and nothing else, which is the status quo;
+    /// losing one range out of a combined set changes the document the injected
+    /// grammar sees, so an unbalanced `<div>` can wreck the whole window. Better
+    /// to leave the host grammar painting.
+    truncated: bool,
+}
+
 fn collect_treesitter_injection_matches_for_line_window(
     tree: &tree_sitter::Tree,
     highlight: &TreesitterHighlightSpec,
@@ -3101,14 +3292,19 @@ fn collect_treesitter_injection_matches_for_line_window(
     line_starts: &[usize],
     start_line_ix: usize,
     end_line_ix: usize,
-) -> Vec<TreesitterInjectionMatch> {
+) -> TreesitterInjectionMatches {
+    let empty = || TreesitterInjectionMatches {
+        singles: Vec::new(),
+        combined: Vec::new(),
+        truncated: false,
+    };
     let Some(injection_query) = highlight.injection_query.as_ref() else {
-        return Vec::new();
+        return empty();
     };
     let Some(injection_content_capture_ix) =
         injection_query.capture_index_for_name("injection.content")
     else {
-        return Vec::new();
+        return empty();
     };
     let injection_language_capture_ix =
         injection_query.capture_index_for_name("injection.language");
@@ -3121,11 +3317,19 @@ fn collect_treesitter_injection_matches_for_line_window(
         end_line_ix,
     );
     if query_passes.is_empty() {
-        return Vec::new();
+        return empty();
     }
+
+    // The one gate that keeps this a no-op for every grammar that does not declare
+    // `injection.combined`: no map allocated, no per-match pattern lookup, no
+    // `did_exceed_match_limit` read, and `combined` stays empty below.
+    let has_combined = highlight.has_combined_injections;
 
     let mut seen = HashSet::default();
     let mut injections = Vec::new();
+    let mut combined_ranges: HashMap<(DiffSyntaxLanguage, usize), Vec<Range<usize>>> =
+        HashMap::default();
+    let mut truncated = false;
     for pass in &query_passes {
         catch_treesitter_query_panic(|| {
             TS_CURSOR.with(|cursor| {
@@ -3144,6 +3348,13 @@ fn collect_treesitter_injection_matches_for_line_window(
                         tree_sitter::StreamingIterator::advance(&mut matches);
                         continue;
                     };
+                    let pattern_ix = m.pattern_index;
+                    let is_combined = has_combined
+                        && highlight
+                            .injection_combined_patterns
+                            .get(pattern_ix)
+                            .copied()
+                            .unwrap_or(false);
                     for capture in m
                         .captures
                         .iter()
@@ -3154,6 +3365,13 @@ fn collect_treesitter_injection_matches_for_line_window(
                         else {
                             continue;
                         };
+                        if is_combined {
+                            combined_ranges
+                                .entry((language, pattern_ix))
+                                .or_default()
+                                .push(byte_range);
+                            continue;
+                        }
                         let injection = TreesitterInjectionMatch {
                             language,
                             byte_start: byte_range.start,
@@ -3171,12 +3389,104 @@ fn collect_treesitter_injection_matches_for_line_window(
                     }
                     tree_sitter::StreamingIterator::advance(&mut matches);
                 }
+                // Read inside the same borrow: the cursor is a thread-local and
+                // the next pass reconfigures it.
+                if has_combined {
+                    truncated |= cursor.did_exceed_match_limit();
+                }
             });
         });
     }
 
     injections.sort_by_key(|injection| (injection.byte_start, injection.byte_end));
-    injections
+
+    if !has_combined {
+        return TreesitterInjectionMatches {
+            singles: injections,
+            combined: Vec::new(),
+            truncated: false,
+        };
+    }
+
+    let mut combined: Vec<(DiffSyntaxLanguage, usize, CombinedInjectionGroup)> = combined_ranges
+        .into_iter()
+        .filter_map(|((language, pattern_ix), ranges)| {
+            let ranges = merge_sorted_injection_ranges(ranges);
+            (!ranges.is_empty()).then_some((
+                language,
+                pattern_ix,
+                CombinedInjectionGroup { language, ranges },
+            ))
+        })
+        .collect();
+    // Applied in a stable order regardless of hash iteration order; on overlap the
+    // later layer wins, so the order has to be deterministic.
+    combined.sort_unstable_by_key(|(language, pattern_ix, _)| (*language, *pattern_ix));
+    let combined = combined
+        .into_iter()
+        .map(|(_, _, group)| group)
+        .collect::<Vec<_>>();
+
+    TreesitterInjectionMatches {
+        singles: injections,
+        combined,
+        truncated,
+    }
+}
+
+/// Sorts and coalesces injection ranges into the form `set_included_ranges`
+/// requires: ascending, non-overlapping, non-empty.
+///
+/// Touching ranges (`a.end == b.start`) are merged too. Leaving them adjacent
+/// would be accepted by tree-sitter but produces one more range than necessary,
+/// and the gap list in [`combined_injection_gaps`] would carry an empty entry.
+pub(super) fn merge_sorted_injection_ranges(mut ranges: Vec<Range<usize>>) -> Vec<Range<usize>> {
+    ranges.retain(|range| range.start < range.end);
+    ranges.sort_unstable_by_key(|range| (range.start, range.end));
+    let mut merged: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        match merged.last_mut() {
+            Some(last) if range.start <= last.end => {
+                last.end = last.end.max(range.end);
+            }
+            _ => merged.push(range),
+        }
+    }
+    merged
+}
+
+/// The complement of `ranges` inside `window`.
+///
+/// Combined injections need this because tree-sitter reports *document* offsets
+/// for a tree parsed with disjoint included ranges: a node whose first token is
+/// in one range and whose last token is in another spans every host byte in
+/// between. `((element) @tag)` over
+/// `{% if x %}<div>{% endif %}text</div>` would otherwise paint the `{% endif %}`
+/// with the injected grammar's colour. Subtracting these gaps from the injected
+/// tokens is what keeps each grammar inside its own bytes.
+///
+/// `ranges` must already be sorted and non-overlapping.
+pub(super) fn combined_injection_gaps(
+    window: Range<usize>,
+    ranges: &[Range<usize>],
+) -> Vec<Range<usize>> {
+    let mut gaps = Vec::with_capacity(ranges.len() + 1);
+    let mut cursor = window.start;
+    for range in ranges {
+        let start = range.start.max(window.start);
+        if start > cursor {
+            gaps.push(cursor..start.min(window.end));
+        }
+        cursor = cursor.max(range.end.min(window.end));
+        if cursor >= window.end {
+            break;
+        }
+    }
+    if cursor < window.end {
+        gaps.push(cursor..window.end);
+    }
+    gaps.retain(|gap| gap.start < gap.end);
+    gaps
 }
 
 fn bounded_node_byte_range(node: tree_sitter::Node, input_len: usize) -> Option<Range<usize>> {
@@ -3431,7 +3741,7 @@ fn collect_injected_tokens_for_parent_line_window(
     })
 }
 
-fn subtract_absolute_range_from_document_tokens(
+pub(super) fn subtract_absolute_range_from_document_tokens(
     line_starts: &[usize],
     input: &[u8],
     start_line_ix: usize,

--- a/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/prepared.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/diff_text/syntax/prepared.rs
@@ -2561,6 +2561,41 @@ pub(super) struct TreesitterHighlightSpec {
     pub(super) has_combined_injections: bool,
 }
 
+impl TreesitterHighlightSpec {
+    /// Whether match `pattern_ix` belongs to a shared layer.
+    ///
+    /// Reads the hoisted `has_combined_injections` gate first, so a grammar with no
+    /// combined pattern costs one branch. Shared by both collectors, which used to
+    /// inline this and drifted apart.
+    pub(super) fn is_combined_injection_pattern(&self, pattern_ix: usize) -> bool {
+        self.has_combined_injections
+            && self
+                .injection_combined_patterns
+                .get(pattern_ix)
+                .copied()
+                .unwrap_or(false)
+    }
+}
+
+/// Merges the per-pattern range map both collectors build into a deterministically
+/// ordered layer list.
+///
+/// The order is load-bearing: overlapping layers are applied in sequence and the
+/// later one wins, so `HashMap` order would tie an overlap's colour to hash seeding.
+pub(super) fn combined_injection_groups_in_apply_order(
+    combined_ranges: HashMap<(DiffSyntaxLanguage, usize), Vec<Range<usize>>>,
+) -> Vec<(DiffSyntaxLanguage, usize, Vec<Range<usize>>)> {
+    let mut groups: Vec<(DiffSyntaxLanguage, usize, Vec<Range<usize>>)> = combined_ranges
+        .into_iter()
+        .filter_map(|((language, pattern_ix), ranges)| {
+            let ranges = merge_sorted_injection_ranges(ranges);
+            (!ranges.is_empty()).then_some((language, pattern_ix, ranges))
+        })
+        .collect();
+    groups.sort_unstable_by_key(|(language, pattern_ix, _)| (*language, *pattern_ix));
+    groups
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct TreesitterQueryPass {
     pub(super) byte_range: Range<usize>,
@@ -3076,12 +3111,8 @@ fn apply_injection_query_tokens_for_document(
         context.start_line_ix,
         context.end_line_ix,
     );
-    if !injections.truncated {
-        for group in &injections.combined {
-            apply_combined_injection_tokens(group, input, context);
-        }
-    }
-    for injection in injections.singles {
+    for injection in &injections.singles {
+        let injection = *injection;
         let Some(injected_tokens) = collect_injected_tokens_for_parent_line_window(
             input,
             context.line_starts,
@@ -3111,6 +3142,17 @@ fn apply_injection_query_tokens_for_document(
                 continue;
             };
             line_tokens.extend(tokens);
+        }
+    }
+
+    // Combined last, and the order matters once a grammar declares both kinds over
+    // the same bytes. Each layer subtracts its own span from `per_line` before
+    // painting, so the last one wins the overlap; running combined first let a
+    // single delete combined tokens and then repaint only the bytes its own
+    // captures cover, leaving the rest bare. No in-tree grammar mixes them yet.
+    if !injections.truncated {
+        for group in &injections.combined {
+            apply_combined_injection_tokens(group, input, context);
         }
     }
 }
@@ -3157,10 +3199,10 @@ pub(super) fn parse_combined_injection_tree(
 }
 
 /// Clears a parser's included ranges on drop.
-struct IncludedRangesGuard<'parser>(&'parser mut tree_sitter::Parser);
+pub(super) struct IncludedRangesGuard<'parser>(&'parser mut tree_sitter::Parser);
 
 impl<'parser> IncludedRangesGuard<'parser> {
-    fn set(
+    pub(super) fn set(
         parser: &'parser mut tree_sitter::Parser,
         ranges: &[tree_sitter::Range],
     ) -> Option<Self> {
@@ -3171,7 +3213,7 @@ impl<'parser> IncludedRangesGuard<'parser> {
         Some(Self(parser))
     }
 
-    fn parser(&mut self) -> &mut tree_sitter::Parser {
+    pub(super) fn parser(&mut self) -> &mut tree_sitter::Parser {
         self.0
     }
 }
@@ -3182,27 +3224,74 @@ impl Drop for IncludedRangesGuard<'_> {
     }
 }
 
+/// The byte span a combined layer is parsed over for a given window.
+///
+/// The rendered window, widened by [`TS_COMBINED_INJECTION_CONTEXT_MARGIN_BYTES`]
+/// on each side so a construct straddling the window edge is still parsed whole.
+/// See that constant for why the margin is not optional.
+pub(super) fn combined_injection_clip_region(
+    line_starts: &[usize],
+    input_len: usize,
+    start_line_ix: usize,
+    end_line_ix: usize,
+) -> Range<usize> {
+    let window_start = line_starts.get(start_line_ix).copied().unwrap_or(0);
+    let window_end = line_region_end_byte(line_starts, input_len, end_line_ix.saturating_sub(1));
+    let clip_start = window_start.saturating_sub(TS_COMBINED_INJECTION_CONTEXT_MARGIN_BYTES);
+    let clip_end = window_end
+        .saturating_add(TS_COMBINED_INJECTION_CONTEXT_MARGIN_BYTES)
+        .min(input_len);
+    clip_start..clip_end.max(clip_start)
+}
+
+/// `ranges` is already sorted and non-overlapping, and clipping preserves both, so
+/// the result needs no re-merge.
+pub(super) fn clip_injection_ranges_to_region(
+    ranges: &[Range<usize>],
+    region: &Range<usize>,
+) -> Vec<Range<usize>> {
+    ranges
+        .iter()
+        .filter_map(|range| {
+            let start = range.start.max(region.start);
+            let end = range.end.min(region.end);
+            (start < end).then_some(start..end)
+        })
+        .collect()
+}
+
 /// Parses one combined group and splices its tokens into `context.per_line`.
 fn apply_combined_injection_tokens(
     group: &CombinedInjectionGroup,
     input: &[u8],
     context: &mut DocumentTokenCollectionContext<'_>,
 ) {
-    if group.ranges.len() > TS_COMBINED_INJECTION_MAX_RANGES {
+    let Some(spec) = tree_sitter_highlight_spec(group.language) else {
+        return;
+    };
+
+    // Clip before the ceilings are applied, not after; see their doc comment.
+    let clip_region = combined_injection_clip_region(
+        context.line_starts,
+        input.len(),
+        context.start_line_ix,
+        context.end_line_ix,
+    );
+    let ranges = clip_injection_ranges_to_region(&group.ranges, &clip_region);
+    if ranges.is_empty() {
         return;
     }
-    let total_bytes: usize = group
-        .ranges
+    if ranges.len() > TS_COMBINED_INJECTION_MAX_RANGES {
+        return;
+    }
+    let total_bytes: usize = ranges
         .iter()
         .map(|range| range.end.saturating_sub(range.start))
         .sum();
     if total_bytes > TS_COMBINED_INJECTION_MAX_BYTES {
         return;
     }
-    let Some(spec) = tree_sitter_highlight_spec(group.language) else {
-        return;
-    };
-    let Some(tree) = parse_combined_injection_tree(spec, input, context.line_starts, &group.ranges)
+    let Some(tree) = parse_combined_injection_tree(spec, input, context.line_starts, &ranges)
     else {
         return;
     };
@@ -3231,7 +3320,7 @@ fn apply_combined_injection_tokens(
         input.len(),
         context.end_line_ix.saturating_sub(1),
     );
-    for gap in combined_injection_gaps(window_start..window_end, &group.ranges) {
+    for gap in combined_injection_gaps(window_start..window_end, &ranges) {
         subtract_absolute_range_from_document_tokens(
             context.line_starts,
             input,
@@ -3242,7 +3331,7 @@ fn apply_combined_injection_tokens(
     }
 
     // ... and drop the host grammar's tokens from the bytes the injection took over.
-    for range in &group.ranges {
+    for range in &ranges {
         subtract_absolute_range_from_document_tokens(
             context.line_starts,
             input,
@@ -3264,16 +3353,27 @@ fn apply_combined_injection_tokens(
 /// [`collect_treesitter_injection_matches_for_line_window`] -- all three are hard
 /// requirements of `Parser::set_included_ranges`, and an *empty* slice is
 /// tree-sitter's "reset to the whole document" rather than "parse nothing".
-struct CombinedInjectionGroup {
-    language: DiffSyntaxLanguage,
-    ranges: Vec<Range<usize>>,
+///
+/// The key is `(language, pattern_index)` with no host-node identity, matching
+/// upstream tree-sitter's semantics. The cost is that unrelated matches of one
+/// pattern share a document: `buildPhase` and `installPhase` in the same chunk parse
+/// as one bash script, so an unterminated `if` in the first recolours the second.
+///
+/// Do not "fix" that by sub-grouping on the parent node. Nix `(string_fragment)`s do
+/// sit under their own `indented_string_expression`, but Jinja `(text)` nodes are
+/// children of whatever encloses them (`source_file`, `for_statement`,
+/// `if_statement`), so a parent key would shatter one template's HTML into a
+/// document per block. The Nix case needs a per-pattern key.
+pub(super) struct CombinedInjectionGroup {
+    pub(super) language: DiffSyntaxLanguage,
+    pub(super) ranges: Vec<Range<usize>>,
 }
 
-struct TreesitterInjectionMatches {
+pub(super) struct TreesitterInjectionMatches {
     /// One layer per match, the pre-existing behaviour. Unchanged for every
     /// grammar that does not declare `injection.combined`.
-    singles: Vec<TreesitterInjectionMatch>,
-    combined: Vec<CombinedInjectionGroup>,
+    pub(super) singles: Vec<TreesitterInjectionMatch>,
+    pub(super) combined: Vec<CombinedInjectionGroup>,
     /// The query cursor overflowed `TS_QUERY_MATCH_LIMIT` somewhere in this
     /// window, so tree-sitter silently dropped matches.
     ///
@@ -3282,10 +3382,10 @@ struct TreesitterInjectionMatches {
     /// losing one range out of a combined set changes the document the injected
     /// grammar sees, so an unbalanced `<div>` can wreck the whole window. Better
     /// to leave the host grammar painting.
-    truncated: bool,
+    pub(super) truncated: bool,
 }
 
-fn collect_treesitter_injection_matches_for_line_window(
+pub(super) fn collect_treesitter_injection_matches_for_line_window(
     tree: &tree_sitter::Tree,
     highlight: &TreesitterHighlightSpec,
     input: &[u8],
@@ -3349,12 +3449,7 @@ fn collect_treesitter_injection_matches_for_line_window(
                         continue;
                     };
                     let pattern_ix = m.pattern_index;
-                    let is_combined = has_combined
-                        && highlight
-                            .injection_combined_patterns
-                            .get(pattern_ix)
-                            .copied()
-                            .unwrap_or(false);
+                    let is_combined = highlight.is_combined_injection_pattern(pattern_ix);
                     for capture in m
                         .captures
                         .iter()
@@ -3408,23 +3503,9 @@ fn collect_treesitter_injection_matches_for_line_window(
         };
     }
 
-    let mut combined: Vec<(DiffSyntaxLanguage, usize, CombinedInjectionGroup)> = combined_ranges
+    let combined = combined_injection_groups_in_apply_order(combined_ranges)
         .into_iter()
-        .filter_map(|((language, pattern_ix), ranges)| {
-            let ranges = merge_sorted_injection_ranges(ranges);
-            (!ranges.is_empty()).then_some((
-                language,
-                pattern_ix,
-                CombinedInjectionGroup { language, ranges },
-            ))
-        })
-        .collect();
-    // Applied in a stable order regardless of hash iteration order; on overlap the
-    // later layer wins, so the order has to be deterministic.
-    combined.sort_unstable_by_key(|(language, pattern_ix, _)| (*language, *pattern_ix));
-    let combined = combined
-        .into_iter()
-        .map(|(_, _, group)| group)
+        .map(|(language, _, ranges)| CombinedInjectionGroup { language, ranges })
         .collect::<Vec<_>>();
 
     TreesitterInjectionMatches {
@@ -3784,11 +3865,22 @@ pub(super) fn subtract_absolute_range_from_document_tokens(
     }
 }
 
-fn subtract_relative_range_from_line_tokens(
+pub(super) fn subtract_relative_range_from_line_tokens(
     line_tokens: &mut Vec<SyntaxToken>,
     cut_range: Range<usize>,
 ) {
     if cut_range.start >= cut_range.end || line_tokens.is_empty() {
+        return;
+    }
+
+    // Usually a no-op: the caller subtracts once per gap and once per range, so a
+    // dense template reaches this ~2R times per chunk while any one line intersects
+    // only a couple of those cuts. Rebuilding regardless cost a malloc, a memcpy and
+    // a free per miss.
+    if line_tokens
+        .iter()
+        .all(|token| token.range.end <= cut_range.start || token.range.start >= cut_range.end)
+    {
         return;
     }
 

--- a/crates/gitcomet/Cargo.toml
+++ b/crates/gitcomet/Cargo.toml
@@ -18,15 +18,7 @@ ui-gpui-runtime = [
     "dep:gitcomet-win32-window-utils",
     "dep:sysinfo",
 ]
-ui-gpui = ["ui-gpui-runtime", "gitcomet-ui-gpui/syntax-all"]
-ui-gpui-syntax-common = [
-    "ui-gpui-runtime",
-    "gitcomet-ui-gpui/syntax-common",
-]
-ui-gpui-syntax-minimal = [
-    "ui-gpui-runtime",
-    "gitcomet-ui-gpui/syntax-minimal",
-]
+ui-gpui = ["ui-gpui-runtime"]
 gix = ["dep:gitcomet-git-gix"]
 
 [dependencies]


### PR DESCRIPTION
Implements https://github.com/Auto-Explore/GitComet/issues/363 and  https://github.com/Auto-Explore/GitComet/issues/348

Removed syntax highlight crate feature groups because the language cross reference each other and they were all enabled anyway