### PR TITLE
Add "Merge into current branch" action to the commit context menu

### DIFF
--- a/crates/gitcomet-git-gix/src/repo/history.rs
+++ b/crates/gitcomet-git-gix/src/repo/history.rs
@@ -1367,7 +1367,9 @@ fn parse_interactive_rebase_log(output: &str) -> Result<Vec<InteractiveRebaseEnt
     }
 
     fields
-        .as_chunks::<3>().0.iter()
+        .as_chunks::<3>()
+        .0
+        .iter()
         .map(|record| {
             let (sha, summary, message) = (record[0], record[1], record[2]);
             let full_hex_id =

--- a/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
@@ -4505,6 +4505,10 @@ pub(super) enum PopoverKind {
         repo_id: RepoId,
         commit_id: CommitId,
     },
+    MergeCommitConfirm {
+        repo_id: RepoId,
+        commit_id: CommitId,
+    },
     MergeAbortConfirm {
         repo_id: RepoId,
     },

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -22,6 +22,7 @@ mod force_delete_branch_confirm;
 mod force_push_confirm;
 mod force_remove_worktree_confirm;
 mod merge_abort_confirm;
+mod merge_commit_confirm;
 mod picker_nav;
 mod picker_row_menu;
 mod pull_reconcile_prompt;
@@ -510,6 +511,7 @@ fn popover_is_confirm_dialog(kind: &PopoverKind) -> bool {
         PopoverKind::StashDropConfirm { .. }
             | PopoverKind::ForcePushConfirm { .. }
             | PopoverKind::CherryPickCommitConfirm { .. }
+            | PopoverKind::MergeCommitConfirm { .. }
             | PopoverKind::MergeAbortConfirm { .. }
             | PopoverKind::RebaseOntoConfirm { .. }
             | PopoverKind::RebaseReword { .. }
@@ -795,6 +797,7 @@ fn popover_anchor_corner(kind: &PopoverKind) -> Anchor {
         | PopoverKind::PushSetUpstreamPrompt { .. }
         | PopoverKind::ForcePushConfirm { .. }
         | PopoverKind::CherryPickCommitConfirm { .. }
+        | PopoverKind::MergeCommitConfirm { .. }
         | PopoverKind::MergeAbortConfirm { .. }
         | PopoverKind::ForceDeleteBranchConfirm { .. }
         | PopoverKind::ForceRemoveWorktreeConfirm { .. }
@@ -859,7 +862,8 @@ pub(in super::super) fn popover_width_spec(kind: &PopoverKind) -> Option<Popover
         PopoverKind::PushSetUpstreamPrompt { .. } => Some(DIALOG_320_WIDTH),
         PopoverKind::ResetPrompt { .. }
         | PopoverKind::RebaseOntoConfirm { .. }
-        | PopoverKind::CherryPickCommitConfirm { .. } => Some(DIALOG_380_WIDTH),
+        | PopoverKind::CherryPickCommitConfirm { .. }
+        | PopoverKind::MergeCommitConfirm { .. } => Some(DIALOG_380_WIDTH),
         PopoverKind::MergeAbortConfirm { .. } => Some(DIALOG_360_WIDTH),
         PopoverKind::ForceRemoveWorktreeConfirm { .. } => Some(DIALOG_460_WIDTH),
         PopoverKind::PullReconcilePrompt { .. } | PopoverKind::AddToGitignorePrompt { .. } => {
@@ -4106,6 +4110,9 @@ impl PopoverHost {
             }
             PopoverKind::CherryPickCommitConfirm { repo_id, commit_id } => {
                 cherry_pick_commit_confirm::panel(self, repo_id, commit_id, cx)
+            }
+            PopoverKind::MergeCommitConfirm { repo_id, commit_id } => {
+                merge_commit_confirm::panel(self, repo_id, commit_id, cx)
             }
             PopoverKind::MergeAbortConfirm { repo_id } => {
                 merge_abort_confirm::panel(self, repo_id, cx)

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/commit.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/commit.rs
@@ -1,5 +1,6 @@
 use super::*;
 use gitcomet_core::services::{InteractiveRebaseAction, InteractiveRebaseEntry};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 type InteractiveRebaseSourceColor = (String, u8);
 type MultiCherryPickPlan = (
@@ -82,6 +83,47 @@ fn multi_cherry_pick_plan(
     }
 
     Some((entries, source_colors))
+}
+
+/// Returns `true` when `commit_id` is already reachable from HEAD — i.e. it is
+/// part of the current branch's history (including HEAD itself). The check walks
+/// the parents of the loaded log page from HEAD. The right-clicked commit is by
+/// construction present in that page, so a path through the page reaching it
+/// proves ancestry; a truncated page can only produce a false negative, which
+/// git corrects at merge time with "Already up to date".
+fn commit_is_ancestor_of_head(this: &PopoverHost, repo_id: RepoId, commit_id: &CommitId) -> bool {
+    let Some(repo) = this.state.repos.iter().find(|repo| repo.id == repo_id) else {
+        return false;
+    };
+    let Some(head) = repo.head_commit_id() else {
+        return false;
+    };
+    if head == *commit_id {
+        return true;
+    }
+    let Loadable::Ready(page) = &repo.log else {
+        return false;
+    };
+    let mut by_id: HashMap<CommitId, &Commit> = HashMap::new();
+    for commit in &page.commits {
+        by_id.insert(commit.id.clone(), commit);
+    }
+    let mut seen: HashSet<CommitId> = HashSet::new();
+    let mut queue: VecDeque<CommitId> = VecDeque::from([head]);
+    while let Some(current) = queue.pop_front() {
+        if current == *commit_id {
+            return true;
+        }
+        if !seen.insert(current.clone()) {
+            continue;
+        }
+        if let Some(commit) = by_id.get(&current) {
+            for parent in &commit.parent_ids {
+                queue.push_back(parent.clone());
+            }
+        }
+    }
+    false
 }
 
 pub(super) fn model(this: &PopoverHost, repo_id: RepoId, commit_id: &CommitId) -> ContextMenuModel {
@@ -405,6 +447,24 @@ pub(super) fn model(this: &PopoverHost, repo_id: RepoId, commit_id: &CommitId) -
             }),
         });
     }
+
+    // "Merge into current" merges the right-clicked commit into the checked-out
+    // branch through the shared MergeRef pipeline. It is a no-op when the commit
+    // is already part of HEAD's history (including HEAD itself), so it is
+    // disabled rather than letting git reject it as "Already up to date".
+    let merge_into_current_disabled = commit_is_ancestor_of_head(this, repo_id, commit_id);
+    items.push(ContextMenuItem::Entry {
+        label: format!("Merge {short} into {current_branch}").into(),
+        icon: Some("icons/swap.svg".into()),
+        shortcut: Some("M".into()),
+        disabled: merge_into_current_disabled,
+        action: Box::new(ContextMenuAction::OpenPopover {
+            kind: PopoverKind::MergeCommitConfirm {
+                repo_id,
+                commit_id: commit_id.clone(),
+            },
+        }),
+    });
 
     items.push(ContextMenuItem::Separator);
     for (label, icon, mode) in [

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/commit.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/commit.rs
@@ -1,6 +1,7 @@
 use super::*;
 use gitcomet_core::services::{InteractiveRebaseAction, InteractiveRebaseEntry};
-use std::collections::{HashMap, HashSet, VecDeque};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::VecDeque;
 
 type InteractiveRebaseSourceColor = (String, u8);
 type MultiCherryPickPlan = (
@@ -95,6 +96,10 @@ fn commit_is_ancestor_of_head(this: &PopoverHost, repo_id: RepoId, commit_id: &C
     let Some(repo) = this.state.repos.iter().find(|repo| repo.id == repo_id) else {
         return false;
     };
+    repo_commit_is_ancestor_of_head(repo, commit_id)
+}
+
+fn repo_commit_is_ancestor_of_head(repo: &RepoState, commit_id: &CommitId) -> bool {
     let Some(head) = repo.head_commit_id() else {
         return false;
     };
@@ -104,11 +109,11 @@ fn commit_is_ancestor_of_head(this: &PopoverHost, repo_id: RepoId, commit_id: &C
     let Loadable::Ready(page) = &repo.log else {
         return false;
     };
-    let mut by_id: HashMap<CommitId, &Commit> = HashMap::new();
+    let mut by_id: FxHashMap<CommitId, &Commit> = FxHashMap::default();
     for commit in &page.commits {
         by_id.insert(commit.id.clone(), commit);
     }
-    let mut seen: HashSet<CommitId> = HashSet::new();
+    let mut seen: FxHashSet<CommitId> = FxHashSet::default();
     let mut queue: VecDeque<CommitId> = VecDeque::from([head]);
     while let Some(current) = queue.pop_front() {
         if current == *commit_id {
@@ -500,4 +505,113 @@ pub(super) fn model(this: &PopoverHost, repo_id: RepoId, commit_id: &CommitId) -
     }
 
     ContextMenuModel::new(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gitcomet_core::domain::{CommitParentIds, LogPage, RepoSpec};
+    use gitcomet_state::model::{Loadable, RepoId, RepoState};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::SystemTime;
+
+    fn repo_state() -> RepoState {
+        RepoState::new_opening(
+            RepoId(1),
+            RepoSpec {
+                workdir: PathBuf::from("/tmp/repo"),
+            },
+        )
+    }
+
+    fn commit(id: &str, parents: &[&str]) -> Commit {
+        Commit {
+            id: CommitId(id.into()),
+            parent_ids: parents
+                .iter()
+                .map(|p| CommitId((*p).into()))
+                .collect::<CommitParentIds>(),
+            summary: "summary".into(),
+            author: "author".into(),
+            time: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    fn with_log(mut repo: RepoState, head: &str, commits: Vec<Commit>) -> RepoState {
+        repo.detached_head_commit = Some(CommitId(head.into()));
+        repo.log = Loadable::Ready(Arc::new(LogPage {
+            commits,
+            next_cursor: None,
+        }));
+        repo
+    }
+
+    #[test]
+    fn head_commit_is_its_own_ancestor() {
+        let repo = with_log(repo_state(), "a", vec![commit("a", &[])]);
+
+        assert!(repo_commit_is_ancestor_of_head(
+            &repo,
+            &CommitId("a".into())
+        ));
+    }
+
+    #[test]
+    fn commit_reachable_through_parent_chain_is_ancestor() {
+        // c -> b -> a (HEAD is c)
+        let repo = with_log(
+            repo_state(),
+            "c",
+            vec![commit("c", &["b"]), commit("b", &["a"]), commit("a", &[])],
+        );
+
+        assert!(repo_commit_is_ancestor_of_head(
+            &repo,
+            &CommitId("a".into())
+        ));
+    }
+
+    #[test]
+    fn commit_on_unrelated_branch_is_not_ancestor() {
+        // HEAD is b, which does not descend from the side-branch commit x
+        let repo = with_log(
+            repo_state(),
+            "b",
+            vec![commit("b", &["a"]), commit("a", &[])],
+        );
+
+        assert!(!repo_commit_is_ancestor_of_head(
+            &repo,
+            &CommitId("x".into())
+        ));
+    }
+
+    #[test]
+    fn no_head_commit_is_not_ancestor() {
+        let repo = repo_state();
+
+        assert!(!repo_commit_is_ancestor_of_head(
+            &repo,
+            &CommitId("a".into())
+        ));
+    }
+
+    #[test]
+    fn merge_entry_disabled_when_commit_is_ancestor_of_head() {
+        let repo = with_log(
+            repo_state(),
+            "c",
+            vec![commit("c", &["b"]), commit("b", &[])],
+        );
+
+        assert!(repo_commit_is_ancestor_of_head(
+            &repo,
+            &CommitId("b".into())
+        ));
+        assert!(!repo_commit_is_ancestor_of_head(
+            &repo,
+            &CommitId("missing".into())
+        ));
+    }
 }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
@@ -169,6 +169,7 @@ fn repo_for_popover<'a>(state: &'a AppState, popover: &PopoverKind) -> Option<&'
         | PopoverKind::PushSetUpstreamPrompt { repo_id, .. }
         | PopoverKind::ForcePushConfirm { repo_id }
         | PopoverKind::CherryPickCommitConfirm { repo_id, .. }
+        | PopoverKind::MergeCommitConfirm { repo_id, .. }
         | PopoverKind::MergeAbortConfirm { repo_id }
         | PopoverKind::ForceDeleteBranchConfirm { repo_id, .. }
         | PopoverKind::ForceRemoveWorktreeConfirm { repo_id, .. }
@@ -364,6 +365,7 @@ fn hash_repo_for_popover<H: Hasher>(repo: &RepoState, popover: &PopoverKind, has
         | PopoverKind::RebaseReword { .. }
         | PopoverKind::RebaseOntoConfirm { .. }
         | PopoverKind::CherryPickCommitConfirm { .. }
+        | PopoverKind::MergeCommitConfirm { .. }
         | PopoverKind::MergeAbortConfirm { .. }
         | PopoverKind::ResetPrompt { .. }
         | PopoverKind::CheckoutRemoteBranchPrompt { .. }
@@ -552,6 +554,11 @@ fn hash_popover_kind<H: Hasher>(kind: &PopoverKind, hasher: &mut H) {
         }
         PopoverKind::CherryPickCommitConfirm { repo_id, commit_id } => {
             76u8.hash(hasher);
+            repo_id.hash(hasher);
+            commit_id.hash(hasher);
+        }
+        PopoverKind::MergeCommitConfirm { repo_id, commit_id } => {
+            83u8.hash(hasher);
             repo_id.hash(hasher);
             commit_id.hash(hasher);
         }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/merge_commit_confirm.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/merge_commit_confirm.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+pub(super) fn panel(
+    this: &mut PopoverHost,
+    repo_id: RepoId,
+    commit_id: CommitId,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Div {
+    let theme = this.theme;
+    let sha = commit_id.as_ref();
+    let short: SharedString = sha.get(0..7).unwrap_or(sha).into();
+    let summary = this
+        .state
+        .repos
+        .iter()
+        .find(|repo| repo.id == repo_id)
+        .and_then(|repo| match &repo.log {
+            Loadable::Ready(page) => page
+                .commits
+                .iter()
+                .find(|commit| commit.id == commit_id)
+                .map(|commit| commit.summary.to_string()),
+            _ => None,
+        })
+        .unwrap_or_default();
+    let current_branch: SharedString = this
+        .active_repo()
+        .and_then(|r| match &r.head_branch {
+            Loadable::Ready(head) if !head.is_empty() && head != "HEAD" => {
+                Some(head.as_str().into())
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| short.clone());
+
+    let dispatch = move |this: &mut PopoverHost, cx: &mut gpui::Context<PopoverHost>| {
+        this.store.dispatch(Msg::MergeRef {
+            repo_id,
+            reference: commit_id.as_ref().to_string(),
+        });
+        this.close_popover(cx);
+    };
+
+    let mut dialog = ConfirmDialog::new("Merge commit?", DIALOG_380_WIDTH)
+        .text(theme, format!("Merge {short} into {current_branch}?"))
+        .note(
+            theme,
+            "Git resolves the merge with a merge commit when history diverges.",
+        );
+    if !summary.is_empty() {
+        dialog = dialog.note(theme, summary);
+    }
+
+    dialog.render(
+        theme,
+        dialog_cancel_button("merge_commit_cancel", "merge_commit_cancel_hint", theme, cx),
+        div().flex().items_center().gap_1().child(
+            components::Button::new("merge_commit_confirm", "Merge")
+                .style(components::ButtonStyle::Filled)
+                .on_click(theme, cx, move |this, _e, _w, cx| dispatch(this, cx)),
+        ),
+        cx,
+    )
+}


### PR DESCRIPTION
 

## Description
Right-clicking a commit now offers a **Merge** entry that merges the selected
commit into the currently checked-out branch, reusing the existing `MergeRef`
pipeline (default `git merge --no-edit`, with the in-place conflict resolution
already used elsewhere).

### Behavior
- New **"Merge {short} into {current_branch}"** item (shortcut `M`) in the
  history group of the commit context menu.
- Opens a confirmation dialog (`MergeCommitConfirm`) before running the merge,
  mirroring the existing `CherryPickCommitConfirm` flow.
- Disabled when the commit is already part of HEAD's history (including HEAD
  itself), so git never rejects it as "Already up to date".
- Confirming dispatches `Msg::MergeRef` with the commit SHA as the reference,
  so fast-forward or merge-commit resolution is handled by the backend and any
  conflicts drop into the existing merge workflow.

### Implementation
- `PopoverKind::MergeCommitConfirm { repo_id, commit_id }` added and wired
  through the popover dispatch, anchor, width, and fingerprint matchers.
- New `merge_commit_confirm.rs` confirm dialog.
- `commit.rs` gains the menu entry plus a synchronous
  `commit_is_ancestor_of_head` helper (parent BFS over the loaded log page).

### Verification
- `cargo fmt --all`, `cargo clippy -p gitcomet-ui-gpui`, and `cargo check` pass.