### PR TITLE
fix Crash: unable to get cursor position: Access is denied.

### DIFF
--- a/crates/gitcomet-ui-gpui/src/external_editor.rs
+++ b/crates/gitcomet-ui-gpui/src/external_editor.rs
@@ -623,12 +623,19 @@ pub(crate) fn label_for_setting(setting: Option<&ExternalCodeEditorSetting>) -> 
     }
 }
 
-pub(crate) fn launch_configured_editor(target: &Path) -> Result<(), ExternalEditorError> {
-    let setting = configured_setting().ok_or(ExternalEditorError::NotConfigured)?;
-    launch_editor(&setting, target)
-}
-
-#[cfg(test)]
+/// Resolve the command that opens `target` in the configured editor.
+///
+/// The main-thread half of launching an editor: every failure worth reporting
+/// straight away — no editor configured, an empty or unparsable custom command,
+/// no terminal launcher — surfaces here. Hand the result to
+/// [`spawn_launch_command`] off the main thread; see
+/// `crate::view::platform_open::spawn_launch` for why.
+///
+/// Note this half is not free: the `vim-terminal`/`neovim-terminal` settings
+/// probe every PATH directory for a terminal launcher on each call. That was
+/// always true, and it does not pump the Windows message queue, but a PATH
+/// entry on an unreachable share can still stall the click. Caching it (as
+/// [`configured_setting`] already caches the setting itself) is a follow-up.
 pub(crate) fn launch_command_for_configured_editor(
     target: &Path,
 ) -> Result<ExternalEditorLaunchCommand, ExternalEditorError> {
@@ -636,11 +643,13 @@ pub(crate) fn launch_command_for_configured_editor(
     launch_command_for_setting(&setting, target)
 }
 
-pub(crate) fn launch_editor(
-    setting: &ExternalCodeEditorSetting,
-    target: &Path,
+/// Spawn a command resolved by [`launch_command_for_configured_editor`].
+///
+/// Blocking, and on Windows it can pump the message queue — run it on a
+/// background thread, never inside a GPUI event handler.
+pub(crate) fn spawn_launch_command(
+    command: ExternalEditorLaunchCommand,
 ) -> Result<(), ExternalEditorError> {
-    let command = launch_command_for_setting(setting, target)?;
     let mut process = background_command(command.program.as_os_str());
     process.args(command.args);
     process.spawn()?;

--- a/crates/gitcomet-ui-gpui/src/view/mod.rs
+++ b/crates/gitcomet-ui-gpui/src/view/mod.rs
@@ -218,8 +218,8 @@ use patch_split::build_patch_split_rows;
 use poller::Poller;
 pub(in crate::view) use terminal_preferences::{
     ActionBarTerminalTarget, ExternalTerminalLaunchContext, ExternalTerminalMode,
-    TerminalPreferences, launch_external_terminal_from_preferences, parse_terminal_args_multiline,
-    resolve_embedded_shell_program,
+    TerminalPreferences, parse_terminal_args_multiline, resolve_embedded_shell_program,
+    resolve_external_terminal_launch_spec,
 };
 use word_diff::{capped_word_diff_ranges, capped_word_diff_ranges_for_file_diff_texts};
 
@@ -3377,27 +3377,76 @@ impl GitCometView {
             return;
         }
 
-        if let Err(err) = crate::external_editor::launch_configured_editor(&path) {
-            self.push_toast(
-                components::ToastKind::Error,
-                format!("Failed to open in code editor: {err}"),
-                cx,
-            );
-        }
+        let command = match crate::external_editor::launch_command_for_configured_editor(&path) {
+            Ok(command) => command,
+            Err(err) => {
+                self.push_toast(
+                    components::ToastKind::Error,
+                    format!("Failed to open in code editor: {err}"),
+                    cx,
+                );
+                return;
+            }
+        };
+
+        platform_open::spawn_launch(
+            cx,
+            move || crate::external_editor::spawn_launch_command(command),
+            |this, result, cx| {
+                if let Err(err) = result {
+                    this.push_toast(
+                        components::ToastKind::Error,
+                        format!("Failed to open in code editor: {err}"),
+                        cx,
+                    );
+                }
+            },
+        );
     }
 
-    fn report_startup_crash_report(&self) -> Result<(), std::io::Error> {
-        self.report_startup_crash_report_with(platform_open::open_url)
+    pub(in crate::view) fn startup_crash_report_issue_url(&self) -> Option<String> {
+        self.startup_crash_report
+            .as_ref()
+            .map(|report| report.issue_url.clone())
+    }
+
+    /// The "Report Issue" button's whole body, so the button stays a one-liner
+    /// and tests can drive the real sequence through
+    /// [`Self::report_startup_crash_report_with`].
+    fn report_startup_crash_report(&mut self, cx: &mut gpui::Context<Self>) {
+        self.report_startup_crash_report_with(cx, |url| platform_open::open_url_blocking(&url));
     }
 
     fn report_startup_crash_report_with(
-        &self,
-        open_url: impl FnOnce(&str) -> Result<(), std::io::Error>,
-    ) -> Result<(), std::io::Error> {
-        let Some(report) = self.startup_crash_report.as_ref() else {
-            return Ok(());
+        &mut self,
+        cx: &mut gpui::Context<Self>,
+        open_url: impl FnOnce(String) -> Result<(), std::io::Error> + Send + 'static,
+    ) {
+        let Some(url) = self.startup_crash_report_issue_url() else {
+            return;
         };
-        open_url(&report.issue_url)
+        platform_open::spawn_launch(
+            cx,
+            move || open_url(url),
+            |this, result, cx| {
+                match result {
+                    Ok(()) => this.push_toast(
+                        components::ToastKind::Success,
+                        "Opened crash report page in your browser.".to_string(),
+                        cx,
+                    ),
+                    Err(err) => this.push_toast(
+                        components::ToastKind::Error,
+                        format!("Failed to open browser: {err}"),
+                        cx,
+                    ),
+                }
+                // `push_toast` sends an Error straight to `show_error_banner`,
+                // which never touches `cx`, so without this the error path would
+                // depend entirely on a store round-trip to repaint.
+                cx.notify();
+            },
+        );
     }
 
     fn ignore_startup_crash_report(&mut self) -> Result<(), std::io::Error> {
@@ -3731,21 +3780,7 @@ impl Render for GitCometView {
                 components::Button::new("startup_crash_report_open", "Report Issue")
                     .style(components::ButtonStyle::Filled)
                     .on_click(theme, cx, |this, _e, _w, cx| {
-                        match this.report_startup_crash_report() {
-                            Ok(()) => this.push_toast(
-                                components::ToastKind::Success,
-                                "Opened crash report page in your browser.".to_string(),
-                                cx,
-                            ),
-                            Err(err) => {
-                                this.push_toast(
-                                    components::ToastKind::Error,
-                                    format!("Failed to open browser: {err}"),
-                                    cx,
-                                );
-                            }
-                        }
-                        cx.notify();
+                        this.report_startup_crash_report(cx);
                     });
 
             let ignore_button =

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu.rs
@@ -249,12 +249,36 @@ impl PopoverHost {
         Ok(normalize_platform_path(workdir.join(path)))
     }
 
-    fn open_path_default(&mut self, path: &std::path::Path) -> Result<(), std::io::Error> {
-        super::super::super::platform_open::open_path(path)
+    fn open_path_default(&mut self, path: std::path::PathBuf, cx: &mut gpui::Context<Self>) {
+        crate::view::platform_open::spawn_launch(
+            cx,
+            move || crate::view::platform_open::open_path_blocking(&path),
+            |this, result, cx| {
+                if let Err(err) = result {
+                    this.push_toast(
+                        components::ToastKind::Error,
+                        format!("Failed to open: {err}"),
+                        cx,
+                    );
+                }
+            },
+        );
     }
 
-    fn open_file_location(&mut self, path: &std::path::Path) -> Result<(), std::io::Error> {
-        super::super::super::platform_open::open_file_location(path)
+    fn open_file_location(&mut self, path: std::path::PathBuf, cx: &mut gpui::Context<Self>) {
+        crate::view::platform_open::spawn_launch(
+            cx,
+            move || crate::view::platform_open::open_file_location_blocking(&path),
+            |this, result, cx| {
+                if let Err(err) = result {
+                    this.push_toast(
+                        components::ToastKind::Error,
+                        format!("Failed to open location: {err}"),
+                        cx,
+                    );
+                }
+            },
+        );
     }
 
     fn reveal_path_in_file_manager(
@@ -278,12 +302,8 @@ impl PopoverHost {
                 format!("Path not found: {}", target.display()),
                 cx,
             );
-        } else if let Err(err) = self.open_file_location(&target) {
-            self.push_toast(
-                components::ToastKind::Error,
-                format!("Failed to open location: {err}"),
-                cx,
-            );
+        } else {
+            self.open_file_location(target, cx);
         }
     }
 
@@ -755,12 +775,8 @@ impl PopoverHost {
                         format!("Path not found: {}", full_path.display()),
                         cx,
                     );
-                } else if let Err(err) = self.open_path_default(&full_path) {
-                    self.push_toast(
-                        components::ToastKind::Error,
-                        format!("Failed to open: {err}"),
-                        cx,
-                    );
+                } else {
+                    self.open_path_default(full_path, cx);
                 }
             }
             ContextMenuAction::OpenFileLocation { repo_id, path } => {
@@ -792,21 +808,11 @@ impl PopoverHost {
                     None => path,
                 };
 
-                if !full_path.exists() {
-                    self.push_toast(
-                        components::ToastKind::Error,
-                        format!("Path not found: {}", full_path.display()),
-                        cx,
-                    );
-                } else if let Err(err) =
-                    crate::external_editor::launch_configured_editor(&full_path)
-                {
-                    self.push_toast(
-                        components::ToastKind::Error,
-                        format!("Failed to open in code editor: {err}"),
-                        cx,
-                    );
-                }
+                // The root view owns this sequence (existence check, resolve,
+                // background launch, toast); routing through it keeps one copy.
+                let _ = self.root_view.update(cx, |root, cx| {
+                    root.open_path_in_external_code_editor(full_path, cx);
+                });
             }
             ContextMenuAction::OpenRepo { path } => {
                 self.store.dispatch(Msg::OpenRepo(path));
@@ -1466,13 +1472,19 @@ impl PopoverHost {
                 );
             }
             ContextMenuAction::OpenWebUrl { url } => {
-                if let Err(err) = crate::view::platform_open::open_url(&url) {
-                    self.push_toast(
-                        components::ToastKind::Error,
-                        format!("Failed to open link: {err}"),
-                        cx,
-                    );
-                }
+                crate::view::platform_open::spawn_launch(
+                    cx,
+                    move || crate::view::platform_open::open_url_blocking(&url),
+                    |this, result, cx| {
+                        if let Err(err) = result {
+                            this.push_toast(
+                                components::ToastKind::Error,
+                                format!("Failed to open link: {err}"),
+                                cx,
+                            );
+                        }
+                    },
+                );
             }
             ContextMenuAction::CopyDiffSelection { text } => {
                 window.activate_window();

--- a/crates/gitcomet-ui-gpui/src/view/panels/tests/shortcuts.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/tests/shortcuts.rs
@@ -1639,7 +1639,7 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
             },
         )
     });
-    assert_declared_shortcuts(&commit_model, &["T", "D", "P", "R", "B", "I"]);
+    assert_declared_shortcuts(&commit_model, &["T", "D", "P", "R", "B", "I", "M"]);
     assert_shortcut_action!(
         commit_model,
         "Enter",
@@ -1694,6 +1694,16 @@ fn file_and_diff_context_menu_shortcuts_match_expected_actions(cx: &mut gpui::Te
         "I",
         ContextMenuAction::LoadInteractiveRebaseSetup { repo_id: rid, base }
             if *rid == repo_id && base == commit_id.as_ref()
+    );
+    assert_shortcut_action!(
+        commit_model,
+        "M",
+        ContextMenuAction::OpenPopover {
+            kind: PopoverKind::MergeCommitConfirm {
+                repo_id: rid,
+                commit_id: cid
+            }
+        } if *rid == repo_id && cid == &commit_id
     );
 
     let commit_file_model = cx.update(|_window, app| {

--- a/crates/gitcomet-ui-gpui/src/view/platform_open.rs
+++ b/crates/gitcomet-ui-gpui/src/view/platform_open.rs
@@ -1,3 +1,4 @@
+use gpui::AppContext as _;
 use std::io;
 use std::path::Path;
 
@@ -26,14 +27,43 @@ const WSL_LINUX_OPEN_HELPERS: [LinuxOpenHelper; 3] = [
     LinuxOpenHelper::WslView,
 ];
 
+/// Run a blocking OS launch off the GPUI main thread.
+///
+/// `CreateProcessW`, `ShellExecute` and the Linux openers below all block, and
+/// on Windows `CreateProcessW` can pump the message queue from inside itself:
+/// resolving an App Execution Alias (`wt.exe`, `code`, …) performs an
+/// out-of-proc COM activation, and COM's wait on an STA thread dispatches
+/// window messages. GPUI runs the main thread as an STA, so launching from a
+/// click handler re-enters the window procedure while GPUI still holds the
+/// `App` borrow, and every platform callback it reaches — window-control hit
+/// testing, frame requests — fails with "RefCell already borrowed".
+///
+/// Resolve *what* to launch on the main thread, then hand the launch itself to
+/// this helper. `on_result` runs back on the main thread once it finishes.
+pub(in crate::view) fn spawn_launch<V, E>(
+    cx: &mut gpui::Context<V>,
+    launch: impl FnOnce() -> Result<(), E> + Send + 'static,
+    on_result: impl FnOnce(&mut V, Result<(), E>, &mut gpui::Context<V>) + 'static,
+) where
+    V: 'static,
+    E: Send + 'static,
+{
+    let task = cx.background_spawn(async move { launch() });
+    cx.spawn(async move |view, cx| {
+        let result = task.await;
+        let _ = view.update(cx, |view, cx| on_result(view, result, cx));
+    })
+    .detach();
+}
+
 /// Open a URL in the user's default browser.
-pub(super) fn open_url(url: &str) -> Result<(), io::Error> {
+pub(in crate::view) fn open_url_blocking(url: &str) -> Result<(), io::Error> {
     let url = validate_external_url(url)?;
     open_with_default(url)
 }
 
 /// Open a file or directory with the system's default application.
-pub(super) fn open_path(path: &Path) -> Result<(), io::Error> {
+pub(in crate::view) fn open_path_blocking(path: &Path) -> Result<(), io::Error> {
     if path.as_os_str().is_empty() {
         return Err(io::Error::new(io::ErrorKind::InvalidInput, "Path is empty"));
     }
@@ -52,9 +82,9 @@ pub(super) fn open_path(path: &Path) -> Result<(), io::Error> {
 }
 
 /// Open the file manager and select/reveal the given path.
-pub(super) fn open_file_location(path: &Path) -> Result<(), io::Error> {
+pub(in crate::view) fn open_file_location_blocking(path: &Path) -> Result<(), io::Error> {
     if path.is_dir() {
-        return open_path(path);
+        return open_path_blocking(path);
     }
 
     #[cfg(target_os = "macos")]
@@ -90,7 +120,7 @@ pub(super) fn open_file_location(path: &Path) -> Result<(), io::Error> {
         }
 
         let parent = path.parent().unwrap_or(path);
-        open_path(parent)
+        open_path_blocking(parent)
     }
 
     #[cfg(not(any(
@@ -624,5 +654,80 @@ mod windows_tests {
             .to_string();
         assert!(!normalized.starts_with(r"\\?\"));
         assert_eq!(normalized, r"C:\git\GitComet\src\main.rs");
+    }
+}
+
+#[cfg(test)]
+mod spawn_launch_tests {
+    use super::spawn_launch;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct LaunchProbe {
+        on_result_ran: bool,
+    }
+
+    impl gpui::Render for LaunchProbe {
+        fn render(
+            &mut self,
+            _window: &mut gpui::Window,
+            _cx: &mut gpui::Context<Self>,
+        ) -> impl gpui::IntoElement {
+            gpui::div()
+        }
+    }
+
+    /// Pins the half of the invariant this harness can observe: the launch must
+    /// not run inside the GPUI handler that asked for it, because that is where
+    /// `App` is borrowed and a nested Windows message pump would re-enter the
+    /// window procedure.
+    ///
+    /// It cannot prove the launch leaves the main thread — under `#[gpui::test]`
+    /// the background executor is a deterministic queue driven by the same
+    /// thread, so a foreground deferral would pass this too. That half is held
+    /// by `background_spawn`'s `Send` bound at the type level instead.
+    #[gpui::test]
+    fn spawn_launch_defers_the_launch_out_of_the_calling_handler(cx: &mut gpui::TestAppContext) {
+        let _visual_guard = crate::test_support::lock_visual_test();
+        let launched = Arc::new(AtomicBool::new(false));
+        let (view, cx) = cx.add_window_view(|_window, _cx| LaunchProbe {
+            on_result_ran: false,
+        });
+
+        let launched_in_task = Arc::clone(&launched);
+        cx.update(|_window, app| {
+            view.update(app, |_this, cx| {
+                spawn_launch(
+                    cx,
+                    move || {
+                        launched_in_task.store(true, Ordering::SeqCst);
+                        Ok::<(), std::io::Error>(())
+                    },
+                    |this, result, _cx| {
+                        assert!(result.is_ok(), "the probe launch cannot fail");
+                        this.on_result_ran = true;
+                    },
+                );
+            });
+        });
+
+        assert!(
+            !launched.load(Ordering::SeqCst),
+            "the launch ran synchronously inside the handler, which is exactly what \
+             re-enters the Windows window procedure while `App` is borrowed"
+        );
+
+        cx.run_until_parked();
+
+        assert!(
+            launched.load(Ordering::SeqCst),
+            "the launch must still happen, just after the handler has returned"
+        );
+        cx.update(|_window, app| {
+            assert!(
+                view.read(app).on_result_ran,
+                "on_result must run back on the main thread"
+            );
+        });
     }
 }

--- a/crates/gitcomet-ui-gpui/src/view/settings_window.rs
+++ b/crates/gitcomet-ui-gpui/src/view/settings_window.rs
@@ -1373,10 +1373,24 @@ impl SettingsWindowView {
     fn test_terminal_launch_from_draft(&mut self, cx: &mut gpui::Context<Self>) {
         let preferences = self.external_terminal_preferences_with_drafts(cx);
         let context = self.preferred_terminal_launch_context(cx);
-        match launch_external_terminal_from_preferences(&preferences, &context) {
-            Ok(()) => self.set_terminal_status(false, "Launch request sent.", cx),
-            Err(err) => self.set_terminal_status(true, format!("Test launch failed: {err}"), cx),
-        }
+        let spec = match resolve_external_terminal_launch_spec(&preferences, &context) {
+            Ok(spec) => spec,
+            Err(err) => {
+                self.set_terminal_status(true, format!("Test launch failed: {err}"), cx);
+                return;
+            }
+        };
+
+        super::platform_open::spawn_launch(
+            cx,
+            move || spec.launch().map_err(|err| err.to_string()),
+            |this, result, cx| match result {
+                Ok(()) => this.set_terminal_status(false, "Launch request sent.", cx),
+                Err(err) => {
+                    this.set_terminal_status(true, format!("Test launch failed: {err}"), cx)
+                }
+            },
+        );
     }
 
     fn show_root(&mut self, cx: &mut gpui::Context<Self>) {
@@ -1425,13 +1439,19 @@ impl SettingsWindowView {
             return;
         };
 
-        if let Err(err) = super::platform_open::open_path(&path) {
-            self.push_main_window_toast(
-                components::ToastKind::Error,
-                format!("Failed to open custom theme folder: {err}"),
-                cx,
-            );
-        }
+        super::platform_open::spawn_launch(
+            cx,
+            move || super::platform_open::open_path_blocking(&path),
+            |this, result, cx| {
+                if let Err(err) = result {
+                    this.push_main_window_toast(
+                        components::ToastKind::Error,
+                        format!("Failed to open custom theme folder: {err}"),
+                        cx,
+                    );
+                }
+            },
+        );
     }
 
     pub(crate) fn apply_ui_scale_percent(

--- a/crates/gitcomet-ui-gpui/src/view/terminal_panel.rs
+++ b/crates/gitcomet-ui-gpui/src/view/terminal_panel.rs
@@ -3009,7 +3009,7 @@ impl GitCometView {
     pub(super) fn open_external_terminal_for_repo(
         &mut self,
         repo_id: RepoId,
-        _cx: &mut gpui::Context<Self>,
+        cx: &mut gpui::Context<Self>,
     ) {
         let workdir = self
             .terminal_sessions
@@ -3030,7 +3030,26 @@ impl GitCometView {
                     .get(&repo_id)
                     .map(|s| s.repo_name.clone()),
             };
-            let _ = launch_external_terminal_from_preferences(&self.terminal_preferences, &context);
+            match resolve_external_terminal_launch_spec(&self.terminal_preferences, &context) {
+                Ok(spec) => super::platform_open::spawn_launch(
+                    cx,
+                    move || spec.launch(),
+                    |this, result, cx| {
+                        if let Err(err) = result {
+                            this.push_toast(
+                                components::ToastKind::Error,
+                                format!("Failed to open external terminal: {err}"),
+                                cx,
+                            );
+                        }
+                    },
+                ),
+                Err(err) => self.push_toast(
+                    components::ToastKind::Error,
+                    format!("Failed to open external terminal: {err}"),
+                    cx,
+                ),
+            }
         }
     }
 

--- a/crates/gitcomet-ui-gpui/src/view/terminal_preferences.rs
+++ b/crates/gitcomet-ui-gpui/src/view/terminal_preferences.rs
@@ -171,6 +171,10 @@ pub(in crate::view) struct ExternalTerminalLaunchSpec {
 }
 
 impl ExternalTerminalLaunchSpec {
+    /// Spawn the terminal. Blocking, and on Windows `wt.exe` resolves through an
+    /// App Execution Alias, whose COM activation pumps the message queue — run
+    /// this on a background thread, never inside a GPUI event handler. See
+    /// [`crate::view::platform_open::spawn_launch`].
     pub(in crate::view) fn launch(&self) -> io::Result<()> {
         let mut command = std::process::Command::new(&self.program);
         command.args(&self.args);
@@ -214,14 +218,6 @@ pub(in crate::view) fn parse_terminal_args_multiline(raw: &str) -> Vec<String> {
 pub(in crate::view) fn resolve_embedded_shell_program() -> Result<PathBuf, String> {
     resolve_automatic_embedded_shell_program()
         .ok_or_else(|| "No shell program was found for the embedded terminal.".to_string())
-}
-
-pub(in crate::view) fn launch_external_terminal_from_preferences(
-    preferences: &TerminalPreferences,
-    context: &ExternalTerminalLaunchContext,
-) -> Result<(), String> {
-    let spec = resolve_external_terminal_launch_spec(preferences, context)?;
-    spec.launch().map_err(|err| err.to_string())
 }
 
 pub(in crate::view) fn resolve_external_terminal_launch_spec(

--- a/crates/gitcomet-ui-gpui/src/view/tests.rs
+++ b/crates/gitcomet-ui-gpui/src/view/tests.rs
@@ -266,15 +266,31 @@ fn reporting_startup_crash_keeps_report_and_notification(cx: &mut gpui::TestAppC
         GitCometView::new_with_config(store, events, config, window, cx)
     });
 
+    // Drive the button's real handler with a stub launcher standing in for the
+    // browser, so the assertions below describe a report page that was actually
+    // opened rather than a getter that was read.
+    let opened = Arc::new(std::sync::Mutex::new(None::<String>));
+    let opened_in_launch = Arc::clone(&opened);
     cx.update(|_window, app| {
-        view.update(app, |this, _cx| {
-            this.report_startup_crash_report_with(|url| {
-                assert_eq!(url, "https://example.invalid/crash-report");
+        view.update(app, |this, cx| {
+            this.report_startup_crash_report_with(cx, move |url| {
+                *opened_in_launch
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(url);
                 Ok(())
-            })
-            .expect("open report URL");
+            });
         });
     });
+    cx.run_until_parked();
+
+    assert_eq!(
+        opened
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_deref(),
+        Some("https://example.invalid/crash-report"),
+        "the button must open the URL recorded for the crash"
+    );
 
     assert!(
         crash_log_path.exists(),

--- a/crates/gitcomet-ui-gpui/src/view/toast_host.rs
+++ b/crates/gitcomet-ui-gpui/src/view/toast_host.rs
@@ -6,6 +6,12 @@ pub(super) struct ToastHost {
     root_view: WeakEntity<GitCometView>,
 
     toasts: Vec<ToastState>,
+    /// Monotonic, so an id is never reused. Deriving the next id from
+    /// `toasts.last()` restarted numbering whenever the list emptied, and both
+    /// removal paths are deferred — the TTL timer below and the launch
+    /// callbacks in `handle_toast_action` — so a recycled id let a stale
+    /// removal delete an unrelated newer toast.
+    next_toast_id: u64,
     clone_progress: Option<CloneOpState>,
     clone_progress_last_seq: u64,
     clone_progress_dest: Option<std::sync::Arc<std::path::PathBuf>>,
@@ -170,6 +176,7 @@ impl ToastHost {
             theme,
             root_view,
             toasts: Vec::new(),
+            next_toast_id: 1,
             clone_progress: None,
             clone_progress_last_seq: 0,
             clone_progress_dest: None,
@@ -303,11 +310,8 @@ impl ToastHost {
         ttl: Option<Duration>,
         cx: &mut gpui::Context<Self>,
     ) -> u64 {
-        let id = self
-            .toasts
-            .last()
-            .map(|t| t.id.wrapping_add(1))
-            .unwrap_or(1);
+        let id = self.next_toast_id;
+        self.next_toast_id = self.next_toast_id.wrapping_add(1).max(1);
         let theme = self.theme;
         let is_code_message = looks_like_code_message(&message);
         let display_message = if is_code_message {
@@ -418,18 +422,25 @@ impl ToastHost {
 
     fn handle_toast_action(&mut self, id: u64, action: ToastAction, cx: &mut gpui::Context<Self>) {
         match action {
-            ToastAction::OpenUrl { url, .. } => match super::platform_open::open_url(&url) {
-                Ok(()) => {
-                    self.remove_toast(id, cx);
-                }
-                Err(err) => {
-                    self.push_toast(
-                        components::ToastKind::Error,
-                        format!("Failed to open link: {err}"),
-                        cx,
-                    );
-                }
-            },
+            ToastAction::OpenUrl { url, .. } => {
+                // Keep the toast until the open succeeds: it carries the URL and
+                // its button, so dismissing it up front would leave a user whose
+                // browser failed to launch with no way to read or retry the link.
+                // Ids are monotonic, so this deferred removal cannot hit a
+                // different toast.
+                super::platform_open::spawn_launch(
+                    cx,
+                    move || super::platform_open::open_url_blocking(&url),
+                    move |this, result, cx| match result {
+                        Ok(()) => this.remove_toast(id, cx),
+                        Err(err) => this.push_toast(
+                            components::ToastKind::Error,
+                            format!("Failed to open link: {err}"),
+                            cx,
+                        ),
+                    },
+                );
+            }
             ToastAction::OpenSurvey {
                 survey_id,
                 survey_name,
@@ -444,15 +455,20 @@ impl ToastHost {
                         cx,
                     );
                 }
-                let open_result = super::platform_open::open_url(&url);
                 self.remove_toast(id, cx);
-                if let Err(err) = open_result {
-                    self.push_toast(
-                        components::ToastKind::Error,
-                        format!("Failed to open {survey_name}: {err}"),
-                        cx,
-                    );
-                }
+                super::platform_open::spawn_launch(
+                    cx,
+                    move || super::platform_open::open_url_blocking(&url),
+                    move |this, result, cx| {
+                        if let Err(err) = result {
+                            this.push_toast(
+                                components::ToastKind::Error,
+                                format!("Failed to open {survey_name}: {err}"),
+                                cx,
+                            );
+                        }
+                    },
+                );
             }
             ToastAction::PostponeSurvey {
                 survey_id,


### PR DESCRIPTION
Remove the nested Windows message pump that was re-entering the windo procedure while gpui held the App borrow fixes https://github.com/Auto-Explore/GitComet/issues/387