### PR TITLE
feat: implement force branch creation and checkout functionality

### DIFF
--- a/crates/gitcomet-core/src/services.rs
+++ b/crates/gitcomet-core/src/services.rs
@@ -645,6 +645,14 @@ pub trait GitRepository: Send + Sync {
     }
 
     fn create_branch(&self, name: &str, target: &CommitId) -> Result<()>;
+    /// Create the local branch `name` at `target`, or reset it there when a
+    /// branch with that name already exists, and check it out. The git
+    /// equivalent is `git checkout -B <name> <target>`.
+    fn create_branch_force_and_checkout(&self, _name: &str, _target: &CommitId) -> Result<()> {
+        Err(Error::new(ErrorKind::Unsupported(
+            "force branch creation and checkout is not implemented for this backend",
+        )))
+    }
     fn rename_branch(&self, _old_name: &str, _new_name: &str) -> Result<()> {
         Err(Error::new(ErrorKind::Unsupported(
             "branch renaming is not implemented for this backend",

--- a/crates/gitcomet-git-gix/src/repo/mod.rs
+++ b/crates/gitcomet-git-gix/src/repo/mod.rs
@@ -582,6 +582,10 @@ impl GitRepository for GixRepo {
         self.checkout_branch_impl(name)
     }
 
+    fn create_branch_force_and_checkout(&self, name: &str, target: &CommitId) -> Result<()> {
+        self.create_branch_force_and_checkout_impl(name, target)
+    }
+
     fn checkout_remote_branch(&self, remote: &str, branch: &str, local_branch: &str) -> Result<()> {
         self.checkout_remote_branch_impl(remote, branch, local_branch)
     }

--- a/crates/gitcomet-git-gix/src/repo/porcelain.rs
+++ b/crates/gitcomet-git-gix/src/repo/porcelain.rs
@@ -519,6 +519,26 @@ impl GixRepo {
         run_git_simple(cmd, "git checkout")
     }
 
+    /// `git checkout -B <name> <target>`: create the branch at `target`, or
+    /// reset an existing branch of that name to `target`, then check it out.
+    ///
+    /// Unlike a `git branch -f` + `git checkout` pair this also handles the
+    /// branch that is checked out in this worktree (the reset then behaves like
+    /// `git reset --hard <target>`), which is exactly the "overwrite and
+    /// checkout" case the caller offers the user.
+    pub(super) fn create_branch_force_and_checkout_impl(
+        &self,
+        name: &str,
+        target: &CommitId,
+    ) -> Result<()> {
+        validate_ref_like_arg(name, "branch name")?;
+        validate_ref_like_arg(target.as_ref(), "branch target")?;
+
+        let mut cmd = self.git_workdir_cmd();
+        cmd.arg("checkout").arg("-B").arg(name).arg(target.as_ref());
+        run_git_simple(cmd, "git checkout -B")
+    }
+
     pub(super) fn checkout_remote_branch_impl(
         &self,
         remote: &str,

--- a/crates/gitcomet-git-gix/tests/status_integration.rs
+++ b/crates/gitcomet-git-gix/tests/status_integration.rs
@@ -5846,6 +5846,93 @@ fn checkout_branch_switches_head_to_target_branch() {
 }
 
 #[test]
+fn create_branch_force_and_checkout_resets_existing_branch_and_checks_it_out() {
+    if !require_git_shell_for_status_integration_tests() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+
+    run_git(repo, &["init", "-b", "main"]);
+    run_git(repo, &["config", "user.email", "you@example.com"]);
+    run_git(repo, &["config", "user.name", "You"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+
+    write(repo, "a.txt", "one\n");
+    run_git(repo, &["add", "a.txt"]);
+    run_git(
+        repo,
+        &["-c", "commit.gpgsign=false", "commit", "-m", "init"],
+    );
+    let first_commit = run_git_output(repo, &["rev-parse", "HEAD"]);
+
+    write(repo, "b.txt", "two\n");
+    run_git(repo, &["add", "b.txt"]);
+    run_git(
+        repo,
+        &["-c", "commit.gpgsign=false", "commit", "-m", "second"],
+    );
+
+    // `feature` exists and points at the second commit while main stays there.
+    run_git(repo, &["branch", "feature"]);
+    run_git(repo, &["checkout", "main"]);
+
+    let backend = GixBackend;
+    let opened = backend.open(repo).unwrap();
+    opened
+        .create_branch_force_and_checkout(
+            "feature",
+            &gitcomet_core::domain::CommitId(first_commit.clone().into()),
+        )
+        .unwrap();
+
+    assert_eq!(
+        run_git_output(repo, &["rev-parse", "--abbrev-ref", "HEAD"]),
+        "feature"
+    );
+    assert_eq!(
+        run_git_output(repo, &["rev-parse", "HEAD"]),
+        first_commit,
+        "the existing branch was moved to the target commit"
+    );
+}
+
+#[test]
+fn create_branch_force_and_checkout_creates_missing_branch_and_checks_it_out() {
+    if !require_git_shell_for_status_integration_tests() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+
+    run_git(repo, &["init", "-b", "main"]);
+    run_git(repo, &["config", "user.email", "you@example.com"]);
+    run_git(repo, &["config", "user.name", "You"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+
+    write(repo, "a.txt", "one\n");
+    run_git(repo, &["add", "a.txt"]);
+    run_git(
+        repo,
+        &["-c", "commit.gpgsign=false", "commit", "-m", "init"],
+    );
+
+    let backend = GixBackend;
+    let opened = backend.open(repo).unwrap();
+    opened
+        .create_branch_force_and_checkout(
+            "feature",
+            &gitcomet_core::domain::CommitId("HEAD".into()),
+        )
+        .unwrap();
+
+    assert_eq!(
+        run_git_output(repo, &["rev-parse", "--abbrev-ref", "HEAD"]),
+        "feature"
+    );
+}
+
+#[test]
 fn delete_branch_force_removes_unmerged_branch() {
     if !require_git_shell_for_status_integration_tests() {
         return;

--- a/crates/gitcomet-state/src/msg/effect.rs
+++ b/crates/gitcomet-state/src/msg/effect.rs
@@ -284,6 +284,9 @@ pub enum Effect {
         repo_id: RepoId,
         name: String,
         target: String,
+        /// Reset the branch to `target` first when a branch with this name
+        /// already exists, instead of failing with "already exists".
+        force: bool,
     },
     RenameBranch {
         repo_id: RepoId,

--- a/crates/gitcomet-state/src/msg/message.rs
+++ b/crates/gitcomet-state/src/msg/message.rs
@@ -518,6 +518,9 @@ pub enum Msg {
         repo_id: RepoId,
         name: String,
         target: String,
+        /// Reset the branch to `target` first when a branch with this name
+        /// already exists, instead of failing with "already exists".
+        force: bool,
     },
     RenameBranch {
         repo_id: RepoId,

--- a/crates/gitcomet-state/src/store/effects.rs
+++ b/crates/gitcomet-state/src/store/effects.rs
@@ -2134,9 +2134,10 @@ pub(super) fn schedule_effect(
             repo_id,
             name,
             target,
+            force,
         } => {
             repo_actions::schedule_create_branch_and_checkout(
-                executor, repos, msg_tx, repo_id, name, target,
+                executor, repos, msg_tx, repo_id, name, target, force,
             );
         }
         Effect::RenameBranch {

--- a/crates/gitcomet-state/src/store/effects/repo_actions.rs
+++ b/crates/gitcomet-state/src/store/effects/repo_actions.rs
@@ -233,12 +233,21 @@ pub(super) fn schedule_create_branch_and_checkout(
     repo_id: RepoId,
     name: String,
     target: String,
+    force: bool,
 ) {
     spawn_with_repo(executor, repos, repo_id, msg_tx, move |repo, msg_tx| {
         let target = gitcomet_core::domain::CommitId(target.into());
-        let created = repo.create_branch(&name, &target);
+        let created = if force {
+            repo.create_branch_force_and_checkout(&name, &target)
+        } else {
+            repo.create_branch(&name, &target)
+        };
         let refresh = created.is_ok();
-        let result = created.and_then(|()| repo.checkout_branch(&name));
+        let result = if force {
+            created
+        } else {
+            created.and_then(|()| repo.checkout_branch(&name))
+        };
         if refresh {
             send_or_log(&msg_tx, Msg::RefreshBranches { repo_id });
         }

--- a/crates/gitcomet-state/src/store/reducer.rs
+++ b/crates/gitcomet-state/src/store/reducer.rs
@@ -1183,12 +1183,13 @@ fn reduce_inner(
             repo_id,
             name,
             target,
+            force,
         } => {
             if let Some(repo_state) = state.repos.iter_mut().find(|r| r.id == repo_id) {
                 repo_state.set_detached_head_commit(None);
             }
             begin_head_changing_local_action(state, repo_id);
-            actions_emit_effects::create_branch_and_checkout(repo_id, name, target)
+            actions_emit_effects::create_branch_and_checkout(repo_id, name, target, force)
         }
         Msg::RenameBranch {
             repo_id,

--- a/crates/gitcomet-state/src/store/reducer/actions_emit_effects.rs
+++ b/crates/gitcomet-state/src/store/reducer/actions_emit_effects.rs
@@ -82,11 +82,13 @@ pub(super) fn create_branch_and_checkout(
     repo_id: RepoId,
     name: String,
     target: String,
+    force: bool,
 ) -> Vec<Effect> {
     vec![Effect::CreateBranchAndCheckout {
         repo_id,
         name,
         target,
+        force,
     }]
 }
 

--- a/crates/gitcomet-state/src/store/tests/actions_emit_effects.rs
+++ b/crates/gitcomet-state/src/store/tests/actions_emit_effects.rs
@@ -2061,6 +2061,7 @@ fn additional_routing_messages_emit_effects_and_update_counters() {
             repo_id,
             name: "feature/new".to_string(),
             target: "HEAD".to_string(),
+            force: false,
         },
     );
     assert!(matches!(
@@ -2068,8 +2069,31 @@ fn additional_routing_messages_emit_effects_and_update_counters() {
         [Effect::CreateBranchAndCheckout {
             repo_id: RepoId(1),
             target,
+            force: false,
             ..
         }] if target == "HEAD"
+    ));
+
+    // The force flag travels with the message: an overwrite request still
+    // reaches the effect layer, just marked.
+    let effects = reduce(
+        &mut repos,
+        &id_alloc,
+        &mut state,
+        Msg::CreateBranchAndCheckout {
+            repo_id,
+            name: "feature/new".to_string(),
+            target: "HEAD".to_string(),
+            force: true,
+        },
+    );
+    assert!(matches!(
+        effects.as_slice(),
+        [Effect::CreateBranchAndCheckout {
+            repo_id: RepoId(1),
+            force: true,
+            ..
+        }]
     ));
 
     let effects = reduce(

--- a/crates/gitcomet-state/src/store/tests/actions_emit_effects.rs
+++ b/crates/gitcomet-state/src/store/tests/actions_emit_effects.rs
@@ -2184,7 +2184,7 @@ fn additional_routing_messages_emit_effects_and_update_counters() {
     ));
 
     assert_eq!(
-        state.repos[0].local_actions_in_flight, 9,
+        state.repos[0].local_actions_in_flight, 10,
         "expected begin_local_action for all routed local-action messages"
     );
 

--- a/crates/gitcomet-state/src/store/tests/effects.rs
+++ b/crates/gitcomet-state/src/store/tests/effects.rs
@@ -3921,7 +3921,10 @@ impl GitRepository for RecordingCheckoutRepo {
         self.calls
             .lock()
             .expect("checkout recording mutex")
-            .push(format!("force-create-and-checkout {name} {}", target.as_ref()));
+            .push(format!(
+                "force-create-and-checkout {name} {}",
+                target.as_ref()
+            ));
         Ok(())
     }
     fn delete_branch(&self, _name: &str) -> Result<()> {

--- a/crates/gitcomet-state/src/store/tests/effects.rs
+++ b/crates/gitcomet-state/src/store/tests/effects.rs
@@ -3917,6 +3917,13 @@ impl GitRepository for RecordingCheckoutRepo {
             .push(format!("create {name} {}", target.as_ref()));
         Ok(())
     }
+    fn create_branch_force_and_checkout(&self, name: &str, target: &CommitId) -> Result<()> {
+        self.calls
+            .lock()
+            .expect("checkout recording mutex")
+            .push(format!("force-create-and-checkout {name} {}", target.as_ref()));
+        Ok(())
+    }
     fn delete_branch(&self, _name: &str) -> Result<()> {
         unsupported_repo_result()
     }
@@ -4189,6 +4196,7 @@ fn create_branch_and_checkout_effect_requests_branch_and_worktree_reload_on_succ
             repo_id,
             name: "feature".to_string(),
             target: "HEAD".to_string(),
+            force: false,
         },
     );
 
@@ -4199,6 +4207,46 @@ fn create_branch_and_checkout_effect_requests_branch_and_worktree_reload_on_succ
             "create feature HEAD".to_string(),
             "checkout feature".to_string()
         ]
+    );
+}
+
+#[test]
+fn create_branch_and_checkout_force_effect_skips_separate_create_and_checkout() {
+    let repo_id = RepoId(704);
+    let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let backend: Arc<dyn GitBackend> = Arc::new(PanicOpenBackend);
+    let repo: Arc<dyn GitRepository> = Arc::new(RecordingCheckoutRepo {
+        spec: RepoSpec {
+            workdir: unique_temp_path("gitcomet-create-branch-and-checkout-force-effect"),
+        },
+        calls: Arc::clone(&calls),
+    });
+    let repos: FxHashMap<RepoId, Arc<dyn GitRepository>> = {
+        let mut repos = FxHashMap::default();
+        repos.insert(repo_id, repo);
+        repos
+    };
+    let executor = super::executor::TaskExecutor::new(1);
+    let (msg_tx, msg_rx) = std::sync::mpsc::channel::<Msg>();
+
+    schedule_effect_for_test(
+        &executor,
+        &executor,
+        &backend,
+        &repos,
+        msg_tx,
+        Effect::CreateBranchAndCheckout {
+            repo_id,
+            name: "feature".to_string(),
+            target: "HEAD".to_string(),
+            force: true,
+        },
+    );
+
+    wait_for_checkout_refresh_messages(&msg_rx, repo_id, true, true);
+    assert_eq!(
+        *calls.lock().expect("checkout recording mutex"),
+        vec!["force-create-and-checkout feature HEAD".to_string()]
     );
 }
 
@@ -5154,6 +5202,7 @@ fn schedule_effect_dispatches_many_variants_with_repo_present() {
                 repo_id,
                 name: "topic2".to_string(),
                 target: "HEAD".to_string(),
+                force: false,
             },
             1,
         ),

--- a/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod_helpers.rs
@@ -4512,6 +4512,14 @@ pub(super) enum PopoverKind {
     MergeAbortConfirm {
         repo_id: RepoId,
     },
+    /// Shown when "Create branch from…" with Checkout enabled names a branch
+    /// that already exists locally. Asks whether to check out the existing
+    /// branch, overwrite it with the target commit and check it out, or cancel.
+    BranchExistsPrompt {
+        repo_id: RepoId,
+        name: String,
+        target: String,
+    },
     ForceDeleteBranchConfirm {
         repo_id: RepoId,
         name: String,

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -797,10 +797,11 @@ fn popover_anchor_corner(kind: &PopoverKind) -> Anchor {
         }
         | PopoverKind::PushSetUpstreamPrompt { .. }
         | PopoverKind::ForcePushConfirm { .. }
-        | PopoverKind::CherryPickCommitConfirm { .. }            | PopoverKind::MergeCommitConfirm { .. }
-            | PopoverKind::MergeAbortConfirm { .. }
-            | PopoverKind::BranchExistsPrompt { .. }
-            | PopoverKind::ForceDeleteBranchConfirm { .. }
+        | PopoverKind::CherryPickCommitConfirm { .. }
+        | PopoverKind::MergeCommitConfirm { .. }
+        | PopoverKind::MergeAbortConfirm { .. }
+        | PopoverKind::BranchExistsPrompt { .. }
+        | PopoverKind::ForceDeleteBranchConfirm { .. }
         | PopoverKind::ForceRemoveWorktreeConfirm { .. }
         | PopoverKind::PullReconcilePrompt { .. }
         | PopoverKind::RebaseOntoConfirm { .. }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover.rs
@@ -5,6 +5,7 @@ mod add_repo_menu;
 mod add_to_gitignore_prompt;
 mod app_menu;
 mod author_filter;
+mod branch_exists_prompt;
 mod branch_picker;
 mod checkout_remote_branch_prompt;
 mod cherry_pick_commit_confirm;
@@ -796,10 +797,10 @@ fn popover_anchor_corner(kind: &PopoverKind) -> Anchor {
         }
         | PopoverKind::PushSetUpstreamPrompt { .. }
         | PopoverKind::ForcePushConfirm { .. }
-        | PopoverKind::CherryPickCommitConfirm { .. }
-        | PopoverKind::MergeCommitConfirm { .. }
-        | PopoverKind::MergeAbortConfirm { .. }
-        | PopoverKind::ForceDeleteBranchConfirm { .. }
+        | PopoverKind::CherryPickCommitConfirm { .. }            | PopoverKind::MergeCommitConfirm { .. }
+            | PopoverKind::MergeAbortConfirm { .. }
+            | PopoverKind::BranchExistsPrompt { .. }
+            | PopoverKind::ForceDeleteBranchConfirm { .. }
         | PopoverKind::ForceRemoveWorktreeConfirm { .. }
         | PopoverKind::PullReconcilePrompt { .. }
         | PopoverKind::RebaseOntoConfirm { .. }
@@ -863,7 +864,8 @@ pub(in super::super) fn popover_width_spec(kind: &PopoverKind) -> Option<Popover
         PopoverKind::ResetPrompt { .. }
         | PopoverKind::RebaseOntoConfirm { .. }
         | PopoverKind::CherryPickCommitConfirm { .. }
-        | PopoverKind::MergeCommitConfirm { .. } => Some(DIALOG_380_WIDTH),
+        | PopoverKind::MergeCommitConfirm { .. }
+        | PopoverKind::BranchExistsPrompt { .. } => Some(DIALOG_380_WIDTH),
         PopoverKind::MergeAbortConfirm { .. } => Some(DIALOG_360_WIDTH),
         PopoverKind::ForceRemoveWorktreeConfirm { .. } => Some(DIALOG_460_WIDTH),
         PopoverKind::PullReconcilePrompt { .. } | PopoverKind::AddToGitignorePrompt { .. } => {
@@ -2513,6 +2515,26 @@ impl PopoverHost {
         }
     }
 
+    /// Whether a local branch with this name is already known for the repo.
+    ///
+    /// `repo.branches` is loaded for every open repo well before the user can
+    /// reach the create-branch prompt, so a missing load means "unknown" and
+    /// the caller falls back to the plain create (git then reports the
+    /// collision itself) rather than blocking on a load.
+    fn local_branch_exists(&self, repo_id: RepoId, name: &str) -> bool {
+        self.state
+            .repos
+            .iter()
+            .find(|repo| repo.id == repo_id)
+            .and_then(|repo| match &repo.branches {
+                Loadable::Ready(branches) => {
+                    Some(branches.iter().any(|branch| branch.name == name))
+                }
+                _ => None,
+            })
+            .unwrap_or(false)
+    }
+
     fn can_submit_create_branch(&self, cx: &mut gpui::Context<Self>) -> bool {
         self.create_branch_prompt_repo_and_target().is_some()
             && self
@@ -2560,10 +2582,26 @@ impl PopoverHost {
         };
 
         if checkout {
+            // A branch with this name may already exist. Ask first instead of
+            // letting git fail with "already exists": the user may want to
+            // check out the existing branch, or overwrite it with this commit.
+            if self.local_branch_exists(repo_id, &name) {
+                self.open_popover_centered(
+                    PopoverKind::BranchExistsPrompt {
+                        repo_id,
+                        name,
+                        target,
+                    },
+                    window,
+                    cx,
+                );
+                return;
+            }
             self.store.dispatch(Msg::CreateBranchAndCheckout {
                 repo_id,
                 name,
                 target,
+                force: false,
             });
         } else {
             self.store.dispatch(Msg::CreateBranch {
@@ -4010,6 +4048,11 @@ impl PopoverHost {
                 remote,
                 branch,
             } => checkout_remote_branch_prompt::panel(self, repo_id, remote, branch, cx),
+            PopoverKind::BranchExistsPrompt {
+                repo_id,
+                name,
+                target,
+            } => branch_exists_prompt::panel(self, repo_id, name, target, cx),
             PopoverKind::StashPrompt => stash_prompt::panel(self, cx),
             PopoverKind::CommitPrompt { repo_id } => commit_prompt::panel(self, repo_id, cx),
             PopoverKind::StashPickerPrompt { repo_id, purpose } => {

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_exists_prompt.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_exists_prompt.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+pub(super) fn panel(
+    this: &mut PopoverHost,
+    repo_id: RepoId,
+    name: String,
+    target: String,
+    cx: &mut gpui::Context<PopoverHost>,
+) -> gpui::Div {
+    let theme = this.theme;
+    let target_short: SharedString = {
+        let sha = target.as_str();
+        let short = sha.get(0..7).unwrap_or(sha);
+        if sha.len() > short.len() {
+            format!("{short}…").into()
+        } else {
+            short.into()
+        }
+    };
+
+    let overwrite_name = name.clone();
+    let overwrite_target = target.clone();
+    let overwrite = move |this: &mut PopoverHost, cx: &mut gpui::Context<PopoverHost>| {
+        this.store.dispatch(Msg::CreateBranchAndCheckout {
+            repo_id,
+            name: overwrite_name.clone(),
+            target: overwrite_target.clone(),
+            force: true,
+        });
+        this.close_popover(cx);
+    };
+    let checkout_existing_name = name.clone();
+    let checkout_existing = move |this: &mut PopoverHost, cx: &mut gpui::Context<PopoverHost>| {
+        this.store.dispatch(Msg::CheckoutBranch {
+            repo_id,
+            name: checkout_existing_name.clone(),
+        });
+        this.close_popover(cx);
+    };
+
+    ConfirmDialog::new("Branch already exists", DIALOG_380_WIDTH)
+        .text(
+            theme,
+            format!("A local branch named '{name}' already exists."),
+        )
+        .mono_value(theme, format!("Target: {target_short}"))
+        .note(
+            theme,
+            "Overwriting moves the branch to the target commit and checks it out.",
+        )
+        .render(
+            theme,
+            dialog_cancel_button("branch_exists_cancel", "branch_exists_cancel_hint", theme, cx),
+            div()
+                .flex()
+                .items_center()
+                .gap_1()
+                .child(
+                    components::Button::new("branch_exists_checkout_existing", "Checkout existing")
+                        .style(components::ButtonStyle::Outlined)
+                        .on_click(theme, cx, {
+                            let checkout_existing = checkout_existing.clone();
+                            move |this, _e, _w, cx| checkout_existing(this, cx)
+                        }),
+                )
+                .child(
+                    components::Button::new("branch_exists_overwrite", "Overwrite & checkout")
+                        .style(components::ButtonStyle::Filled)
+                        .on_click(theme, cx, move |this, _e, _w, cx| overwrite(this, cx)),
+                ),
+            cx,
+        )
+}

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_exists_prompt.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_exists_prompt.rs
@@ -50,7 +50,12 @@ pub(super) fn panel(
         )
         .render(
             theme,
-            dialog_cancel_button("branch_exists_cancel", "branch_exists_cancel_hint", theme, cx),
+            dialog_cancel_button(
+                "branch_exists_cancel",
+                "branch_exists_cancel_hint",
+                theme,
+                cx,
+            ),
             div()
                 .flex()
                 .items_center()

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_picker.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/branch_picker.rs
@@ -475,6 +475,7 @@ pub(super) fn activate(
                 repo_id,
                 name,
                 target,
+                force: false,
             });
             this.close_popover(cx);
         }

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
@@ -171,6 +171,7 @@ fn repo_for_popover<'a>(state: &'a AppState, popover: &PopoverKind) -> Option<&'
         | PopoverKind::CherryPickCommitConfirm { repo_id, .. }
         | PopoverKind::MergeCommitConfirm { repo_id, .. }
         | PopoverKind::MergeAbortConfirm { repo_id }
+        | PopoverKind::BranchExistsPrompt { repo_id, .. }
         | PopoverKind::ForceDeleteBranchConfirm { repo_id, .. }
         | PopoverKind::ForceRemoveWorktreeConfirm { repo_id, .. }
         | PopoverKind::DiscardChangesConfirm { repo_id, .. }
@@ -367,6 +368,7 @@ fn hash_repo_for_popover<H: Hasher>(repo: &RepoState, popover: &PopoverKind, has
         | PopoverKind::CherryPickCommitConfirm { .. }
         | PopoverKind::MergeCommitConfirm { .. }
         | PopoverKind::MergeAbortConfirm { .. }
+        | PopoverKind::BranchExistsPrompt { .. }
         | PopoverKind::ResetPrompt { .. }
         | PopoverKind::CheckoutRemoteBranchPrompt { .. }
         | PopoverKind::CreateTagPrompt { .. }
@@ -561,6 +563,12 @@ fn hash_popover_kind<H: Hasher>(kind: &PopoverKind, hasher: &mut H) {
             83u8.hash(hasher);
             repo_id.hash(hasher);
             commit_id.hash(hasher);
+        }
+        PopoverKind::BranchExistsPrompt { repo_id, name, target } => {
+            84u8.hash(hasher);
+            repo_id.hash(hasher);
+            name.hash(hasher);
+            target.hash(hasher);
         }
         PopoverKind::ForceDeleteBranchConfirm { repo_id, name } => {
             32u8.hash(hasher);

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
@@ -564,7 +564,11 @@ fn hash_popover_kind<H: Hasher>(kind: &PopoverKind, hasher: &mut H) {
             repo_id.hash(hasher);
             commit_id.hash(hasher);
         }
-        PopoverKind::BranchExistsPrompt { repo_id, name, target } => {
+        PopoverKind::BranchExistsPrompt {
+            repo_id,
+            name,
+            target,
+        } => {
             84u8.hash(hasher);
             repo_id.hash(hasher);
             name.hash(hasher);

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/branch.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/branch.rs
@@ -133,6 +133,26 @@ impl GitRepository for TrackingRepo {
         Ok(())
     }
 
+    fn create_branch_force_and_checkout(&self, name: &str, _target: &CommitId) -> Result<()> {
+        self.actions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(format!("force-create-and-checkout:{name}"));
+
+        let mut branches = self
+            .branches
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !branches.iter().any(|branch| branch == name) {
+            branches.push(name.to_string());
+        }
+        *self
+            .current_branch
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = name.to_string();
+        Ok(())
+    }
+
     fn delete_branch(&self, name: &str) -> Result<()> {
         let mut branches = self
             .branches
@@ -919,6 +939,160 @@ fn create_branch_popover_enter_creates_and_closes(cx: &mut gpui::TestAppContext)
     wait_until("create-branch repo actions", || {
         repo.actions() == vec!["create:feature".to_string(), "checkout:feature".to_string()]
     });
+}
+
+fn open_create_branch_prompt_for_enter_test(
+    cx: &mut gpui::VisualTestContext,
+    view: &gpui::Entity<GitCometView>,
+    repo_id: RepoId,
+) {
+    cx.update(|window, app| {
+        app.bind_keys([gpui::KeyBinding::new(
+            "enter",
+            crate::kit::Enter,
+            Some("TextInput"),
+        )]);
+        let _ = window.draw(app);
+    });
+
+    cx.update(|window, app| {
+        view.update(app, |this, cx| {
+            this.popover_host.update(cx, |host, cx| {
+                host.open_popover_at(
+                    PopoverKind::CreateBranchFromRefPrompt {
+                        repo_id,
+                        target: "HEAD".to_string(),
+                        source_selectable: false,
+                        name_prefix: String::new(),
+                    },
+                    gpui::point(gpui::px(120.0), gpui::px(72.0)),
+                    window,
+                    cx,
+                );
+            });
+        });
+    });
+    cx.update(|window, app| {
+        let _ = window.draw(app);
+    });
+}
+
+/// Typing an existing branch name into "Create branch from…" with Checkout on
+/// used to fail with git's "already exists" error. Instead the prompt should
+/// hand over to the BranchExistsPrompt, and "Overwrite & checkout" should
+/// dispatch the force create-and-checkout action.
+#[gpui::test]
+fn create_branch_popover_existing_name_offers_overwrite_and_checkout(
+    cx: &mut gpui::TestAppContext,
+) {
+    let (store, events, repo, _workdir) = create_tracking_store("branch-exists-overwrite");
+    let repo_id = store.snapshot().active_repo.expect("expected active repo");
+    wait_until("tracked repo branches to load", || {
+        store
+            .snapshot()
+            .repos
+            .iter()
+            .find(|r| r.id == repo_id)
+            .is_some_and(|r| matches!(r.branches, Loadable::Ready(_)))
+    });
+    let store_for_view = store.clone();
+    let (view, cx) = cx
+        .add_window_view(|window, cx| GitCometView::new(store_for_view, events, None, window, cx));
+
+    open_create_branch_prompt_for_enter_test(cx, &view, repo_id);
+
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            this.popover_host.update(cx, |host, cx| {
+                host.create_branch_input
+                    .update(cx, |input, cx| input.set_text("main", cx));
+            });
+        });
+    });
+    cx.update(|window, app| {
+        let _ = window.draw(app);
+    });
+
+    cx.simulate_keystrokes("enter");
+    cx.run_until_parked();
+    cx.update(|window, app| {
+        let _ = window.draw(app);
+    });
+
+    cx.update(|_window, app| {
+        let host = view.read(app).popover_host.read(app);
+        assert!(
+            host.is_open(),
+            "expected the existing-name submit to keep a popover open"
+        );
+        assert!(
+            matches!(host.popover, Some(PopoverKind::BranchExistsPrompt { .. })),
+            "expected the BranchExistsPrompt, got {:?}",
+            host.popover
+        );
+    });
+    std::thread::sleep(Duration::from_millis(100));
+    assert!(
+        repo.actions().is_empty(),
+        "expected no git actions before the user chooses"
+    );
+
+    click_debug_selector(cx, "branch_exists_overwrite");
+
+    wait_until("force create-and-checkout repo action", || {
+        repo.actions() == vec!["force-create-and-checkout:main".to_string()]
+    });
+    let is_open = cx.update(|_window, app| view.read(app).popover_host.read(app).is_open());
+    assert!(!is_open, "expected Overwrite to close the popover");
+}
+
+/// The other BranchExistsPrompt choice: check out the existing branch as-is
+/// rather than moving it.
+#[gpui::test]
+fn create_branch_popover_existing_name_can_checkout_existing_branch(
+    cx: &mut gpui::TestAppContext,
+) {
+    let (store, events, repo, _workdir) = create_tracking_store("branch-exists-checkout");
+    let repo_id = store.snapshot().active_repo.expect("expected active repo");
+    wait_until("tracked repo branches to load", || {
+        store
+            .snapshot()
+            .repos
+            .iter()
+            .find(|r| r.id == repo_id)
+            .is_some_and(|r| matches!(r.branches, Loadable::Ready(_)))
+    });
+    let store_for_view = store.clone();
+    let (view, cx) = cx
+        .add_window_view(|window, cx| GitCometView::new(store_for_view, events, None, window, cx));
+
+    open_create_branch_prompt_for_enter_test(cx, &view, repo_id);
+
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            this.popover_host.update(cx, |host, cx| {
+                host.create_branch_input
+                    .update(cx, |input, cx| input.set_text("main", cx));
+            });
+        });
+    });
+    cx.update(|window, app| {
+        let _ = window.draw(app);
+    });
+
+    cx.simulate_keystrokes("enter");
+    cx.run_until_parked();
+    cx.update(|window, app| {
+        let _ = window.draw(app);
+    });
+
+    click_debug_selector(cx, "branch_exists_checkout_existing");
+
+    wait_until("checkout-existing repo action", || {
+        repo.actions() == vec!["checkout:main".to_string()]
+    });
+    let is_open = cx.update(|_window, app| view.read(app).popover_host.read(app).is_open());
+    assert!(!is_open, "expected Checkout existing to close the popover");
 }
 
 #[gpui::test]

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/branch.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/branch.rs
@@ -1049,9 +1049,7 @@ fn create_branch_popover_existing_name_offers_overwrite_and_checkout(
 /// The other BranchExistsPrompt choice: check out the existing branch as-is
 /// rather than moving it.
 #[gpui::test]
-fn create_branch_popover_existing_name_can_checkout_existing_branch(
-    cx: &mut gpui::TestAppContext,
-) {
+fn create_branch_popover_existing_name_can_checkout_existing_branch(cx: &mut gpui::TestAppContext) {
     let (store, events, repo, _workdir) = create_tracking_store("branch-exists-checkout");
     let repo_id = store.snapshot().active_repo.expect("expected active repo");
     wait_until("tracked repo branches to load", || {


### PR DESCRIPTION
This pull request introduces support for **force branch creation and checkout** in GitComet, enabling users to create a branch from a target commit even when a branch with the requested name already exists. Instead of failing with Git's conventional `branch already exists` error, the new flow allows the user to explicitly overwrite the existing branch reference and immediately check it out.

The implementation is designed around the equivalent Git operation:

```bash
git checkout -B <name> <target>
```

This provides a single, explicit operation for the **overwrite-and-checkout** workflow and also correctly handles the special case where the branch being overwritten is currently checked out in the worktree.

## What Changed

The change spans the Git backend, state/effect layers, UI interaction flow, and automated tests.

At the backend level, a new `create_branch_force_and_checkout` operation has been added to the Git repository abstraction. The generic service layer exposes the operation while retaining an unsupported-backend fallback, and the `git-gix` implementation delegates to a concrete `git checkout -B` invocation. Branch names and targets are validated before the command is executed.
The state-management flow has also been extended with a `force` flag on `CreateBranchAndCheckout`. This flag is propagated from the message layer through the reducer and effect generation into repository execution. When `force` is enabled, GitComet performs the new force-create-and-checkout operation directly rather than executing the traditional create-then-checkout sequence. This keeps the normal branch creation path unchanged while introducing the overwrite behavior only when it has been explicitly requested.

## User Experience

The UI now recognizes when a requested branch name already exists during the **Create branch from…** workflow. Rather than immediately surfacing Git's `already exists` failure, GitComet presents a dedicated `BranchExistsPrompt` that gives the user an explicit choice about what should happen next.

The new overwrite path dispatches `CreateBranchAndCheckout` with `force: true`, allowing the existing branch to be moved to the requested target and checked out. The popover is then closed after the action is dispatched.
The existing-branch prompt also retains a separate **checkout existing branch** path. This means that when a branch name is already present, users can choose between overwriting the branch reference and checking it out, or simply checking out the existing branch without moving it.

The target commit is presented in a shortened form in the prompt, using the first seven characters of the target SHA when appropriate, making the potentially destructive overwrite operation easier to understand in context.

## Backend Behavior

The new backend operation intentionally uses `git checkout -B` rather than composing separate `git branch -f` and `git checkout` commands.

This is important because the combined operation also handles the case where the branch being reset is currently checked out in the worktree. In that situation, the behavior corresponds to the overwrite-and-checkout semantics required by the UI, including the reset behavior described in the implementation comments.

The implementation validates both the branch name and branch target before constructing the Git command, preventing invalid ref-like arguments from being passed directly to the command invocation.

## Tests

This PR adds comprehensive coverage for the new behavior across multiple layers.

### Repository integration tests

Integration coverage verifies both major backend scenarios:

* force-creating a branch when the branch already exists, ensuring the existing branch is moved to the requested target and checked out;
* force-creating a branch that does not yet exist, ensuring the new branch is created and checked out successfully.

### State and effect tests

The state-management tests verify that the `force` flag is preserved as the action travels through the reducer/effect pipeline and that the force path invokes the dedicated repository operation rather than separately creating and checking out the branch.

### UI tests

The UI test suite covers the complete existing-name interaction, including:

* entering an existing branch name;
* presenting the `BranchExistsPrompt`;
* ensuring no Git action is performed before the user makes a choice;
* selecting **Overwrite & checkout** and verifying that the force operation is dispatched;
* ensuring the popover closes after the overwrite action;
* selecting the alternative **Checkout existing** behavior and verifying that the existing branch is checked out without being moved.

## Compatibility and Existing Behavior

The normal branch creation and checkout flow remains available through the existing `force: false` path. The new behavior is therefore opt-in and only activated when the user explicitly chooses the overwrite operation.

This preserves the existing semantics for ordinary branch creation while adding a dedicated and clearly surfaced workflow for the case where a branch name is already occupied.
