### PR TITLE
Restore star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ SourceTree, GitKraken, Zed, GPUI, KDiff3, Meld, Github Desktop, Git, Gix, Rust, 
 
 This project has been created with the help of AI tools, including OpenAI Codex and Claude Code.
 
+### Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=Auto-Explore/gitcomet&type=Date)](https://star-history.dera.page/#Auto-Explore/gitcomet&Date)
+
 ### License
 
 GitComet is licensed under the GNU Affero General Public License Version 3


### PR DESCRIPTION
The star history chart was removed from the README because it stopped working after GitHub changed how stargazer data is exposed. This change restores the chart using a working source so the project's star history is visible again.

Originally removed in 8a6a83c "Removed star history because that information is no longer publicly available".