### PR TITLE
feat: implement remote management infrastructure, UI components, and state-driven effect handling for repository operations

### DIFF
--- a/crates/gitcomet-core/src/lib.rs
+++ b/crates/gitcomet-core/src/lib.rs
@@ -16,3 +16,4 @@ pub mod process;
 pub mod services;
 pub mod squash;
 pub mod text_utils;
+pub mod url_utils;

--- a/crates/gitcomet-core/src/services.rs
+++ b/crates/gitcomet-core/src/services.rs
@@ -842,6 +842,11 @@ pub trait GitRepository: Send + Sync {
             "git remote remove is not implemented for this backend",
         )))
     }
+    fn rename_remote_with_output(&self, _old_name: &str, _new_name: &str) -> Result<CommandOutput> {
+        Err(Error::new(ErrorKind::Unsupported(
+            "git remote rename is not implemented for this backend",
+        )))
+    }
     fn set_remote_url_with_output(
         &self,
         _name: &str,

--- a/crates/gitcomet-core/src/url_utils.rs
+++ b/crates/gitcomet-core/src/url_utils.rs
@@ -1,0 +1,174 @@
+//! URL parsing and manipulation utilities for Git remotes.
+//! Supports HTTPS, HTTP, SSH (URL and SCP-style syntax), and file protocols.
+
+/// Extracts (username, base_url_without_user) from a remote URL.
+///
+/// Examples:
+/// - `https://user@github.com/org/repo.git` -> `(Some("user"), "https://github.com/org/repo.git")`
+/// - `https://github.com/org/repo.git` -> `(None, "https://github.com/org/repo.git")`
+/// - `ssh://user@host.com:22/path/repo.git` -> `(Some("user"), "ssh://host.com:22/path/repo.git")`
+/// - `git@github.com:org/repo.git` -> `(Some("git"), "github.com:org/repo.git")`
+pub fn extract_username_and_base_url(url: &str) -> (Option<String>, String) {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return (None, String::new());
+    }
+
+    // 1. Standard protocol with scheme: "proto://..."
+    if let Some(proto_pos) = trimmed.find("://") {
+        let scheme = &trimmed[..proto_pos + 3];
+        let rest = &trimmed[proto_pos + 3..];
+
+        // Find the boundary between authority and path: first '/' or '?' or '#'
+        let authority_end = rest
+            .find('/')
+            .unwrap_or_else(|| rest.find('?').unwrap_or(rest.len()));
+        let authority = &rest[..authority_end];
+        let path_and_query = &rest[authority_end..];
+
+        if let Some(at_pos) = authority.find('@') {
+            let user = &authority[..at_pos];
+            let host_and_port = &authority[at_pos + 1..];
+            let base_url = format!("{scheme}{host_and_port}{path_and_query}");
+            return (
+                if user.is_empty() {
+                    None
+                } else {
+                    Some(user.to_string())
+                },
+                base_url,
+            );
+        } else {
+            return (None, trimmed.to_string());
+        }
+    }
+
+    // 2. SCP-style syntax: "user@host:path/to/repo.git" or "host:path/to/repo.git"
+    // Only consider it SCP-style if there is a colon and no leading slash/drive letter
+    if let Some(colon_pos) = trimmed.find(':') {
+        let before_colon = &trimmed[..colon_pos];
+        if !before_colon.contains('/')
+            && !before_colon.contains('\\')
+            && let Some(at_pos) = before_colon.find('@')
+        {
+            let user = &before_colon[..at_pos];
+            let host = &before_colon[at_pos + 1..];
+            let path = &trimmed[colon_pos..];
+            let base_url = format!("{host}{path}");
+            return (
+                if user.is_empty() {
+                    None
+                } else {
+                    Some(user.to_string())
+                },
+                base_url,
+            );
+        }
+    }
+
+    (None, trimmed.to_string())
+}
+
+/// Embeds or removes the username in a Git remote URL.
+///
+/// If `username` is `Some("...")` (and not empty), injects `username@` into the authority.
+/// If `username` is `None` or empty, strips any embedded username.
+pub fn embed_username_into_url(url: &str, username: Option<&str>) -> String {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let (_, base_url) = extract_username_and_base_url(trimmed);
+    let clean_user = username.map(str::trim).filter(|u| !u.is_empty());
+
+    let Some(user) = clean_user else {
+        return base_url;
+    };
+
+    // 1. Standard protocol with scheme: "proto://..."
+    if let Some(proto_pos) = base_url.find("://") {
+        let scheme = &base_url[..proto_pos + 3];
+        let rest = &base_url[proto_pos + 3..];
+        return format!("{scheme}{user}@{rest}");
+    }
+
+    // 2. SCP-style syntax: "host:path" -> "user@host:path"
+    if let Some(colon_pos) = base_url.find(':') {
+        let before_colon = &base_url[..colon_pos];
+        if !before_colon.contains('/') && !before_colon.contains('\\') {
+            return format!("{user}@{base_url}");
+        }
+    }
+
+    // 3. Fallback for generic host/path or unparsed string: if no scheme, default to https://
+    format!("{user}@{base_url}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_username_and_base_url() {
+        // HTTPS with user
+        let (user, base) =
+            extract_username_and_base_url("https://username@github.com/OrgName/RepoName.git");
+        assert_eq!(user.as_deref(), Some("username"));
+        assert_eq!(base, "https://github.com/OrgName/RepoName.git");
+
+        // HTTPS without user
+        let (user, base) = extract_username_and_base_url("https://github.com/OrgName/RepoName.git");
+        assert_eq!(user, None);
+        assert_eq!(base, "https://github.com/OrgName/RepoName.git");
+
+        // SSH with scheme and user and port
+        let (user, base) =
+            extract_username_and_base_url("ssh://git@github.com:22/OrgName/Repo.git");
+        assert_eq!(user.as_deref(), Some("git"));
+        assert_eq!(base, "ssh://github.com:22/OrgName/Repo.git");
+
+        // SCP-style SSH
+        let (user, base) = extract_username_and_base_url("git@github.com:OrgName/Repo.git");
+        assert_eq!(user.as_deref(), Some("git"));
+        assert_eq!(base, "github.com:OrgName/Repo.git");
+
+        // Empty
+        let (user, base) = extract_username_and_base_url("");
+        assert_eq!(user, None);
+        assert_eq!(base, "");
+    }
+
+    #[test]
+    fn test_embed_username_into_url() {
+        // Add user to https URL
+        let url = "https://github.com/OrgName/RepoName.git";
+        let with_user = embed_username_into_url(url, Some("username"));
+        assert_eq!(
+            with_user,
+            "https://username@github.com/OrgName/RepoName.git"
+        );
+
+        // Replace user in https URL
+        let url_with_old_user = "https://olduser@github.com/OrgName/RepoName.git";
+        let with_new_user = embed_username_into_url(url_with_old_user, Some("username"));
+        assert_eq!(
+            with_new_user,
+            "https://username@github.com/OrgName/RepoName.git"
+        );
+
+        // Remove user from https URL
+        let stripped = embed_username_into_url(url_with_old_user, None);
+        assert_eq!(stripped, "https://github.com/OrgName/RepoName.git");
+        let stripped_empty = embed_username_into_url(url_with_old_user, Some("   "));
+        assert_eq!(stripped_empty, "https://github.com/OrgName/RepoName.git");
+
+        // SSH SCP style
+        let scp = "git@github.com:OrgName/Repo.git";
+        let new_scp = embed_username_into_url(scp, Some("username"));
+        assert_eq!(new_scp, "username@github.com:OrgName/Repo.git");
+
+        let stripped_scp = embed_username_into_url(scp, None);
+        assert_eq!(stripped_scp, "github.com:OrgName/Repo.git");
+    }
+}

--- a/crates/gitcomet-git-gix/src/repo/mod.rs
+++ b/crates/gitcomet-git-gix/src/repo/mod.rs
@@ -834,6 +834,10 @@ impl GitRepository for GixRepo {
         self.remove_remote_with_output_impl(name)
     }
 
+    fn rename_remote_with_output(&self, old_name: &str, new_name: &str) -> Result<CommandOutput> {
+        self.rename_remote_with_output_impl(old_name, new_name)
+    }
+
     fn set_remote_url_with_output(
         &self,
         name: &str,

--- a/crates/gitcomet-git-gix/src/repo/remotes.rs
+++ b/crates/gitcomet-git-gix/src/repo/remotes.rs
@@ -923,6 +923,23 @@ impl GixRepo {
         run_git_with_output(cmd, &format!("git remote remove {name}"))
     }
 
+    pub(super) fn rename_remote_with_output_impl(
+        &self,
+        old_name: &str,
+        new_name: &str,
+    ) -> Result<CommandOutput> {
+        validate_ref_like_arg(old_name, "remote old name")?;
+        validate_ref_like_arg(new_name, "remote new name")?;
+
+        let mut cmd = self.git_workdir_cmd();
+        cmd.arg("remote")
+            .arg("rename")
+            .arg("--")
+            .arg(old_name)
+            .arg(new_name);
+        run_git_with_output(cmd, &format!("git remote rename {old_name} {new_name}"))
+    }
+
     pub(super) fn set_remote_url_with_output_impl(
         &self,
         name: &str,

--- a/crates/gitcomet-git-gix/tests/remote_management_integration.rs
+++ b/crates/gitcomet-git-gix/tests/remote_management_integration.rs
@@ -276,8 +276,17 @@ fn remote_add_set_url_and_remove_round_trip() {
         .to_string();
     assert_eq!(push_url, fetch_remote_str);
 
+    let rename_output = opened
+        .rename_remote_with_output("origin", "upstream")
+        .expect("rename remote");
+    assert_eq!(rename_output.exit_code, Some(0));
+
+    let remotes_after_rename = opened.list_remotes().expect("list remotes after rename");
+    assert_eq!(remotes_after_rename.len(), 1);
+    assert_eq!(remotes_after_rename[0].name, "upstream");
+
     let remove_output = opened
-        .remove_remote_with_output("origin")
+        .remove_remote_with_output("upstream")
         .expect("remove remote");
     assert_eq!(remove_output.exit_code, Some(0));
 

--- a/crates/gitcomet-state/src/msg/effect.rs
+++ b/crates/gitcomet-state/src/msg/effect.rs
@@ -590,6 +590,11 @@ pub enum Effect {
         repo_id: RepoId,
         name: String,
     },
+    RenameRemote {
+        repo_id: RepoId,
+        old_name: String,
+        new_name: String,
+    },
     SetRemoteUrl {
         repo_id: RepoId,
         name: String,

--- a/crates/gitcomet-state/src/msg/message.rs
+++ b/crates/gitcomet-state/src/msg/message.rs
@@ -820,6 +820,11 @@ pub enum Msg {
         repo_id: RepoId,
         name: String,
     },
+    RenameRemote {
+        repo_id: RepoId,
+        old_name: String,
+        new_name: String,
+    },
     SetRemoteUrl {
         repo_id: RepoId,
         name: String,

--- a/crates/gitcomet-state/src/msg/repo_command_kind.rs
+++ b/crates/gitcomet-state/src/msg/repo_command_kind.rs
@@ -108,6 +108,10 @@ pub enum RepoCommandKind {
     RemoveRemote {
         name: String,
     },
+    RenameRemote {
+        old_name: String,
+        new_name: String,
+    },
     SetRemoteUrl {
         name: String,
         url: String,

--- a/crates/gitcomet-state/src/store/effects.rs
+++ b/crates/gitcomet-state/src/store/effects.rs
@@ -1265,6 +1265,17 @@ fn send_unavailable_git_effect_result(
                 result: Err(git_unavailable_error(runtime)),
             },
         )),
+        Effect::RenameRemote {
+            repo_id,
+            old_name,
+            new_name,
+        } => send(Msg::Internal(
+            crate::msg::InternalMsg::RepoCommandFinished {
+                repo_id,
+                command: RepoCommandKind::RenameRemote { old_name, new_name },
+                result: Err(git_unavailable_error(runtime)),
+            },
+        )),
         Effect::SetRemoteUrl {
             repo_id,
             name,
@@ -2518,6 +2529,15 @@ pub(super) fn schedule_effect(
         }
         Effect::RemoveRemote { repo_id, name } => {
             repo_commands::schedule_remove_remote(executor, repos, msg_tx, repo_id, name);
+        }
+        Effect::RenameRemote {
+            repo_id,
+            old_name,
+            new_name,
+        } => {
+            repo_commands::schedule_rename_remote(
+                executor, repos, msg_tx, repo_id, old_name, new_name,
+            );
         }
         Effect::SetRemoteUrl {
             repo_id,

--- a/crates/gitcomet-state/src/store/effects/repo_commands.rs
+++ b/crates/gitcomet-state/src/store/effects/repo_commands.rs
@@ -1245,6 +1245,29 @@ pub(super) fn schedule_remove_remote(
     );
 }
 
+pub(super) fn schedule_rename_remote(
+    executor: &TaskExecutor,
+    repos: &RepoMap,
+    msg_tx: StoreWorkerSender,
+    repo_id: RepoId,
+    old_name: String,
+    new_name: String,
+) {
+    let command_old_name = old_name.clone();
+    let command_new_name = new_name.clone();
+    schedule_repo_command(
+        executor,
+        repos,
+        msg_tx,
+        repo_id,
+        RepoCommandKind::RenameRemote {
+            old_name: command_old_name,
+            new_name: command_new_name,
+        },
+        move |repo| repo.rename_remote_with_output(&old_name, &new_name),
+    );
+}
+
 pub(super) fn schedule_set_remote_url(
     executor: &TaskExecutor,
     repos: &RepoMap,

--- a/crates/gitcomet-state/src/store/reducer.rs
+++ b/crates/gitcomet-state/src/store/reducer.rs
@@ -197,6 +197,7 @@ pub(crate) fn msg_requires_available_git(msg: &Msg) -> bool {
             | Msg::DeleteRemoteTag { .. }
             | Msg::AddRemote { .. }
             | Msg::RemoveRemote { .. }
+            | Msg::RenameRemote { .. }
             | Msg::SetRemoteUrl { .. }
             | Msg::CheckoutConflictSide { .. }
             | Msg::AcceptConflictDeletion { .. }
@@ -464,6 +465,11 @@ fn retry_msg_for_repo_command(repo_id: RepoId, command: RepoCommandKind) -> Opti
         },
         RepoCommandKind::AddRemote { name, url } => Msg::AddRemote { repo_id, name, url },
         RepoCommandKind::RemoveRemote { name } => Msg::RemoveRemote { repo_id, name },
+        RepoCommandKind::RenameRemote { old_name, new_name } => Msg::RenameRemote {
+            repo_id,
+            old_name,
+            new_name,
+        },
         RepoCommandKind::SetRemoteUrl { name, url, kind } => Msg::SetRemoteUrl {
             repo_id,
             name,
@@ -1640,6 +1646,14 @@ fn reduce_inner(
         Msg::RemoveRemote { repo_id, name } => {
             begin_local_action(state, repo_id);
             actions_emit_effects::remove_remote(repo_id, name)
+        }
+        Msg::RenameRemote {
+            repo_id,
+            old_name,
+            new_name,
+        } => {
+            begin_local_action(state, repo_id);
+            actions_emit_effects::rename_remote(repo_id, old_name, new_name)
         }
         Msg::SetRemoteUrl {
             repo_id,

--- a/crates/gitcomet-state/src/store/reducer/actions_emit_effects.rs
+++ b/crates/gitcomet-state/src/store/reducer/actions_emit_effects.rs
@@ -730,6 +730,14 @@ pub(super) fn remove_remote(repo_id: RepoId, name: String) -> Vec<Effect> {
     vec![Effect::RemoveRemote { repo_id, name }]
 }
 
+pub(super) fn rename_remote(repo_id: RepoId, old_name: String, new_name: String) -> Vec<Effect> {
+    vec![Effect::RenameRemote {
+        repo_id,
+        old_name,
+        new_name,
+    }]
+}
+
 pub(super) fn set_remote_url(
     repo_id: RepoId,
     name: String,
@@ -990,6 +998,7 @@ fn tracks_local_actions_in_flight(command: &RepoCommandKind) -> bool {
             | RepoCommandKind::DeleteTag { .. }
             | RepoCommandKind::AddRemote { .. }
             | RepoCommandKind::RemoveRemote { .. }
+            | RepoCommandKind::RenameRemote { .. }
             | RepoCommandKind::SetRemoteUrl { .. }
             | RepoCommandKind::SetUpstreamBranch { .. }
             | RepoCommandKind::UnsetUpstreamBranch { .. }

--- a/crates/gitcomet-state/src/store/reducer/util.rs
+++ b/crates/gitcomet-state/src/store/reducer/util.rs
@@ -1145,6 +1145,7 @@ fn summarize_command(
             RepoCommandKind::DeleteTag { .. } => "Tag",
             RepoCommandKind::AddRemote { .. } => "Remote",
             RepoCommandKind::RemoveRemote { .. } => "Remote",
+            RepoCommandKind::RenameRemote { .. } => "Remote",
             RepoCommandKind::SetRemoteUrl { .. } => "Remote",
             RepoCommandKind::CheckoutConflict { side, .. } => match side {
                 ConflictSide::Ours => "Checkout ours",
@@ -1424,6 +1425,9 @@ fn summarize_command(
         RepoCommandKind::DeleteTag { name } => format!("Tag {name}: Deleted"),
         RepoCommandKind::AddRemote { name, .. } => format!("Remote {name}: Added"),
         RepoCommandKind::RemoveRemote { name } => format!("Remote {name}: Removed"),
+        RepoCommandKind::RenameRemote { old_name, new_name } => {
+            format!("Remote {old_name}: Renamed to {new_name}")
+        }
         RepoCommandKind::SetRemoteUrl { name, kind, .. } => {
             let kind = match kind {
                 gitcomet_core::services::RemoteUrlKind::Fetch => "fetch",

--- a/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
@@ -4747,6 +4747,7 @@ pub(super) enum RepoPopoverKind {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) enum RemotePopoverKind {
     AddPrompt,
+    EditPrompt { name: String },
     EditUrlPrompt { name: String, kind: RemoteUrlKind },
     RemoveConfirm { name: String },
     Menu { name: String },

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -28,6 +28,7 @@ mod pull_reconcile_prompt;
 mod push_set_upstream_prompt;
 mod rebase_onto_confirm;
 mod remote_add_prompt;
+mod remote_edit_prompt;
 mod remote_edit_url_prompt;
 mod remote_remove_confirm;
 mod rename_branch_prompt;
@@ -300,6 +301,10 @@ pub(in super::super) struct PopoverHost {
     remote_name_input: Entity<components::TextInput>,
     remote_url_input: Entity<components::TextInput>,
     remote_url_edit_input: Entity<components::TextInput>,
+    remote_edit_username_input: Entity<components::TextInput>,
+    remote_edit_push_url_input: Entity<components::TextInput>,
+    remote_edit_same_push_url: bool,
+    remote_edit_same_push_toggle_focus_handle: FocusHandle,
     create_branch_input: Entity<components::TextInput>,
     create_branch_checkout_enabled: bool,
     create_branch_source_target: String,
@@ -868,7 +873,9 @@ pub(in super::super) fn popover_width_spec(kind: &PopoverKind) -> Option<Popover
         PopoverKind::Repo {
             kind:
                 RepoPopoverKind::Remote(
-                    RemotePopoverKind::AddPrompt | RemotePopoverKind::EditUrlPrompt { .. },
+                    RemotePopoverKind::AddPrompt
+                    | RemotePopoverKind::EditPrompt { .. }
+                    | RemotePopoverKind::EditUrlPrompt { .. },
                 ),
             ..
         }
@@ -1293,6 +1300,31 @@ impl PopoverHost {
             )
         });
 
+        let remote_edit_username_input = cx.new(|cx| {
+            components::TextInput::new(
+                components::TextInputOptions {
+                    placeholder: "username (optional)".into(),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
+
+        let remote_edit_push_url_input = cx.new(|cx| {
+            components::TextInput::new(
+                components::TextInputOptions {
+                    placeholder: "https://example.com/org/repo.git".into(),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
+
+        let remote_edit_same_push_toggle_focus_handle =
+            cx.focus_handle().tab_index(0).tab_stop(true);
+
         let create_branch_input = cx.new(|cx| {
             components::TextInput::new(
                 components::TextInputOptions {
@@ -1485,6 +1517,86 @@ impl PopoverHost {
                 }
             },
         ));
+        prompt_input_subscriptions.push(cx.observe(
+            &remote_edit_username_input,
+            |this, input, cx| {
+                if matches!(
+                    this.popover,
+                    Some(PopoverKind::Repo {
+                        kind: RepoPopoverKind::Remote(RemotePopoverKind::EditPrompt { .. }),
+                        ..
+                    })
+                ) {
+                    let user_text = input.read(cx).text().trim().to_string();
+                    let current_fetch = this
+                        .remote_url_edit_input
+                        .read_with(cx, |i, _| i.text().trim().to_string());
+                    let new_fetch = gitcomet_core::url_utils::embed_username_into_url(
+                        &current_fetch,
+                        if user_text.is_empty() {
+                            None
+                        } else {
+                            Some(&user_text)
+                        },
+                    );
+                    if new_fetch != current_fetch {
+                        let theme = this.theme;
+                        this.remote_url_edit_input.update(cx, |i, cx| {
+                            i.set_theme(theme, cx);
+                            i.set_text(new_fetch.clone(), cx);
+                            cx.notify();
+                        });
+                        if this.remote_edit_same_push_url {
+                            this.remote_edit_push_url_input.update(cx, |i, cx| {
+                                i.set_theme(theme, cx);
+                                i.set_text(new_fetch, cx);
+                                cx.notify();
+                            });
+                        }
+                    }
+                    cx.notify();
+                }
+            },
+        ));
+        prompt_input_subscriptions.push(cx.observe(&remote_url_edit_input, |this, input, cx| {
+            if matches!(
+                this.popover,
+                Some(PopoverKind::Repo {
+                    kind: RepoPopoverKind::Remote(RemotePopoverKind::EditPrompt { .. }),
+                    ..
+                })
+            ) {
+                let fetch_text = input.read(cx).text().trim().to_string();
+                let (user, _) =
+                    gitcomet_core::url_utils::extract_username_and_base_url(&fetch_text);
+                let user_str = user.unwrap_or_default();
+                let current_user = this
+                    .remote_edit_username_input
+                    .read_with(cx, |i, _| i.text().trim().to_string());
+                if user_str != current_user {
+                    let theme = this.theme;
+                    this.remote_edit_username_input.update(cx, |i, cx| {
+                        i.set_theme(theme, cx);
+                        i.set_text(user_str, cx);
+                        cx.notify();
+                    });
+                }
+                if this.remote_edit_same_push_url {
+                    let current_push = this
+                        .remote_edit_push_url_input
+                        .read_with(cx, |i, _| i.text().trim().to_string());
+                    if current_push != fetch_text {
+                        let theme = this.theme;
+                        this.remote_edit_push_url_input.update(cx, |i, cx| {
+                            i.set_theme(theme, cx);
+                            i.set_text(fetch_text, cx);
+                            cx.notify();
+                        });
+                    }
+                }
+                cx.notify();
+            }
+        }));
         for input in [&clone_repo_url_input, &clone_repo_parent_dir_input] {
             prompt_input_subscriptions.push(Self::prompt_enter_subscription(
                 input,
@@ -1582,6 +1694,28 @@ impl PopoverHost {
             },
             |this, _window, cx| this.submit_remote_edit_url(cx),
         ));
+        for input in [
+            &remote_name_input,
+            &remote_url_edit_input,
+            &remote_edit_username_input,
+            &remote_edit_push_url_input,
+        ] {
+            prompt_input_subscriptions.push(Self::prompt_enter_subscription(
+                input,
+                window,
+                cx,
+                |this| {
+                    matches!(
+                        this.popover,
+                        Some(PopoverKind::Repo {
+                            kind: RepoPopoverKind::Remote(RemotePopoverKind::EditPrompt { .. }),
+                            ..
+                        })
+                    )
+                },
+                |this, _window, cx| this.submit_remote_edit(cx),
+            ));
+        }
         prompt_input_subscriptions.push(Self::prompt_enter_subscription(
             &push_upstream_branch_input,
             window,
@@ -1755,6 +1889,10 @@ impl PopoverHost {
             remote_name_input,
             remote_url_input,
             remote_url_edit_input,
+            remote_edit_username_input,
+            remote_edit_push_url_input,
+            remote_edit_same_push_url: true,
+            remote_edit_same_push_toggle_focus_handle,
             create_branch_input,
             create_branch_checkout_enabled: true,
             create_branch_source_target: String::new(),
@@ -1819,6 +1957,8 @@ impl PopoverHost {
             &self.remote_name_input,
             &self.remote_url_input,
             &self.remote_url_edit_input,
+            &self.remote_edit_username_input,
+            &self.remote_edit_push_url_input,
             &self.create_branch_input,
             &self.stash_message_input,
             &self.commit_prompt_message_input,
@@ -2083,6 +2223,10 @@ impl PopoverHost {
                     ..
                 })
                 | Some(PopoverKind::Repo {
+                    kind: RepoPopoverKind::Remote(RemotePopoverKind::EditPrompt { .. }),
+                    ..
+                })
+                | Some(PopoverKind::Repo {
                     kind: RepoPopoverKind::Remote(RemotePopoverKind::EditUrlPrompt { .. }),
                     ..
                 })
@@ -2184,6 +2328,10 @@ impl PopoverHost {
             | Some(PopoverKind::PushSetUpstreamPrompt { .. })
             | Some(PopoverKind::Repo {
                 kind: RepoPopoverKind::Remote(RemotePopoverKind::AddPrompt),
+                ..
+            })
+            | Some(PopoverKind::Repo {
+                kind: RepoPopoverKind::Remote(RemotePopoverKind::EditPrompt { .. }),
                 ..
             })
             | Some(PopoverKind::Repo {
@@ -2715,6 +2863,81 @@ impl PopoverHost {
     pub(super) fn can_submit_remote_edit_url(&self, cx: &mut gpui::Context<Self>) -> bool {
         self.remote_url_edit_input
             .read_with(cx, |i, _| !i.text().trim().is_empty())
+    }
+
+    pub(super) fn can_submit_remote_edit(&self, cx: &mut gpui::Context<Self>) -> bool {
+        let name_valid = self
+            .remote_name_input
+            .read_with(cx, |i, _| !i.text().trim().is_empty());
+        let fetch_valid = self
+            .remote_url_edit_input
+            .read_with(cx, |i, _| !i.text().trim().is_empty());
+        let push_valid = if self.remote_edit_same_push_url {
+            true
+        } else {
+            self.remote_edit_push_url_input
+                .read_with(cx, |i, _| !i.text().trim().is_empty())
+        };
+        name_valid && fetch_valid && push_valid
+    }
+
+    pub(super) fn submit_remote_edit(&mut self, cx: &mut gpui::Context<Self>) {
+        let Some(PopoverKind::Repo {
+            repo_id,
+            kind: RepoPopoverKind::Remote(RemotePopoverKind::EditPrompt { name: old_name }),
+        }) = self.popover.clone()
+        else {
+            return;
+        };
+        if !self.can_submit_remote_edit(cx) {
+            return;
+        }
+
+        let new_name = self
+            .remote_name_input
+            .read_with(cx, |i, _| i.text().trim().to_string());
+        let fetch_url = self
+            .remote_url_edit_input
+            .read_with(cx, |i, _| i.text().trim().to_string());
+        let push_url = if self.remote_edit_same_push_url {
+            fetch_url.clone()
+        } else {
+            self.remote_edit_push_url_input
+                .read_with(cx, |i, _| i.text().trim().to_string())
+        };
+
+        // If name changed, rename remote first
+        if new_name != old_name {
+            self.store.dispatch(Msg::RenameRemote {
+                repo_id,
+                old_name: old_name.clone(),
+                new_name: new_name.clone(),
+            });
+        }
+
+        let effective_name = if new_name != old_name {
+            new_name
+        } else {
+            old_name
+        };
+
+        // Set Fetch URL
+        self.store.dispatch(Msg::SetRemoteUrl {
+            repo_id,
+            name: effective_name.clone(),
+            url: fetch_url,
+            kind: RemoteUrlKind::Fetch,
+        });
+
+        // Set Push URL
+        self.store.dispatch(Msg::SetRemoteUrl {
+            repo_id,
+            name: effective_name,
+            url: push_url,
+            kind: RemoteUrlKind::Push,
+        });
+
+        self.close_popover(cx);
     }
 
     pub(super) fn submit_remote_edit_url(&mut self, cx: &mut gpui::Context<Self>) {
@@ -3251,6 +3474,60 @@ impl PopoverHost {
                         input.set_text("", cx);
                         cx.notify();
                     });
+                    let focus = self
+                        .remote_name_input
+                        .read_with(cx, |i, _| i.focus_handle());
+                    window.focus(&focus, cx);
+                }
+                PopoverKind::Repo {
+                    repo_id,
+                    kind: RepoPopoverKind::Remote(RemotePopoverKind::EditPrompt { name }),
+                } => {
+                    let theme = self.theme;
+                    let fetch_url = self
+                        .state
+                        .repos
+                        .iter()
+                        .find(|r| r.id == *repo_id)
+                        .and_then(|r| match &r.remotes {
+                            Loadable::Ready(remotes) => remotes
+                                .iter()
+                                .find(|remote| remote.name.as_str() == name.as_str())
+                                .and_then(|remote| remote.url.clone()),
+                            _ => None,
+                        })
+                        .unwrap_or_default();
+
+                    let (username, _) =
+                        gitcomet_core::url_utils::extract_username_and_base_url(&fetch_url);
+                    let username_str = username.unwrap_or_default();
+
+                    self.remote_name_input.update(cx, |input, cx| {
+                        input.set_theme(theme, cx);
+                        input.set_text(name.clone(), cx);
+                        cx.notify();
+                    });
+
+                    self.remote_edit_username_input.update(cx, |input, cx| {
+                        input.set_theme(theme, cx);
+                        input.set_text(username_str, cx);
+                        cx.notify();
+                    });
+
+                    self.remote_url_edit_input.update(cx, |input, cx| {
+                        input.set_theme(theme, cx);
+                        input.set_text(fetch_url.clone(), cx);
+                        cx.notify();
+                    });
+
+                    self.remote_edit_push_url_input.update(cx, |input, cx| {
+                        input.set_theme(theme, cx);
+                        input.set_text(fetch_url, cx);
+                        cx.notify();
+                    });
+
+                    self.remote_edit_same_push_url = true;
+
                     let focus = self
                         .remote_name_input
                         .read_with(cx, |i, _| i.focus_handle());
@@ -4029,6 +4306,9 @@ impl PopoverHost {
             PopoverKind::Repo { repo_id, kind } => match kind {
                 RepoPopoverKind::Remote(remote_kind) => match remote_kind {
                     RemotePopoverKind::AddPrompt => remote_add_prompt::panel(self, repo_id, cx),
+                    RemotePopoverKind::EditPrompt { name } => {
+                        remote_edit_prompt::panel(self, repo_id, name, cx)
+                    }
                     RemotePopoverKind::EditUrlPrompt { name, kind } => {
                         remote_edit_url_prompt::panel(self, repo_id, name, kind, cx)
                     }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/remote.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/remote.rs
@@ -27,6 +27,20 @@ pub(super) fn model(_this: &PopoverHost, repo_id: RepoId, name: &str) -> Context
     });
     items.push(ContextMenuItem::Separator);
 
+    items.push(ContextMenuItem::Entry {
+        label: "Edit remote…".into(),
+        icon: Some("icons/pencil.svg".into()),
+        shortcut: None,
+        disabled: false,
+        action: Box::new(ContextMenuAction::OpenPopover {
+            kind: PopoverKind::remote(
+                repo_id,
+                RemotePopoverKind::EditPrompt {
+                    name: name.to_owned(),
+                },
+            ),
+        }),
+    });
     for (label, kind) in [
         ("Edit fetch URL…", RemoteUrlKind::Fetch),
         ("Edit push URL…", RemoteUrlKind::Push),

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
@@ -880,6 +880,11 @@ fn hash_repo_popover_kind<H: Hasher>(repo_id: RepoId, kind: &RepoPopoverKind, ha
                 9u8.hash(hasher);
                 repo_id.hash(hasher);
             }
+            RemotePopoverKind::EditPrompt { name } => {
+                54u8.hash(hasher);
+                repo_id.hash(hasher);
+                name.hash(hasher);
+            }
             RemotePopoverKind::EditUrlPrompt { name, kind } => {
                 13u8.hash(hasher);
                 repo_id.hash(hasher);

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/remote_edit_prompt.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/remote_edit_prompt.rs
@@ -1,0 +1,170 @@
+use super::*;
+
+fn same_as_fetch_toggle(
+    theme: AppTheme,
+    enabled: bool,
+    focus_handle: &FocusHandle,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Stateful<gpui::Div> {
+    let scaled_px = super::popover_scaled_px_fn(cx);
+    let border = if enabled {
+        theme.colors.status.success.foreground
+    } else {
+        theme.colors.stroke.default
+    };
+    let background = if enabled {
+        with_alpha(
+            theme.colors.status.success.foreground,
+            if theme.is_dark { 0.18 } else { 0.12 },
+        )
+    } else {
+        gpui::rgba(0x00000000)
+    };
+
+    focusable_toggle_row(
+        "remote_edit_same_push_url_toggle",
+        "remote_edit_same_push_url_toggle",
+        theme,
+        focus_handle,
+        cx,
+    )
+    .flex()
+    .gap_2()
+    .justify_start()
+    .child(
+        div()
+            .size(scaled_px(16.0))
+            .flex()
+            .items_center()
+            .justify_center()
+            .border_1()
+            .border_color(border)
+            .rounded(scaled_px(theme.radii.control * 0.5))
+            .bg(background)
+            .when(enabled, |this| {
+                this.child(crate::view::icons::svg_icon(
+                    "icons/check.svg",
+                    theme.colors.status.success.foreground,
+                    scaled_px(10.0),
+                ))
+            }),
+    )
+    .child(div().text_sm().child("Push URL same as Fetch URL"))
+}
+
+pub(super) fn panel(
+    this: &mut PopoverHost,
+    _repo_id: RepoId,
+    name: String,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Div {
+    let theme = this.theme;
+    let can_submit = this.can_submit_remote_edit(cx);
+    let scaled_px = super::popover_scaled_px_fn(cx);
+    let same_as_fetch = this.remote_edit_same_push_url;
+
+    div()
+        .flex()
+        .flex_col()
+        .w(scaled_px(680.0))
+        .child(popover_title(format!("Edit remote '{name}'")))
+        .child(div().border_t_1().border_color(theme.colors.stroke.default))
+        // Remote Name
+        .child(input_label(theme, "Remote Name"))
+        .child(
+            div()
+                .px_2()
+                .pb_1()
+                .w_full()
+                .min_w(px(0.0))
+                .child(this.remote_name_input.clone()),
+        )
+        // Username helper
+        .child(input_label(theme, "Username (embedded in URL)"))
+        .child(
+            div()
+                .px_2()
+                .pb_1()
+                .w_full()
+                .min_w(px(0.0))
+                .child(this.remote_edit_username_input.clone()),
+        )
+        // Fetch URL
+        .child(input_label(theme, "Fetch URL"))
+        .child(
+            div()
+                .px_2()
+                .pb_1()
+                .w_full()
+                .min_w(px(0.0))
+                .child(this.remote_url_edit_input.clone()),
+        )
+        // Toggle Push same as Fetch
+        .child(
+            div().px_2().py_1().child(
+                same_as_fetch_toggle(
+                    theme,
+                    same_as_fetch,
+                    &this.remote_edit_same_push_toggle_focus_handle,
+                    cx,
+                )
+                .on_click(cx.listener(|this, _e: &ClickEvent, _w, cx| {
+                    this.remote_edit_same_push_url = !this.remote_edit_same_push_url;
+                    if this.remote_edit_same_push_url {
+                        let fetch_url = this
+                            .remote_url_edit_input
+                            .read_with(cx, |i, _| i.text().trim().to_string());
+                        let theme = this.theme;
+                        this.remote_edit_push_url_input.update(cx, |input, cx| {
+                            input.set_theme(theme, cx);
+                            input.set_text(fetch_url, cx);
+                            cx.notify();
+                        });
+                    }
+                    cx.notify();
+                })),
+            ),
+        )
+        // Push URL (only shown or enabled when not same_as_fetch)
+        .when(!same_as_fetch, |this_div| {
+            this_div.child(input_label(theme, "Push URL")).child(
+                div()
+                    .px_2()
+                    .pb_1()
+                    .w_full()
+                    .min_w(px(0.0))
+                    .child(this.remote_edit_push_url_input.clone()),
+            )
+        })
+        .child(div().border_t_1().border_color(theme.colors.stroke.default))
+        // Footer buttons
+        .child(
+            div()
+                .px_2()
+                .py_1()
+                .flex()
+                .items_center()
+                .justify_between()
+                .child(
+                    cancel_button("edit_remote_cancel", "edit_remote_cancel_hint", theme)
+                        .focus_handle(this.remote_edit_focus.cancel.clone())
+                        .on_click(theme, cx, |this, _e, window, cx| {
+                            this.dismiss_prompt_popover(window, cx);
+                        }),
+                )
+                .child(
+                    components::Button::new("edit_remote_go", "Save")
+                        .focus_handle(this.remote_edit_focus.submit.clone())
+                        .disabled(!can_submit)
+                        .separated_end_slot(super::hotkey_hint(
+                            theme,
+                            "edit_remote_go_hint",
+                            "Enter",
+                        ))
+                        .style(components::ButtonStyle::Filled)
+                        .on_click(theme, cx, |this, _e, _w, cx| {
+                            this.submit_remote_edit(cx);
+                        }),
+                ),
+        )
+}

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/refs.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/refs.rs
@@ -883,6 +883,22 @@ fn remote_menu_lists_fetch_and_prune_actions(cx: &mut gpui::TestAppContext) {
             prune_tags,
             Some(ContextMenuAction::PruneLocalTags { repo_id: rid }) if rid == repo_id
         ));
+
+        let edit_remote = model.items.iter().find_map(|item| match item {
+            ContextMenuItem::Entry { label, action, .. } if label.as_ref() == "Edit remote…" => {
+                Some((**action).clone())
+            }
+            _ => None,
+        });
+        assert!(matches!(
+            edit_remote,
+            Some(ContextMenuAction::OpenPopover {
+                kind: PopoverKind::Repo {
+                    repo_id: rid,
+                    kind: RepoPopoverKind::Remote(RemotePopoverKind::EditPrompt { name }),
+                },
+            }) if rid == repo_id && name == remote_name
+        ));
     });
 }
 


### PR DESCRIPTION
Support for managing Git remotes directly from the GitComet UI. It adds the ability to edit an existing remote, change its name, update its fetch and push URLs, and persist those changes through the application state and Git backend. The implementation covers the complete flow from the UI interaction down to the Git command execution, including state management, effects, backend support, and integration tests.

### Remote editing UI

A new **Edit remote…** action is added to the remote context menu, allowing users to open an editing popover directly from an existing remote. The edit flow exposes the remote name and URL information and allows users to modify the configuration without having to remove and recreate the remote. 

The edit form also handles the relationship between fetch and push URLs. When the user chooses to keep the push URL synchronized with the fetch URL, the new fetch URL is automatically used for both values. Otherwise, the push URL can be edited independently. This makes it possible to support both the common single-URL setup and remotes that intentionally use different fetch and push endpoints. 

### Remote rename support

The PR adds a dedicated `RenameRemote` message to the state layer, carrying the repository ID, the previous remote name, and the new name. The reducer/effect flow then translates this state change into the corresponding remote operation.  

When submitting an edit, the implementation first determines whether the remote name has actually changed. If it has, a rename operation is dispatched before applying the updated URL configuration. This keeps remote identity changes explicit in the state/effect system while allowing the complete edit operation to be handled from a single UI flow. 

### Git backend support

Remote rename functionality is also wired through the Git backend layer, extending the existing remote management API with `rename_remote_with_output`. This allows the higher-level state and UI layers to use the same command/effect architecture already used for other remote operations. 

The implementation is accompanied by integration coverage that verifies that a remote can be renamed successfully, that the resulting remote list contains the new name, and that subsequent operations continue to work using the renamed remote. The test also verifies the command exit status before checking the resulting repository state. 

### URL and remote configuration handling

The changes extend the remote-management flow beyond simply changing a display value. Remote configuration is treated as an actual Git operation, ensuring that changes made through the UI are propagated to the underlying repository.

The edit flow reads the updated remote name and fetch URL from the corresponding inputs, determines the appropriate push URL based on the synchronization setting, and then applies the required operations. This provides a consistent path for modifying both remote metadata and its associated URLs. 

### State and effects

The new functionality is integrated into the existing state-driven architecture rather than performing Git operations directly from the UI. A `RenameRemote` message is emitted by the UI layer, handled by the reducer/effect system, and ultimately translated into the backend operation. This keeps remote management consistent with the application's existing command and effect patterns.  

### Testing

Integration coverage has been expanded to validate the remote rename lifecycle, including:

* Renaming an existing remote from its original name to a new name.
* Verifying that the Git operation succeeds with an exit code of `0`.
* Reloading/listing the repository remotes after the operation.
* Confirming that the renamed remote is present under the expected name.
* Continuing to use the renamed remote for subsequent remote-management operations. 

Additional UI-related test coverage is included alongside the remote popover and related view components, helping ensure that the new editing flow is integrated into the existing GitComet UI architecture. 


