### PR TITLE
order log rows like `git log --date-order` (#390)

### DIFF
--- a/crates/gitcomet-git-gix/src/repo/log.rs
+++ b/crates/gitcomet-git-gix/src/repo/log.rs
@@ -601,12 +601,6 @@ fn log_paged_walk_handle(repo: &gix::ThreadSafeRepository) -> gix::OdbHandleArc 
 /// end of what was cloned. `repo.rev_walk(..)` installs exactly this, but its
 /// filter borrows the repository, and a walk parked in the walk cache outlives
 /// any such borrow — hence the owned handle and the boxed closure.
-///
-/// Returns the filter together with whether the repository is shallow at all:
-/// that is the same question the boundary list answers, and the walk builder
-/// needs it. Asking `gix::Repository::is_shallow` instead would stat the file
-/// and run a `core.shallowFile` config lookup a second time, for an answer this
-/// function has already read.
 fn log_paged_walk_filter(
     repo: &gix::ThreadSafeRepository,
 ) -> Result<(super::LogPagedWalkFilter, bool)> {
@@ -638,78 +632,6 @@ fn log_paged_walk_filter(
     Ok((filter, true))
 }
 
-/// How the log orders its rows.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum LogRowOrder {
-    /// Newest committer date first, over everything currently queued.
-    CommitTime,
-    /// `git log --date-order`: newest committer date first, except that no
-    /// parent is shown before all of its children.
-    DateOrder,
-}
-
-/// Env override for [`log_row_order`]: `0`/`false`/`off`/`no` selects the plain
-/// commit-date queue, anything else the default date order.
-const LOG_ROW_ORDER_ENV: &str = "GITCOMET_LOG_DATE_ORDER";
-
-/// Reads a [`LogRowOrder`] out of a raw [`LOG_ROW_ORDER_ENV`] value.
-///
-/// Split from [`log_row_order`] because that one caches into a `OnceLock`: the
-/// first call in a process fixes the answer, so a test that set the variable
-/// afterwards would be testing nothing, and two tests in one binary could never
-/// cover both orderings. This is the part worth testing, and it is pure.
-fn log_row_order_from_env(raw: Option<&str>) -> LogRowOrder {
-    match raw.map(|raw| raw.trim().to_ascii_lowercase()) {
-        Some(value) if matches!(value.as_str(), "0" | "false" | "off" | "no") => {
-            LogRowOrder::CommitTime
-        }
-        _ => LogRowOrder::DateOrder,
-    }
-}
-
-/// The order the log walk sorts rows in, read once per process.
-///
-/// `--date-order` is the default because a plain commit-date queue disagrees
-/// with git whenever a commit's committer date is newer than one of its
-/// children's — a rebase with `--committer-date-is-author-date`, a `git am`, a
-/// machine whose clock runs behind — and then a parent is drawn above its own
-/// child and every row below it shifts by one against `git log` (issue #390).
-///
-/// It is the default *unconditionally*, because the rows being right matters
-/// more here than the page being quick. That is a real bill, and this is what
-/// it costs. The two orderings differ in what they must know before they can
-/// name the **first** row, which is all a page needs: the commit-date queue
-/// seeds itself from the tips and pops the newest, so it is O(tips), while date
-/// order cannot release a commit until no unemitted child of it is left, so it
-/// computes in-degrees first — down to the *lowest generation number among the
-/// tips*, which one long-abandoned branch drags to the floor.
-///
-/// Where a commit-graph supplies generation numbers that pass is bounded and
-/// the ordering is close to free. Where there is none every generation is
-/// `GENERATION_NUMBER_INFINITY`, the bound degenerates, and the pass covers the
-/// whole reachable graph. Measured here on a 50k-commit repository, 200-row
-/// first page, no commit-graph: 423ms against 2.5ms for the commit-date queue —
-/// where `git log --date-order -n 200` over the same repository pays 147ms
-/// against 3ms, so git is buying the same ordering at the same shape of price.
-/// With a commit-graph written (`git commit-graph write --reachable`, 155ms for
-/// those 50k commits) the same page costs 1.4ms, i.e. *below* the commit-date
-/// queue, and a graph that has gone stale still works: an ungraphed tip only
-/// keeps the bound off until the walk reaches its first graphed ancestor.
-///
-/// So the escape hatch is the env var below, and the cure is a commit-graph —
-/// not a quieter ordering. Nothing in this crate writes one today.
-pub(super) fn log_row_order() -> LogRowOrder {
-    static ORDER: std::sync::OnceLock<LogRowOrder> = std::sync::OnceLock::new();
-    *ORDER.get_or_init(|| log_row_order_from_env(std::env::var(LOG_ROW_ORDER_ENV).ok().as_deref()))
-}
-
-/// The commit-date queue, which every walk can fall back to.
-///
-/// Loads its own commit-graph rather than borrowing one: `gix_commitgraph::Graph`
-/// is not `Clone`, and this is either the only walk built or the one built after
-/// the topo builder consumed the first graph. Opening it is an mmap, not a read.
-/// The filter is passed in for the same reason in reverse — building one reads
-/// the shallow boundary, and the caller has already done that.
 fn new_commit_time_walk(
     repo: &gix::ThreadSafeRepository,
     tips: &[gix::ObjectId],
@@ -739,17 +661,11 @@ fn new_commit_time_walk(
     ))
 }
 
-/// A resumable walk of `mode` seeded from `tips`.
 fn new_log_paged_walk(
     repo: &gix::ThreadSafeRepository,
     tips: impl IntoIterator<Item = gix::ObjectId>,
     mode: HistoryMode,
 ) -> Result<super::LogPagedWalkState> {
-    // Without the commit-graph the traversal decodes every commit object just to
-    // read its parents and date, and the page builder then decodes the same
-    // objects again — two inflates per commit across the whole history on a
-    // filtered walk. `repo.rev_walk(..)` wires the graph up by default; these
-    // walks are built from the traversals directly, so they have to ask for it.
     let parents = if mode == HistoryMode::FirstParent {
         gix::traverse::commit::Parents::First
     } else {
@@ -760,60 +676,29 @@ fn new_log_paged_walk(
     let tips: Vec<gix::ObjectId> = tips.into_iter().collect();
     let (filter, is_shallow) = log_paged_walk_filter(repo)?;
 
-    // Two walks stay on the commit-date queue whatever the setting says, and
-    // neither is a performance judgement — both are about the rows coming out
-    // wrong, or not at all, the other way.
-    //
-    // First-parent mode has nothing to gain: it is seeded from one tip and
-    // follows one parent per step, so only ever one commit is queued and the
-    // rows come out in chain order either way — `Simple` does not even sort it,
-    // `Parents::First` routes it to the breadth-first queue. It would lose
-    // something, though: `Simple` reports just the followed parent in
-    // `Info::parent_ids` while the topo walk reports every parent, and that list
-    // is what becomes `Commit::parent_ids`. Merges would start drawing as merges
-    // in a view whose whole point is that the merged-in branch is not shown.
-    //
-    // A shallow boundary records parents that were never cloned. `Simple` asks
-    // its filter before following one, which is what `log_paged_walk_filter`
-    // exists for; the topo walk resolves parents in its in-degree pass, before
-    // any predicate can drop them, and fails the whole walk on the first one it
-    // cannot find. Shallow repositories therefore keep the plain commit-date
-    // queue — worse ordering under date skew, but a log that loads.
-    let order = match log_row_order() {
-        LogRowOrder::DateOrder if mode == HistoryMode::FirstParent || is_shallow => {
-            LogRowOrder::CommitTime
-        }
-        order => order,
-    };
-
-    let walk = match order {
-        LogRowOrder::CommitTime => new_commit_time_walk(repo, &tips, parents, filter)?,
-        LogRowOrder::DateOrder => {
-            let commit_graph = repo
-                .to_thread_local()
-                .commit_graph_if_enabled()
-                .ok()
-                .flatten();
-            match gix::traverse::commit::topo::Builder::new(log_paged_walk_handle(repo))
-                .with_predicate(filter)
-                .with_tips(tips.iter().copied())
-                .sorting(gix::traverse::commit::topo::Sorting::DateOrder)
-                .parents(parents)
-                .with_commit_graph(commit_graph)
-                .build()
-            {
-                Ok(walk) => super::LogPagedWalk::DateOrder(walk),
-                // The in-degree pass resolves the whole reachable region before
-                // it will yield a first row, so one unreachable ancestor —
-                // an expired stash reflog entry whose commit was gc'd, a
-                // half-fetched pack — fails a page that would never have
-                // touched it. The commit-date queue only fails if the walk
-                // actually arrives there, so a damaged history still renders
-                // the rows above the damage.
-                Err(_) => {
-                    let (filter, _) = log_paged_walk_filter(repo)?;
-                    new_commit_time_walk(repo, &tips, parents, filter)?
-                }
+    // The topo walk reports all parents in first-parent mode and cannot cross a
+    // shallow boundary whose missing parents are resolved during its setup.
+    let walk = if mode == HistoryMode::FirstParent || is_shallow {
+        new_commit_time_walk(repo, &tips, parents, filter)?
+    } else {
+        let commit_graph = repo
+            .to_thread_local()
+            .commit_graph_if_enabled()
+            .ok()
+            .flatten();
+        match gix::traverse::commit::topo::Builder::new(log_paged_walk_handle(repo))
+            .with_predicate(filter)
+            .with_tips(tips.iter().copied())
+            .sorting(gix::traverse::commit::topo::Sorting::DateOrder)
+            .parents(parents)
+            .with_commit_graph(commit_graph)
+            .build()
+        {
+            Ok(walk) => super::LogPagedWalk::DateOrder(walk),
+            // Fall back lazily when a missing ancestor prevents the in-degree pass.
+            Err(_) => {
+                let (filter, _) = log_paged_walk_filter(repo)?;
+                new_commit_time_walk(repo, &tips, parents, filter)?
             }
         }
     };
@@ -915,14 +800,6 @@ impl<'a> ChunkEmitter<'a> {
     /// Counts `count` more visited commits and reports the page so far once the
     /// interval has elapsed — including when nothing new matched, so a filter
     /// that is finding nothing still shows that it is working.
-    ///
-    /// Called once per decode batch, so the clock is read once per batch: a
-    /// `Instant::now()` is tens of nanoseconds against the microseconds a batch
-    /// costs to decode. There used to be a stride here that only let every
-    /// `DECODE_BATCH`-th commit reach the clock, on the theory that a caller
-    /// might count one commit at a time. None does, and once a page capped its
-    /// batches at what it could still use, the stride swallowed whole batches
-    /// and progress stopped being reported at all.
     fn visited(&mut self, count: u64, commits: &[Commit]) {
         self.scanned += count;
         if std::time::Instant::now() < self.next_emit_at {
@@ -949,44 +826,12 @@ fn mode_includes(mode: HistoryMode, parent_count: usize) -> bool {
     }
 }
 
-/// Commits handed to one round of decoding, and the ceiling on a gather.
-/// An unfiltered page caps its gather at what it can still use, so for any page
-/// smaller than this the cap binds first and this bounds only the
-/// author-filtered walks, whose hit rate cannot be predicted.
-///
-/// A page that fills mid-batch parks the rest of that batch in
-/// [`super::LogPagedWalkState::pending`], and the walk cache holds it until the
-/// walk is resumed or evicted, so the batch size is what bounds that part of a
-/// parked walk. It is no longer the part that matters: a parked *date-order*
-/// walk also holds the in-degree bookkeeping for everything it explored, which
-/// is ~3.3MB per 50k commits of history against the ~2048 `Info`s here — see
-/// [`super::LOG_PAGED_TOPO_WALK_CACHE_LIMIT`], which is what bounds that.
-///
-/// The rounds can be this small because [`DecodeWorkers`] outlive them: the
-/// per-round cost is a thread spawn and join, not a repository handle and fresh
-/// inflate buffers. Measured on the 100k-commit rare-author benchmark: 8192
-/// costs ~472ms and retains up to ~19MB, 2048 costs ~481ms and retains up to
-/// ~4.7MB, 1024 costs ~491ms. 2% for a quarter of the worst-case retention is
-/// the trade taken here.
 const DECODE_BATCH: usize = 2_048;
 /// Commit-decode threads in flight across the whole process. Object inflation is
 /// what a filtered walk spends its time on and it parallelizes cleanly, but the
 /// budget is shared: several repositories loading at once must not multiply into
 /// as many decode threads as they have walks.
 const DECODE_THREADS_MAX: usize = 8;
-/// Below this a batch decodes on the calling thread alone — the spawn and join
-/// round trip costs more than it saves.
-///
-/// It has to sit under the batch an ordinary page asks for, or the page decodes
-/// on one thread: with the gather capped at what the page can use, a 200-row
-/// page hands over 200 commits and not the 2048 of a full [`DECODE_BATCH`].
-/// Measured on a 50k-commit repository with a commit-graph, nine pages after the
-/// first, best of seven: at 200 rows parallel decoding takes 4.1ms against 6.1ms
-/// on one thread, at 100 rows 3.2ms against 3.6ms, and at 64 rows it loses,
-/// 2.9ms against 2.6ms. The crossover is between 64 and 100, so the threshold
-/// goes just under the smaller of the two. No caller asks for a page that small
-/// anyway — `DEFAULT_LOG_PAGE_SIZE` is 200 — so this only decides what happens
-/// if one ever does.
 const DECODE_PARALLEL_MIN: usize = 96;
 static DECODE_THREADS_IN_USE: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
@@ -1149,30 +994,8 @@ fn log_page_from_paged_walk_state(
     let mut walk_done = false;
 
     while !walk_done {
-        // Decoding is the expensive half, so never gather more than the page can
-        // use. One past the limit is the exception: that commit is what proves
-        // there is a next page, and it is gathered but *not* decoded — it goes
-        // back to `pending` as the raw `Info` it arrived as, and the next page
-        // decodes it once.
-        //
-        // Two different sizes have been cut away here and they are worth very
-        // different amounts. Gathering a whole [`DECODE_BATCH`] of 2048 for a
-        // 200-row page and throwing 1848 away was reported to cost two thirds of
-        // the wall time on chromium. Trimming the remaining slack — a floor of
-        // 256 down to the 201 a page actually reads — is a fifth less decoding
-        // for the same rows and *no measurable time at all*: on a 50k-commit
-        // repository with a commit-graph, nine pages after the first come to
-        // 4.0-4.7ms either way, where repeated runs of one binary spread by ~6%
-        // on their own. It is kept for the work it does not do, not for a speed
-        // up it does not deliver.
-        //
-        // What the trim must not do is drop the batch below
-        // [`DECODE_PARALLEL_MIN`]: decoding those 200 rows on one thread costs
-        // about 30%, far more than the trim saves.
-        //
-        // An author filter breaks the arithmetic — the hit rate is unknown, and
-        // most of a batch can be filtered out — so those walks keep the full
-        // batch and amortize the round over it.
+        // An unfiltered page gathers only what it can use plus one commit to
+        // prove another page exists. A filtered page has an unknown hit rate.
         let batch_cap = match author {
             Some(_) => DECODE_BATCH,
             None => DECODE_BATCH.min(limit.saturating_sub(commits.len()).saturating_add(1)),
@@ -1220,10 +1043,7 @@ fn log_page_from_paged_walk_state(
             break;
         }
 
-        // The commit past the limit proves a next page exists; it is not part
-        // of this one, so it is put back undecoded rather than decoded and
-        // dropped. An author-filtered batch has no such commit — which of it
-        // matches is only known after decoding — so it decodes whole.
+        // Park the lookahead commit without decoding it.
         let decode_len = match author {
             Some(_) => batch.len(),
             None => batch.len().min(limit.saturating_sub(commits.len())),
@@ -1261,9 +1081,6 @@ fn log_page_from_paged_walk_state(
         }
 
         if commits.len() >= limit {
-            // Whatever the gather reached past the limit is parked, so pending
-            // holding anything is exactly "there is a next page". An empty one
-            // means the gather ran the walk out.
             return Ok((commits, !walk_state.pending.is_empty()));
         }
     }
@@ -1297,21 +1114,7 @@ impl GixRepo {
         super::repo_file_stamp(&self._repo.to_thread_local().shallow_file())
     }
 
-    /// Serve a page from the cache, keeping its scroll lineage alive with it.
-    ///
-    /// A page hands out a resume token for a walk that the *next* page consumes,
-    /// so once page 2 has been read once, page 1's cached cursor names a walk
-    /// that no longer exists. That costs nothing while page 2 is cached too —
-    /// it answers from here. It costs a great deal if page 2 has been evicted
-    /// while page 1 stayed fresh, which is exactly what a plain LRU does to a
-    /// log that is refreshed at the top and scrolled rarely: the request then
-    /// misses both caches and rebuilds the walk from the tips, which for date
-    /// order means the whole in-degree pass again. Measured on a 50k-commit
-    /// repository: 1.97ms with the token live against 21.5ms rebuilt with a
-    /// commit-graph, and 3.11ms against 426ms without one.
-    ///
-    /// So a hit touches the successor as well — the entry whose cursor starts
-    /// where this page ends — and a lineage ages as one.
+    /// Serves a cached page and refreshes its successor's LRU position.
     fn cached_log_page(&self, key: &super::LogPageCacheKey) -> Option<LogPage> {
         let mut cache = self.log_page_cache.lock().expect("log page cache");
         let index = cache.iter().position(|entry| &entry.key == key)?;
@@ -1334,15 +1137,6 @@ impl GixRepo {
         Some(page)
     }
 
-    /// Cache `page` under `key` and hand it back — unless the request it was
-    /// built for has been superseded in the meantime, in which case the caller
-    /// hears that instead.
-    ///
-    /// Both page paths finish here so neither can quietly drop the re-check: a
-    /// load cancelled after the last batch was decoded but before the call
-    /// returned would otherwise hand a completed page to a caller that has
-    /// already moved on. The page is still cached first — it is correct work,
-    /// and the next request for it should not have to be walked again.
     fn finish_log_page(
         &self,
         key: super::LogPageCacheKey,
@@ -1449,9 +1243,7 @@ impl GixRepo {
         if cache.entries.len() >= super::LOG_PAGED_WALK_CACHE_LIMIT {
             cache.entries.remove(0);
         }
-        // Date-order walks are parked under a tighter bound of their own: they
-        // retain the in-degree bookkeeping for everything they explored, which
-        // grows with the history and not with the page.
+        // Date-order walks retain in-degree state proportional to history size.
         if state.walk.is_date_order() {
             while cache
                 .entries
@@ -1872,12 +1664,6 @@ impl GixRepo {
         self.log_all_branches_page_impl_inner(limit, cursor, Some(cancellation), None, None)
     }
 
-    /// Every tip `git log --all` would walk, deduplicated and sorted.
-    ///
-    /// Sorted because the tips identify the walk in the walk cache, so they have
-    /// to come out the same way on every page: ref enumeration order is not
-    /// guaranteed, and a reshuffled list would reject a perfectly good resume
-    /// token. It costs the walk nothing — every tip is just a seed.
     fn all_branches_tips(
         &self,
         cancellation: Option<&CancellationToken>,
@@ -1887,12 +1673,7 @@ impl GixRepo {
             .references()
             .map_err(|e| Error::new(ErrorKind::Backend(format!("gix references: {e}"))))?;
 
-        // Every ref under `refs/`, not just `refs/heads` and `refs/remotes`: some
-        // repositories (e.g. Chromium) keep branches in namespaces of their own,
-        // like `refs/branch-heads/*`. Tags are the one namespace left out, and
-        // walking past them is not free — on a repository with 39k tags this
-        // iteration is ~10ms — but `prefixed()` would have to name the
-        // namespaces to keep, and missing one drops branches from the graph.
+        // Include custom ref namespaces while leaving tags out of the graph.
         let mut tips = Vec::new();
         let mut seen = FxHashSet::default();
         if let Some(head_id) = gix_head_id_or_none(&repo)? {
@@ -1923,9 +1704,7 @@ impl GixRepo {
             }
         }
 
-        // `git log --all` includes only the `refs/stash` tip, but users expect
-        // scope=all to surface older stash entries (reflog-backed) as well, so
-        // those become tips too and their rows render like any other.
+        // Older stash entries are reflog-only and need explicit tips.
         for id in stash_reflog_tips(&repo, 50).unwrap_or_default() {
             if seen.insert(id) {
                 tips.push(id);
@@ -1934,11 +1713,6 @@ impl GixRepo {
 
         tips.sort();
 
-        // Hand back the same `Arc` as last time while the refs still produce the
-        // same tips. Every page request rebuilds this list, and every cached
-        // page holds the seed it was walked from, so without this a cacheful of
-        // pages holds a cacheful of identical tip vectors — on a fork with tens
-        // of thousands of `refs/pull/*` heads, tens of megabytes of them.
         let mut cached = self
             .all_branches_tips
             .lock()
@@ -1970,12 +1744,6 @@ impl GixRepo {
 
         let tips = self.all_branches_tips(cancellation)?;
 
-        // Every primary refresh asks for this page again, and most of them are
-        // triggered by something that left the refs alone — a file edit, an
-        // index write. Re-walking for those is the difference between a redraw
-        // and a second of traversal on a large repository, so the page is cached
-        // against the tips it was walked from, exactly as the head modes cache
-        // theirs against HEAD.
         let cache_key = self.log_page_cache_key(
             HistoryMode::AllBranches,
             super::LogPageSeed::Tips(Arc::clone(&tips)),
@@ -2877,9 +2645,6 @@ mod tests {
         assert!(entries.is_empty());
     }
 
-    /// Both page paths finish through `finish_log_page`, so covering it covers
-    /// the all-branches path too — the one that used to return a completed page
-    /// for a request that had already been superseded.
     #[test]
     fn finishing_a_page_reports_a_request_that_was_superseded_while_it_was_built() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -2912,18 +2677,12 @@ mod tests {
             error.kind()
         );
 
-        // The page is cached either way: it is correct work, and the next
-        // request for it should not have to walk again.
         assert!(
             repo.cached_log_page(&key).is_some(),
             "a cancelled request still leaves the page it finished in the cache"
         );
     }
 
-    /// A page and the page after it are one scroll lineage: page 1's cursor
-    /// names a walk that page 2 consumes, so page 1 outliving page 2 in the
-    /// cache is what turns an ordinary scroll-after-refresh into a full rebuild.
-    /// Refreshing the top must therefore keep the page below it alive too.
     #[test]
     fn a_cached_page_keeps_the_page_that_follows_it_from_being_evicted() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -2956,8 +2715,6 @@ mod tests {
             None,
         );
 
-        // Enough distinct keys to turn the whole cache over, with the top of the
-        // log re-read in between the way a refresh re-reads it.
         for round in 0..super::super::LOG_PAGE_CACHE_LIMIT + 4 {
             repo.log_history_mode_page_impl(mode, 5 + round, None)
                 .expect("filler page");
@@ -2972,54 +2729,12 @@ mod tests {
         );
     }
 
-    /// The env override is the only way out of the date-order bill, so both of
-    /// its answers have to be covered — which is why the parsing is a pure
-    /// function and the `OnceLock` wraps it rather than containing it.
-    #[test]
-    fn log_row_order_reads_every_spelling_of_off() {
-        for raw in ["0", "false", "off", "no", "OFF", " No ", "FALSE"] {
-            assert_eq!(
-                log_row_order_from_env(Some(raw)),
-                LogRowOrder::CommitTime,
-                "{raw:?} asks for the commit-date queue"
-            );
-        }
-    }
-
-    /// Unset, and anything that is not a spelling of off, is date order: the
-    /// rows being right is the default, and an unrecognised value must not
-    /// silently opt a user out of it.
-    #[test]
-    fn log_row_order_defaults_to_date_order() {
-        for raw in [
-            None,
-            Some(""),
-            Some("  "),
-            Some("1"),
-            Some("yes"),
-            Some("nope"),
-        ] {
-            assert_eq!(
-                log_row_order_from_env(raw),
-                LogRowOrder::DateOrder,
-                "{raw:?} must not turn date order off"
-            );
-        }
-    }
-
-    /// A page walk hands [`ChunkEmitter::visited`] one batch at a time, and a
-    /// batch is only as big as the page can still use — 200 rows, not the 2048
-    /// a full [`DECODE_BATCH`] holds. Progress has to keep flowing at that size:
-    /// the walks that need it most are the ones whose mode predicate rejects
-    /// nearly everything, and they are exactly the walks that spend seconds
-    /// gathering a single batch.
     #[test]
     fn chunk_emitter_reports_progress_for_the_smallest_batch_a_page_can_ask_for() {
         let mut seen: Vec<u64> = Vec::new();
         let mut on_chunk = |chunk: LogChunk| seen.push(chunk.scanned);
         let mut emitter = ChunkEmitter::new(&mut on_chunk);
 
-        // Past the interval, so only the stride can hold a report back.
         std::thread::sleep(CHUNK_INTERVAL + std::time::Duration::from_millis(20));
         for _ in 0..3 {
             emitter.visited(200, &[]);

--- a/crates/gitcomet-git-gix/src/repo/log.rs
+++ b/crates/gitcomet-git-gix/src/repo/log.rs
@@ -601,19 +601,27 @@ fn log_paged_walk_handle(repo: &gix::ThreadSafeRepository) -> gix::OdbHandleArc 
 /// end of what was cloned. `repo.rev_walk(..)` installs exactly this, but its
 /// filter borrows the repository, and a walk parked in the walk cache outlives
 /// any such borrow — hence the owned handle and the boxed closure.
-fn log_paged_walk_filter(repo: &gix::ThreadSafeRepository) -> Result<super::LogPagedWalkFilter> {
+///
+/// Returns the filter together with whether the repository is shallow at all:
+/// that is the same question the boundary list answers, and the walk builder
+/// needs it. Asking `gix::Repository::is_shallow` instead would stat the file
+/// and run a `core.shallowFile` config lookup a second time, for an answer this
+/// function has already read.
+fn log_paged_walk_filter(
+    repo: &gix::ThreadSafeRepository,
+) -> Result<(super::LogPagedWalkFilter, bool)> {
     let shallow_commits = repo
         .to_thread_local()
         .shallow_commits()
         .map_err(|e| Error::new(ErrorKind::Backend(format!("gix shallow commits: {e}"))))?;
     let Some(shallow_commits) = shallow_commits else {
-        return Ok(Box::new(|_| true));
+        return Ok((Box::new(|_| true), false));
     };
 
     let objects = log_paged_walk_handle(repo);
     let mut grafted_parents_to_skip: Vec<gix::ObjectId> = Vec::new();
     let mut buf = Vec::new();
-    Ok(Box::new(move |id| {
+    let filter: super::LogPagedWalkFilter = Box::new(move |id| {
         let id = id.to_owned();
         if let Ok(index) = grafted_parents_to_skip.binary_search(&id) {
             grafted_parents_to_skip.remove(index);
@@ -626,7 +634,109 @@ fn log_paged_walk_filter(repo: &gix::ThreadSafeRepository) -> Result<super::LogP
             grafted_parents_to_skip.sort();
         }
         true
-    }))
+    });
+    Ok((filter, true))
+}
+
+/// How the log orders its rows.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum LogRowOrder {
+    /// Newest committer date first, over everything currently queued.
+    CommitTime,
+    /// `git log --date-order`: newest committer date first, except that no
+    /// parent is shown before all of its children.
+    DateOrder,
+}
+
+/// Env override for [`log_row_order`]: `0`/`false`/`off`/`no` selects the plain
+/// commit-date queue, anything else the default date order.
+const LOG_ROW_ORDER_ENV: &str = "GITCOMET_LOG_DATE_ORDER";
+
+/// Reads a [`LogRowOrder`] out of a raw [`LOG_ROW_ORDER_ENV`] value.
+///
+/// Split from [`log_row_order`] because that one caches into a `OnceLock`: the
+/// first call in a process fixes the answer, so a test that set the variable
+/// afterwards would be testing nothing, and two tests in one binary could never
+/// cover both orderings. This is the part worth testing, and it is pure.
+fn log_row_order_from_env(raw: Option<&str>) -> LogRowOrder {
+    match raw.map(|raw| raw.trim().to_ascii_lowercase()) {
+        Some(value) if matches!(value.as_str(), "0" | "false" | "off" | "no") => {
+            LogRowOrder::CommitTime
+        }
+        _ => LogRowOrder::DateOrder,
+    }
+}
+
+/// The order the log walk sorts rows in, read once per process.
+///
+/// `--date-order` is the default because a plain commit-date queue disagrees
+/// with git whenever a commit's committer date is newer than one of its
+/// children's — a rebase with `--committer-date-is-author-date`, a `git am`, a
+/// machine whose clock runs behind — and then a parent is drawn above its own
+/// child and every row below it shifts by one against `git log` (issue #390).
+///
+/// It is the default *unconditionally*, because the rows being right matters
+/// more here than the page being quick. That is a real bill, and this is what
+/// it costs. The two orderings differ in what they must know before they can
+/// name the **first** row, which is all a page needs: the commit-date queue
+/// seeds itself from the tips and pops the newest, so it is O(tips), while date
+/// order cannot release a commit until no unemitted child of it is left, so it
+/// computes in-degrees first — down to the *lowest generation number among the
+/// tips*, which one long-abandoned branch drags to the floor.
+///
+/// Where a commit-graph supplies generation numbers that pass is bounded and
+/// the ordering is close to free. Where there is none every generation is
+/// `GENERATION_NUMBER_INFINITY`, the bound degenerates, and the pass covers the
+/// whole reachable graph. Measured here on a 50k-commit repository, 200-row
+/// first page, no commit-graph: 423ms against 2.5ms for the commit-date queue —
+/// where `git log --date-order -n 200` over the same repository pays 147ms
+/// against 3ms, so git is buying the same ordering at the same shape of price.
+/// With a commit-graph written (`git commit-graph write --reachable`, 155ms for
+/// those 50k commits) the same page costs 1.4ms, i.e. *below* the commit-date
+/// queue, and a graph that has gone stale still works: an ungraphed tip only
+/// keeps the bound off until the walk reaches its first graphed ancestor.
+///
+/// So the escape hatch is the env var below, and the cure is a commit-graph —
+/// not a quieter ordering. Nothing in this crate writes one today.
+pub(super) fn log_row_order() -> LogRowOrder {
+    static ORDER: std::sync::OnceLock<LogRowOrder> = std::sync::OnceLock::new();
+    *ORDER.get_or_init(|| log_row_order_from_env(std::env::var(LOG_ROW_ORDER_ENV).ok().as_deref()))
+}
+
+/// The commit-date queue, which every walk can fall back to.
+///
+/// Loads its own commit-graph rather than borrowing one: `gix_commitgraph::Graph`
+/// is not `Clone`, and this is either the only walk built or the one built after
+/// the topo builder consumed the first graph. Opening it is an mmap, not a read.
+/// The filter is passed in for the same reason in reverse — building one reads
+/// the shallow boundary, and the caller has already done that.
+fn new_commit_time_walk(
+    repo: &gix::ThreadSafeRepository,
+    tips: &[gix::ObjectId],
+    parents: gix::traverse::commit::Parents,
+    filter: super::LogPagedWalkFilter,
+) -> Result<super::LogPagedWalk> {
+    let commit_graph = repo
+        .to_thread_local()
+        .commit_graph_if_enabled()
+        .ok()
+        .flatten();
+    Ok(super::LogPagedWalk::CommitTime(
+        gix::traverse::commit::Simple::filtered(
+            tips.iter().copied(),
+            log_paged_walk_handle(repo),
+            filter,
+        )
+        .sorting(gix::traverse::commit::simple::Sorting::ByCommitTime(
+            CommitTimeOrder::NewestFirst,
+        ))
+        .map_err(|e| Error::new(ErrorKind::Backend(format!("gix walk: {e}"))))?
+        // Set after the sorting, the way `rev_walk` does: first-parent mode
+        // walks the chain in order rather than by date, and asking for it
+        // swaps the queue.
+        .parents(parents)
+        .commit_graph(commit_graph),
+    ))
 }
 
 /// A resumable walk of `mode` seeded from `tips`.
@@ -638,30 +748,75 @@ fn new_log_paged_walk(
     // Without the commit-graph the traversal decodes every commit object just to
     // read its parents and date, and the page builder then decodes the same
     // objects again — two inflates per commit across the whole history on a
-    // filtered walk. `repo.rev_walk(..)` wires the graph up by default; this
-    // walk is built from `Simple` directly, so it has to ask for it.
-    let commit_graph = repo
-        .to_thread_local()
-        .commit_graph_if_enabled()
-        .ok()
-        .flatten();
-    let walk = gix::traverse::commit::Simple::filtered(
-        tips,
-        log_paged_walk_handle(repo),
-        log_paged_walk_filter(repo)?,
-    )
-    .sorting(gix::traverse::commit::simple::Sorting::ByCommitTime(
-        CommitTimeOrder::NewestFirst,
-    ))
-    .map_err(|e| Error::new(ErrorKind::Backend(format!("gix walk: {e}"))))?
-    // Set after the sorting, the way `rev_walk` does: first-parent mode walks the
-    // chain in order rather than by date, and asking for it swaps the queue.
-    .parents(if mode == HistoryMode::FirstParent {
+    // filtered walk. `repo.rev_walk(..)` wires the graph up by default; these
+    // walks are built from the traversals directly, so they have to ask for it.
+    let parents = if mode == HistoryMode::FirstParent {
         gix::traverse::commit::Parents::First
     } else {
         gix::traverse::commit::Parents::All
-    })
-    .commit_graph(commit_graph);
+    };
+    // Collected because the commit-date queue is also the fallback below, and a
+    // fallback cannot re-consume an iterator the topo builder already drained.
+    let tips: Vec<gix::ObjectId> = tips.into_iter().collect();
+    let (filter, is_shallow) = log_paged_walk_filter(repo)?;
+
+    // Two walks stay on the commit-date queue whatever the setting says, and
+    // neither is a performance judgement — both are about the rows coming out
+    // wrong, or not at all, the other way.
+    //
+    // First-parent mode has nothing to gain: it is seeded from one tip and
+    // follows one parent per step, so only ever one commit is queued and the
+    // rows come out in chain order either way — `Simple` does not even sort it,
+    // `Parents::First` routes it to the breadth-first queue. It would lose
+    // something, though: `Simple` reports just the followed parent in
+    // `Info::parent_ids` while the topo walk reports every parent, and that list
+    // is what becomes `Commit::parent_ids`. Merges would start drawing as merges
+    // in a view whose whole point is that the merged-in branch is not shown.
+    //
+    // A shallow boundary records parents that were never cloned. `Simple` asks
+    // its filter before following one, which is what `log_paged_walk_filter`
+    // exists for; the topo walk resolves parents in its in-degree pass, before
+    // any predicate can drop them, and fails the whole walk on the first one it
+    // cannot find. Shallow repositories therefore keep the plain commit-date
+    // queue — worse ordering under date skew, but a log that loads.
+    let order = match log_row_order() {
+        LogRowOrder::DateOrder if mode == HistoryMode::FirstParent || is_shallow => {
+            LogRowOrder::CommitTime
+        }
+        order => order,
+    };
+
+    let walk = match order {
+        LogRowOrder::CommitTime => new_commit_time_walk(repo, &tips, parents, filter)?,
+        LogRowOrder::DateOrder => {
+            let commit_graph = repo
+                .to_thread_local()
+                .commit_graph_if_enabled()
+                .ok()
+                .flatten();
+            match gix::traverse::commit::topo::Builder::new(log_paged_walk_handle(repo))
+                .with_predicate(filter)
+                .with_tips(tips.iter().copied())
+                .sorting(gix::traverse::commit::topo::Sorting::DateOrder)
+                .parents(parents)
+                .with_commit_graph(commit_graph)
+                .build()
+            {
+                Ok(walk) => super::LogPagedWalk::DateOrder(walk),
+                // The in-degree pass resolves the whole reachable region before
+                // it will yield a first row, so one unreachable ancestor —
+                // an expired stash reflog entry whose commit was gc'd, a
+                // half-fetched pack — fails a page that would never have
+                // touched it. The commit-date queue only fails if the walk
+                // actually arrives there, so a damaged history still renders
+                // the rows above the damage.
+                Err(_) => {
+                    let (filter, _) = log_paged_walk_filter(repo)?;
+                    new_commit_time_walk(repo, &tips, parents, filter)?
+                }
+            }
+        }
+    };
     Ok(super::LogPagedWalkState {
         pending: std::collections::VecDeque::new(),
         walk,
@@ -747,11 +902,6 @@ pub(super) struct ChunkEmitter<'a> {
 }
 
 const CHUNK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(120);
-/// How often the clock is consulted. Reading it per commit would cost more than
-/// the throttling saves on a million-commit walk; a thousand commits is well
-/// under a millisecond of work, far below the emit interval. Kept equal to
-/// [`DECODE_BATCH`] so a batched caller consults the clock once per batch.
-const CHUNK_CLOCK_STRIDE: u64 = DECODE_BATCH as u64;
 
 impl<'a> ChunkEmitter<'a> {
     pub(super) fn new(on_chunk: &'a mut dyn FnMut(LogChunk)) -> Self {
@@ -766,15 +916,16 @@ impl<'a> ChunkEmitter<'a> {
     /// interval has elapsed — including when nothing new matched, so a filter
     /// that is finding nothing still shows that it is working.
     ///
-    /// Callers that count one commit at a time only reach the clock once per
-    /// stride; a batched caller passes a whole batch, which is the stride, so
-    /// its quotient always moves and every batch consults the clock.
+    /// Called once per decode batch, so the clock is read once per batch: a
+    /// `Instant::now()` is tens of nanoseconds against the microseconds a batch
+    /// costs to decode. There used to be a stride here that only let every
+    /// `DECODE_BATCH`-th commit reach the clock, on the theory that a caller
+    /// might count one commit at a time. None does, and once a page capped its
+    /// batches at what it could still use, the stride swallowed whole batches
+    /// and progress stopped being reported at all.
     fn visited(&mut self, count: u64, commits: &[Commit]) {
-        let before = self.scanned;
         self.scanned += count;
-        if before / CHUNK_CLOCK_STRIDE == self.scanned / CHUNK_CLOCK_STRIDE
-            || std::time::Instant::now() < self.next_emit_at
-        {
+        if std::time::Instant::now() < self.next_emit_at {
             return;
         }
         self.next_emit_at = std::time::Instant::now() + CHUNK_INTERVAL;
@@ -798,18 +949,25 @@ fn mode_includes(mode: HistoryMode, parent_count: usize) -> bool {
     }
 }
 
-/// Commits handed to one round of decoding.
+/// Commits handed to one round of decoding, and the ceiling on a gather.
+/// An unfiltered page caps its gather at what it can still use, so for any page
+/// smaller than this the cap binds first and this bounds only the
+/// author-filtered walks, whose hit rate cannot be predicted.
 ///
 /// A page that fills mid-batch parks the rest of that batch in
 /// [`super::LogPagedWalkState::pending`], and the walk cache holds it until the
-/// walk is resumed or evicted — up to `LOG_PAGED_WALK_CACHE_LIMIT` walks at 72
-/// bytes an entry, so the batch size is what bounds that. The rounds can be this
-/// small because [`DecodeWorkers`] outlive them: the per-round cost is a thread
-/// spawn and join, not a repository handle and fresh inflate buffers.
+/// walk is resumed or evicted, so the batch size is what bounds that part of a
+/// parked walk. It is no longer the part that matters: a parked *date-order*
+/// walk also holds the in-degree bookkeeping for everything it explored, which
+/// is ~3.3MB per 50k commits of history against the ~2048 `Info`s here — see
+/// [`super::LOG_PAGED_TOPO_WALK_CACHE_LIMIT`], which is what bounds that.
 ///
-/// Measured on the 100k-commit rare-author benchmark: 8192 costs ~472ms and
-/// retains up to ~19MB, 2048 costs ~481ms and retains up to ~4.7MB, 1024 costs
-/// ~491ms. 2% for a quarter of the worst-case retention is the trade taken here.
+/// The rounds can be this small because [`DecodeWorkers`] outlive them: the
+/// per-round cost is a thread spawn and join, not a repository handle and fresh
+/// inflate buffers. Measured on the 100k-commit rare-author benchmark: 8192
+/// costs ~472ms and retains up to ~19MB, 2048 costs ~481ms and retains up to
+/// ~4.7MB, 1024 costs ~491ms. 2% for a quarter of the worst-case retention is
+/// the trade taken here.
 const DECODE_BATCH: usize = 2_048;
 /// Commit-decode threads in flight across the whole process. Object inflation is
 /// what a filtered walk spends its time on and it parallelizes cleanly, but the
@@ -818,7 +976,18 @@ const DECODE_BATCH: usize = 2_048;
 const DECODE_THREADS_MAX: usize = 8;
 /// Below this a batch decodes on the calling thread alone — the spawn and join
 /// round trip costs more than it saves.
-const DECODE_PARALLEL_MIN: usize = 256;
+///
+/// It has to sit under the batch an ordinary page asks for, or the page decodes
+/// on one thread: with the gather capped at what the page can use, a 200-row
+/// page hands over 200 commits and not the 2048 of a full [`DECODE_BATCH`].
+/// Measured on a 50k-commit repository with a commit-graph, nine pages after the
+/// first, best of seven: at 200 rows parallel decoding takes 4.1ms against 6.1ms
+/// on one thread, at 100 rows 3.2ms against 3.6ms, and at 64 rows it loses,
+/// 2.9ms against 2.6ms. The crossover is between 64 and 100, so the threshold
+/// goes just under the smaller of the two. No caller asks for a page that small
+/// anyway — `DEFAULT_LOG_PAGE_SIZE` is 200 — so this only decides what happens
+/// if one ever does.
+const DECODE_PARALLEL_MIN: usize = 96;
 static DECODE_THREADS_IN_USE: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
@@ -980,11 +1149,40 @@ fn log_page_from_paged_walk_state(
     let mut walk_done = false;
 
     while !walk_done {
+        // Decoding is the expensive half, so never gather more than the page can
+        // use. One past the limit is the exception: that commit is what proves
+        // there is a next page, and it is gathered but *not* decoded — it goes
+        // back to `pending` as the raw `Info` it arrived as, and the next page
+        // decodes it once.
+        //
+        // Two different sizes have been cut away here and they are worth very
+        // different amounts. Gathering a whole [`DECODE_BATCH`] of 2048 for a
+        // 200-row page and throwing 1848 away was reported to cost two thirds of
+        // the wall time on chromium. Trimming the remaining slack — a floor of
+        // 256 down to the 201 a page actually reads — is a fifth less decoding
+        // for the same rows and *no measurable time at all*: on a 50k-commit
+        // repository with a commit-graph, nine pages after the first come to
+        // 4.0-4.7ms either way, where repeated runs of one binary spread by ~6%
+        // on their own. It is kept for the work it does not do, not for a speed
+        // up it does not deliver.
+        //
+        // What the trim must not do is drop the batch below
+        // [`DECODE_PARALLEL_MIN`]: decoding those 200 rows on one thread costs
+        // about 30%, far more than the trim saves.
+        //
+        // An author filter breaks the arithmetic — the hit rate is unknown, and
+        // most of a batch can be filtered out — so those walks keep the full
+        // batch and amortize the round over it.
+        let batch_cap = match author {
+            Some(_) => DECODE_BATCH,
+            None => DECODE_BATCH.min(limit.saturating_sub(commits.len()).saturating_add(1)),
+        };
+
         // Gathering ids is the cheap half — with a commit-graph it touches no
         // objects at all — so the gate and the mode predicate run here, before
         // anything is handed to the decoders.
         batch.clear();
-        while batch.len() < DECODE_BATCH {
+        while batch.len() < batch_cap {
             let Some(info) = walk_state.pending.pop_front() else {
                 // Checked per commit walked, not per batch: a mode predicate or
                 // a cursor gate that rejects everything can traverse an entire
@@ -1022,8 +1220,20 @@ fn log_page_from_paged_walk_state(
             break;
         }
 
+        // The commit past the limit proves a next page exists; it is not part
+        // of this one, so it is put back undecoded rather than decoded and
+        // dropped. An author-filtered batch has no such commit — which of it
+        // matches is only known after decoding — so it decodes whole.
+        let decode_len = match author {
+            Some(_) => batch.len(),
+            None => batch.len().min(limit.saturating_sub(commits.len())),
+        };
+        let scanned = decode_len as u64;
+        for info in batch.drain(decode_len..).rev() {
+            walk_state.pending.push_front(info);
+        }
+
         workers.decode(&batch, author, &mut decoded)?;
-        let scanned = batch.len() as u64;
 
         for (index, commit) in decoded.drain(..).enumerate() {
             let Some(commit) = commit else {
@@ -1049,22 +1259,31 @@ fn log_page_from_paged_walk_state(
         if let Some(chunks) = chunks.as_deref_mut() {
             chunks.visited(scanned, &commits);
         }
+
+        if commits.len() >= limit {
+            // Whatever the gather reached past the limit is parked, so pending
+            // holding anything is exactly "there is a next page". An empty one
+            // means the gather ran the walk out.
+            return Ok((commits, !walk_state.pending.is_empty()));
+        }
     }
 
     Ok((commits, false))
 }
 
 impl GixRepo {
-    fn log_head_page_cache_key(
+    fn log_page_cache_key(
+        &self,
         mode: HistoryMode,
-        head_oid: Option<gix::ObjectId>,
+        seed: super::LogPageSeed,
         limit: usize,
         cursor: Option<&LogCursor>,
         author: Option<&AuthorFilter>,
-    ) -> super::LogHeadPageCacheKey {
-        super::LogHeadPageCacheKey {
+    ) -> super::LogPageCacheKey {
+        super::LogPageCacheKey {
             mode,
-            head_oid,
+            seed,
+            shallow: self.shallow_stamp(),
             limit,
             last_seen: cursor.map(|cursor| cursor.last_seen.clone()),
             resume_from: cursor.and_then(|cursor| cursor.resume_from.clone()),
@@ -1072,30 +1291,80 @@ impl GixRepo {
         }
     }
 
-    fn cached_log_head_page(&self, key: &super::LogHeadPageCacheKey) -> Option<LogPage> {
-        let mut cache = self
-            .log_head_page_cache
-            .lock()
-            .expect("log head page cache");
+    /// Stamp of the shallow boundary file, for [`Self::log_page_cache_key`].
+    /// Read through gix so a `core.shallowFile` override is honoured.
+    fn shallow_stamp(&self) -> super::RepoFileStamp {
+        super::repo_file_stamp(&self._repo.to_thread_local().shallow_file())
+    }
+
+    /// Serve a page from the cache, keeping its scroll lineage alive with it.
+    ///
+    /// A page hands out a resume token for a walk that the *next* page consumes,
+    /// so once page 2 has been read once, page 1's cached cursor names a walk
+    /// that no longer exists. That costs nothing while page 2 is cached too —
+    /// it answers from here. It costs a great deal if page 2 has been evicted
+    /// while page 1 stayed fresh, which is exactly what a plain LRU does to a
+    /// log that is refreshed at the top and scrolled rarely: the request then
+    /// misses both caches and rebuilds the walk from the tips, which for date
+    /// order means the whole in-degree pass again. Measured on a 50k-commit
+    /// repository: 1.97ms with the token live against 21.5ms rebuilt with a
+    /// commit-graph, and 3.11ms against 426ms without one.
+    ///
+    /// So a hit touches the successor as well — the entry whose cursor starts
+    /// where this page ends — and a lineage ages as one.
+    fn cached_log_page(&self, key: &super::LogPageCacheKey) -> Option<LogPage> {
+        let mut cache = self.log_page_cache.lock().expect("log page cache");
         let index = cache.iter().position(|entry| &entry.key == key)?;
         let entry = cache.remove(index);
         let page = entry.page.clone();
+        let successor_starts_at = page.commits.last().map(|commit| commit.id.clone());
         cache.push(entry);
+
+        if let Some(last_seen) = successor_starts_at
+            && let Some(successor) = cache.iter().position(|entry| {
+                entry.key.last_seen.as_ref() == Some(&last_seen)
+                    && entry.key.mode == key.mode
+                    && entry.key.seed == key.seed
+                    && entry.key.author == key.author
+            })
+        {
+            let successor = cache.remove(successor);
+            cache.push(successor);
+        }
         Some(page)
     }
 
-    fn store_log_head_page(&self, key: super::LogHeadPageCacheKey, page: &LogPage) {
-        let mut cache = self
-            .log_head_page_cache
-            .lock()
-            .expect("log head page cache");
+    /// Cache `page` under `key` and hand it back — unless the request it was
+    /// built for has been superseded in the meantime, in which case the caller
+    /// hears that instead.
+    ///
+    /// Both page paths finish here so neither can quietly drop the re-check: a
+    /// load cancelled after the last batch was decoded but before the call
+    /// returned would otherwise hand a completed page to a caller that has
+    /// already moved on. The page is still cached first — it is correct work,
+    /// and the next request for it should not have to be walked again.
+    fn finish_log_page(
+        &self,
+        key: super::LogPageCacheKey,
+        page: LogPage,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<LogPage> {
+        self.store_log_page(key, &page);
+        if let Some(cancellation) = cancellation {
+            cancellation.check_cancelled()?;
+        }
+        Ok(page)
+    }
+
+    fn store_log_page(&self, key: super::LogPageCacheKey, page: &LogPage) {
+        let mut cache = self.log_page_cache.lock().expect("log page cache");
         if let Some(index) = cache.iter().position(|entry| entry.key == key) {
             cache.remove(index);
         }
-        if cache.len() >= super::LOG_HEAD_PAGE_CACHE_LIMIT {
+        if cache.len() >= super::LOG_PAGE_CACHE_LIMIT {
             cache.remove(0);
         }
-        cache.push(super::LogHeadPageCacheEntry {
+        cache.push(super::LogPageCacheEntry {
             key,
             page: page.clone(),
         });
@@ -1179,6 +1448,27 @@ impl GixRepo {
         cache.next_id = cache.next_id.wrapping_add(1);
         if cache.entries.len() >= super::LOG_PAGED_WALK_CACHE_LIMIT {
             cache.entries.remove(0);
+        }
+        // Date-order walks are parked under a tighter bound of their own: they
+        // retain the in-degree bookkeeping for everything they explored, which
+        // grows with the history and not with the page.
+        if state.walk.is_date_order() {
+            while cache
+                .entries
+                .iter()
+                .filter(|entry| entry.state.walk.is_date_order())
+                .count()
+                >= super::LOG_PAGED_TOPO_WALK_CACHE_LIMIT
+            {
+                let Some(oldest) = cache
+                    .entries
+                    .iter()
+                    .position(|entry| entry.state.walk.is_date_order())
+                else {
+                    break;
+                };
+                cache.entries.remove(oldest);
+            }
         }
         cache.entries.push(super::LogPagedWalkCacheEntry {
             token: Arc::clone(&token),
@@ -1538,8 +1828,14 @@ impl GixRepo {
 
         let repo = self._repo.to_thread_local();
         let head_id = gix_head_id_or_none(&repo)?;
-        let cache_key = Self::log_head_page_cache_key(mode, head_id, limit, cursor, author);
-        if let Some(page) = self.cached_log_head_page(&cache_key) {
+        let cache_key = self.log_page_cache_key(
+            mode,
+            super::LogPageSeed::Head(head_id),
+            limit,
+            cursor,
+            author,
+        );
+        if let Some(page) = self.cached_log_page(&cache_key) {
             return Ok(page);
         }
 
@@ -1556,11 +1852,7 @@ impl GixRepo {
             None => empty_log_page(),
         };
 
-        self.store_log_head_page(cache_key, &page);
-        if let Some(cancellation) = cancellation {
-            cancellation.check_cancelled()?;
-        }
-        Ok(page)
+        self.finish_log_page(cache_key, page, cancellation)
     }
 
     pub(super) fn log_all_branches_page_impl(
@@ -1580,34 +1872,30 @@ impl GixRepo {
         self.log_all_branches_page_impl_inner(limit, cursor, Some(cancellation), None, None)
     }
 
-    fn log_all_branches_page_impl_inner(
+    /// Every tip `git log --all` would walk, deduplicated and sorted.
+    ///
+    /// Sorted because the tips identify the walk in the walk cache, so they have
+    /// to come out the same way on every page: ref enumeration order is not
+    /// guaranteed, and a reshuffled list would reject a perfectly good resume
+    /// token. It costs the walk nothing — every tip is just a seed.
+    fn all_branches_tips(
         &self,
-        limit: usize,
-        cursor: Option<&LogCursor>,
         cancellation: Option<&CancellationToken>,
-        author: Option<&AuthorFilter>,
-        chunks: Option<&mut ChunkEmitter<'_>>,
-    ) -> Result<LogPage> {
-        if let Some(cancellation) = cancellation {
-            cancellation.check_cancelled()?;
-        }
-        if limit == 0 {
-            return Ok(empty_log_page());
-        }
-
+    ) -> Result<Arc<[gix::ObjectId]>> {
         let repo = self._repo.to_thread_local();
-        let head_id = gix_head_id_or_none(&repo)?;
-
         let refs = repo
             .references()
             .map_err(|e| Error::new(ErrorKind::Backend(format!("gix references: {e}"))))?;
 
-        // Emulate `git log --all`: include all refs under `refs/`, not just `refs/heads` and
-        // `refs/remotes`. Some repositories (e.g. Chromium) use additional namespaces like
-        // `refs/branch-heads/*`.
+        // Every ref under `refs/`, not just `refs/heads` and `refs/remotes`: some
+        // repositories (e.g. Chromium) keep branches in namespaces of their own,
+        // like `refs/branch-heads/*`. Tags are the one namespace left out, and
+        // walking past them is not free — on a repository with 39k tags this
+        // iteration is ~10ms — but `prefixed()` would have to name the
+        // namespaces to keep, and missing one drops branches from the graph.
         let mut tips = Vec::new();
         let mut seen = FxHashSet::default();
-        if let Some(head_id) = head_id {
+        if let Some(head_id) = gix_head_id_or_none(&repo)? {
             tips.push(head_id);
             seen.insert(head_id);
         }
@@ -1635,31 +1923,80 @@ impl GixRepo {
             }
         }
 
-        // `git log --all` includes only `refs/stash` tip, but users expect history scope=all
-        // to also surface older stash entries (reflog-backed). Add stash reflog commits as extra
-        // walk tips so stash rows can be rendered consistently in history graph.
+        // `git log --all` includes only the `refs/stash` tip, but users expect
+        // scope=all to surface older stash entries (reflog-backed) as well, so
+        // those become tips too and their rows render like any other.
         for id in stash_reflog_tips(&repo, 50).unwrap_or_default() {
             if seen.insert(id) {
                 tips.push(id);
             }
         }
 
-        // The tips identify the walk in the walk cache, so they have to come out
-        // the same way each page: ref enumeration order is not guaranteed, and a
-        // reshuffled list would reject a perfectly good resume token. Sorting
-        // costs the walk nothing — every tip is just a seed, and the traversal
-        // orders what it yields by commit time regardless.
         tips.sort();
 
-        self.log_paged_page(
+        // Hand back the same `Arc` as last time while the refs still produce the
+        // same tips. Every page request rebuilds this list, and every cached
+        // page holds the seed it was walked from, so without this a cacheful of
+        // pages holds a cacheful of identical tip vectors — on a fork with tens
+        // of thousands of `refs/pull/*` heads, tens of megabytes of them.
+        let mut cached = self
+            .all_branches_tips
+            .lock()
+            .expect("all branches tips cache");
+        match cached.as_ref() {
+            Some(previous) if previous.as_ref() == tips.as_slice() => Ok(Arc::clone(previous)),
+            _ => {
+                let tips: Arc<[gix::ObjectId]> = Arc::from(tips);
+                *cached = Some(Arc::clone(&tips));
+                Ok(tips)
+            }
+        }
+    }
+
+    fn log_all_branches_page_impl_inner(
+        &self,
+        limit: usize,
+        cursor: Option<&LogCursor>,
+        cancellation: Option<&CancellationToken>,
+        author: Option<&AuthorFilter>,
+        chunks: Option<&mut ChunkEmitter<'_>>,
+    ) -> Result<LogPage> {
+        if let Some(cancellation) = cancellation {
+            cancellation.check_cancelled()?;
+        }
+        if limit == 0 {
+            return Ok(empty_log_page());
+        }
+
+        let tips = self.all_branches_tips(cancellation)?;
+
+        // Every primary refresh asks for this page again, and most of them are
+        // triggered by something that left the refs alone — a file edit, an
+        // index write. Re-walking for those is the difference between a redraw
+        // and a second of traversal on a large repository, so the page is cached
+        // against the tips it was walked from, exactly as the head modes cache
+        // theirs against HEAD.
+        let cache_key = self.log_page_cache_key(
             HistoryMode::AllBranches,
-            Arc::from(tips),
+            super::LogPageSeed::Tips(Arc::clone(&tips)),
+            limit,
+            cursor,
+            author,
+        );
+        if let Some(page) = self.cached_log_page(&cache_key) {
+            return Ok(page);
+        }
+
+        let page = self.log_paged_page(
+            HistoryMode::AllBranches,
+            tips,
             limit,
             cursor,
             cancellation,
             author,
             chunks,
-        )
+        )?;
+        self.finish_log_page(cache_key, page, cancellation)
     }
 
     pub(super) fn log_file_page_impl(
@@ -2538,5 +2875,160 @@ mod tests {
         let repo = open_repo(workdir);
         let entries = repo.reflog_head_impl(0).expect("reflog_head_impl");
         assert!(entries.is_empty());
+    }
+
+    /// Both page paths finish through `finish_log_page`, so covering it covers
+    /// the all-branches path too — the one that used to return a completed page
+    /// for a request that had already been superseded.
+    #[test]
+    fn finishing_a_page_reports_a_request_that_was_superseded_while_it_was_built() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workdir = tmp.path();
+        init_test_repo(workdir);
+        commit_file(workdir, "a.txt", "one\n", "first");
+        let repo = open_repo(workdir);
+
+        let key = repo.log_page_cache_key(
+            HistoryMode::AllBranches,
+            super::super::LogPageSeed::Tips(std::sync::Arc::from(Vec::new())),
+            10,
+            None,
+            None,
+        );
+        let page = empty_log_page();
+
+        let live = CancellationToken::new();
+        repo.finish_log_page(key.clone(), page.clone(), Some(&live))
+            .expect("a live request gets its page");
+
+        let cancelled = CancellationToken::new();
+        cancelled.cancel();
+        let error = repo
+            .finish_log_page(key.clone(), page, Some(&cancelled))
+            .expect_err("a superseded request must not be handed a page");
+        assert!(
+            matches!(error.kind(), ErrorKind::Cancelled),
+            "expected Cancelled, got {:?}",
+            error.kind()
+        );
+
+        // The page is cached either way: it is correct work, and the next
+        // request for it should not have to walk again.
+        assert!(
+            repo.cached_log_page(&key).is_some(),
+            "a cancelled request still leaves the page it finished in the cache"
+        );
+    }
+
+    /// A page and the page after it are one scroll lineage: page 1's cursor
+    /// names a walk that page 2 consumes, so page 1 outliving page 2 in the
+    /// cache is what turns an ordinary scroll-after-refresh into a full rebuild.
+    /// Refreshing the top must therefore keep the page below it alive too.
+    #[test]
+    fn a_cached_page_keeps_the_page_that_follows_it_from_being_evicted() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workdir = tmp.path();
+        init_test_repo(workdir);
+        for index in 0..12 {
+            commit_file(
+                workdir,
+                "a.txt",
+                &format!("v{index}\n"),
+                &format!("c{index}"),
+            );
+        }
+        let repo = open_repo(workdir);
+
+        let mode = HistoryMode::FullReachable;
+        let first = repo
+            .log_history_mode_page_impl(mode, 4, None)
+            .expect("first page");
+        let cursor = first.next_cursor.clone().expect("a second page exists");
+        repo.log_history_mode_page_impl(mode, 4, Some(&cursor))
+            .expect("second page");
+
+        let head = gix_head_id_or_none(&repo._repo.to_thread_local()).expect("head");
+        let second_key = repo.log_page_cache_key(
+            mode,
+            super::super::LogPageSeed::Head(head),
+            4,
+            Some(&cursor),
+            None,
+        );
+
+        // Enough distinct keys to turn the whole cache over, with the top of the
+        // log re-read in between the way a refresh re-reads it.
+        for round in 0..super::super::LOG_PAGE_CACHE_LIMIT + 4 {
+            repo.log_history_mode_page_impl(mode, 5 + round, None)
+                .expect("filler page");
+            repo.log_history_mode_page_impl(mode, 4, None)
+                .expect("refresh of the first page");
+        }
+
+        assert!(
+            repo.cached_log_page(&second_key).is_some(),
+            "the page below the one being refreshed was evicted, so scrolling \
+             down rebuilds the walk instead of resuming it"
+        );
+    }
+
+    /// The env override is the only way out of the date-order bill, so both of
+    /// its answers have to be covered — which is why the parsing is a pure
+    /// function and the `OnceLock` wraps it rather than containing it.
+    #[test]
+    fn log_row_order_reads_every_spelling_of_off() {
+        for raw in ["0", "false", "off", "no", "OFF", " No ", "FALSE"] {
+            assert_eq!(
+                log_row_order_from_env(Some(raw)),
+                LogRowOrder::CommitTime,
+                "{raw:?} asks for the commit-date queue"
+            );
+        }
+    }
+
+    /// Unset, and anything that is not a spelling of off, is date order: the
+    /// rows being right is the default, and an unrecognised value must not
+    /// silently opt a user out of it.
+    #[test]
+    fn log_row_order_defaults_to_date_order() {
+        for raw in [
+            None,
+            Some(""),
+            Some("  "),
+            Some("1"),
+            Some("yes"),
+            Some("nope"),
+        ] {
+            assert_eq!(
+                log_row_order_from_env(raw),
+                LogRowOrder::DateOrder,
+                "{raw:?} must not turn date order off"
+            );
+        }
+    }
+
+    /// A page walk hands [`ChunkEmitter::visited`] one batch at a time, and a
+    /// batch is only as big as the page can still use — 200 rows, not the 2048
+    /// a full [`DECODE_BATCH`] holds. Progress has to keep flowing at that size:
+    /// the walks that need it most are the ones whose mode predicate rejects
+    /// nearly everything, and they are exactly the walks that spend seconds
+    /// gathering a single batch.
+    #[test]
+    fn chunk_emitter_reports_progress_for_the_smallest_batch_a_page_can_ask_for() {
+        let mut seen: Vec<u64> = Vec::new();
+        let mut on_chunk = |chunk: LogChunk| seen.push(chunk.scanned);
+        let mut emitter = ChunkEmitter::new(&mut on_chunk);
+
+        // Past the interval, so only the stride can hold a report back.
+        std::thread::sleep(CHUNK_INTERVAL + std::time::Duration::from_millis(20));
+        for _ in 0..3 {
+            emitter.visited(200, &[]);
+        }
+
+        assert!(
+            !seen.is_empty(),
+            "a batched caller must reach the clock: three 200-commit batches past \
+             the interval reported nothing"
+        );
     }
 }

--- a/crates/gitcomet-git-gix/src/repo/log.rs
+++ b/crates/gitcomet-git-gix/src/repo/log.rs
@@ -594,6 +594,91 @@ fn log_paged_walk_handle(repo: &gix::ThreadSafeRepository) -> gix::OdbHandleArc 
         .with_write_passthrough()
 }
 
+/// The cancellation token currently associated with a resumable walk.
+///
+/// A walk can outlive several page requests, so its object lookup cannot retain
+/// the token from the request that originally built it.
+#[derive(Clone, Default)]
+pub(super) struct LogWalkCancellation(Arc<std::sync::RwLock<Option<CancellationToken>>>);
+
+impl LogWalkCancellation {
+    fn new(cancellation: Option<&CancellationToken>) -> Self {
+        Self(Arc::new(std::sync::RwLock::new(cancellation.cloned())))
+    }
+
+    fn replace(&self, cancellation: Option<&CancellationToken>) {
+        *self.0.write().expect("log walk cancellation") = cancellation.cloned();
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.0
+            .read()
+            .expect("log walk cancellation")
+            .as_ref()
+            .is_some_and(CancellationToken::is_cancelled)
+    }
+}
+
+/// Object lookup used by the expensive date-order setup pass.
+///
+/// gix's topo builder has no cancellation hook of its own. On repositories
+/// without a commit-graph it resolves an object for every reachable commit, so
+/// checking at this boundary makes that slow path promptly cancellable without
+/// changing the traversal algorithm.
+pub(super) struct CancellableLogWalkFind {
+    inner: gix::OdbHandleArc,
+    cancellation: LogWalkCancellation,
+}
+
+impl gix::objs::Find for CancellableLogWalkFind {
+    fn try_find<'a>(
+        &self,
+        id: &gix::oid,
+        buffer: &'a mut Vec<u8>,
+    ) -> std::result::Result<Option<gix::objs::Data<'a>>, gix::objs::find::Error> {
+        if self.cancellation.is_cancelled() {
+            return Err(
+                std::io::Error::new(std::io::ErrorKind::Interrupted, "log walk cancelled").into(),
+            );
+        }
+        gix::objs::Find::try_find(&self.inner, id, buffer)
+    }
+}
+
+/// Read and parse the shallow boundary once for a log request.
+///
+/// The parsed ids are both the cache fingerprint and the traversal input. This
+/// deliberately bypasses gix's shared shallow snapshot, whose refresh decision
+/// is mtime-only and can therefore retain old contents after a timestamp
+/// collision.
+fn shallow_snapshot(repo: &gix::Repository) -> Result<super::ShallowSnapshot> {
+    let path = repo.shallow_file();
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(super::ShallowSnapshot::default());
+        }
+        Err(error) => {
+            return Err(Error::new(ErrorKind::Backend(format!(
+                "read shallow boundary {}: {error}",
+                path.display()
+            ))));
+        }
+    };
+
+    let commits = bytes
+        .lines()
+        .map(gix::ObjectId::from_hex)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|error| {
+            Error::new(ErrorKind::Backend(format!(
+                "parse shallow boundary {}: {error}",
+                path.display()
+            )))
+        })?;
+    Ok(super::ShallowSnapshot::from_commits(commits))
+}
+
 /// The commit filter a paged walk over `repo` needs.
 ///
 /// On a shallow repository the boundary commits record parents that are not in
@@ -603,15 +688,13 @@ fn log_paged_walk_handle(repo: &gix::ThreadSafeRepository) -> gix::OdbHandleArc 
 /// any such borrow — hence the owned handle and the boxed closure.
 fn log_paged_walk_filter(
     repo: &gix::ThreadSafeRepository,
-) -> Result<(super::LogPagedWalkFilter, bool)> {
-    let shallow_commits = repo
-        .to_thread_local()
-        .shallow_commits()
-        .map_err(|e| Error::new(ErrorKind::Backend(format!("gix shallow commits: {e}"))))?;
-    let Some(shallow_commits) = shallow_commits else {
-        return Ok((Box::new(|_| true), false));
-    };
+    shallow: &super::ShallowSnapshot,
+) -> super::LogPagedWalkFilter {
+    if !shallow.is_shallow() {
+        return Box::new(|_| true);
+    }
 
+    let shallow_commits = Arc::clone(&shallow.0);
     let objects = log_paged_walk_handle(repo);
     let mut grafted_parents_to_skip: Vec<gix::ObjectId> = Vec::new();
     let mut buf = Vec::new();
@@ -629,7 +712,7 @@ fn log_paged_walk_filter(
         }
         true
     });
-    Ok((filter, true))
+    filter
 }
 
 fn new_commit_time_walk(
@@ -665,6 +748,9 @@ fn new_log_paged_walk(
     repo: &gix::ThreadSafeRepository,
     tips: impl IntoIterator<Item = gix::ObjectId>,
     mode: HistoryMode,
+    shallow: &super::ShallowSnapshot,
+    cancellation: Option<&CancellationToken>,
+    mut chunks: Option<&mut ChunkEmitter<'_>>,
 ) -> Result<super::LogPagedWalkState> {
     let parents = if mode == HistoryMode::FirstParent {
         gix::traverse::commit::Parents::First
@@ -674,19 +760,33 @@ fn new_log_paged_walk(
     // Collected because the commit-date queue is also the fallback below, and a
     // fallback cannot re-consume an iterator the topo builder already drained.
     let tips: Vec<gix::ObjectId> = tips.into_iter().collect();
-    let (filter, is_shallow) = log_paged_walk_filter(repo)?;
+    let filter = log_paged_walk_filter(repo, shallow);
+    let walk_cancellation = LogWalkCancellation::new(cancellation);
 
     // The topo walk reports all parents in first-parent mode and cannot cross a
     // shallow boundary whose missing parents are resolved during its setup.
-    let walk = if mode == HistoryMode::FirstParent || is_shallow {
+    let walk = if mode == HistoryMode::FirstParent || shallow.is_shallow() {
         new_commit_time_walk(repo, &tips, parents, filter)?
     } else {
+        if let Some(cancellation) = cancellation {
+            cancellation.check_cancelled()?;
+        }
+        if let Some(chunks) = chunks.as_mut() {
+            chunks.ordering_started();
+        }
+        if let Some(cancellation) = cancellation {
+            cancellation.check_cancelled()?;
+        }
         let commit_graph = repo
             .to_thread_local()
             .commit_graph_if_enabled()
             .ok()
             .flatten();
-        match gix::traverse::commit::topo::Builder::new(log_paged_walk_handle(repo))
+        let find = CancellableLogWalkFind {
+            inner: log_paged_walk_handle(repo),
+            cancellation: walk_cancellation.clone(),
+        };
+        match gix::traverse::commit::topo::Builder::new(find)
             .with_predicate(filter)
             .with_tips(tips.iter().copied())
             .sorting(gix::traverse::commit::topo::Sorting::DateOrder)
@@ -694,18 +794,44 @@ fn new_log_paged_walk(
             .with_commit_graph(commit_graph)
             .build()
         {
-            Ok(walk) => super::LogPagedWalk::DateOrder(walk),
+            Ok(walk) => {
+                if let Some(cancellation) = cancellation {
+                    cancellation.check_cancelled()?;
+                }
+                super::LogPagedWalk::DateOrder(walk)
+            }
             // Fall back lazily when a missing ancestor prevents the in-degree pass.
-            Err(_) => {
-                let (filter, _) = log_paged_walk_filter(repo)?;
+            Err(error) if topo_build_error_is_missing_object(&error) => {
+                if let Some(cancellation) = cancellation {
+                    cancellation.check_cancelled()?;
+                }
+                let filter = log_paged_walk_filter(repo, shallow);
                 new_commit_time_walk(repo, &tips, parents, filter)?
+            }
+            Err(error) => {
+                if let Some(cancellation) = cancellation {
+                    cancellation.check_cancelled()?;
+                }
+                return Err(Error::new(ErrorKind::Backend(format!(
+                    "gix date-order walk: {error}"
+                ))));
             }
         }
     };
     Ok(super::LogPagedWalkState {
         pending: std::collections::VecDeque::new(),
         walk,
+        cancellation: walk_cancellation,
     })
+}
+
+fn topo_build_error_is_missing_object(error: &gix::traverse::commit::topo::Error) -> bool {
+    matches!(
+        error,
+        gix::traverse::commit::topo::Error::Find(
+            gix::objs::find::existing_iter::Error::NotFound { .. }
+        )
+    )
 }
 
 fn apply_first_parent_resume_hint(page: &mut LogPage) {
@@ -783,6 +909,7 @@ fn paginate_commits(
 pub(super) struct ChunkEmitter<'a> {
     on_chunk: &'a mut dyn FnMut(LogChunk),
     next_emit_at: std::time::Instant,
+    interval: std::time::Duration,
     scanned: u64,
 }
 
@@ -790,11 +917,27 @@ const CHUNK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(120
 
 impl<'a> ChunkEmitter<'a> {
     pub(super) fn new(on_chunk: &'a mut dyn FnMut(LogChunk)) -> Self {
+        Self::with_interval(on_chunk, CHUNK_INTERVAL)
+    }
+
+    fn with_interval(on_chunk: &'a mut dyn FnMut(LogChunk), interval: std::time::Duration) -> Self {
         Self {
             on_chunk,
-            next_emit_at: std::time::Instant::now() + CHUNK_INTERVAL,
+            next_emit_at: std::time::Instant::now() + interval,
+            interval,
             scanned: 0,
         }
+    }
+
+    /// Make the expensive ordering phase visible before gix begins its
+    /// in-degree pass. That pass cannot yield page rows yet, so an empty prefix
+    /// with a zero count is the only truthful chunk available at this point.
+    fn ordering_started(&mut self) {
+        self.next_emit_at = std::time::Instant::now() + self.interval;
+        (self.on_chunk)(LogChunk {
+            commits: Vec::new(),
+            scanned: self.scanned,
+        });
     }
 
     /// Counts `count` more visited commits and reports the page so far once the
@@ -805,7 +948,7 @@ impl<'a> ChunkEmitter<'a> {
         if std::time::Instant::now() < self.next_emit_at {
             return;
         }
-        self.next_emit_at = std::time::Instant::now() + CHUNK_INTERVAL;
+        self.next_emit_at = std::time::Instant::now() + self.interval;
         (self.on_chunk)(LogChunk {
             commits: commits.to_vec(),
             scanned: self.scanned,
@@ -827,6 +970,11 @@ fn mode_includes(mode: HistoryMode, parent_count: usize) -> bool {
 }
 
 const DECODE_BATCH: usize = 2_048;
+/// Check the progress clock after this many visited candidates. Keeping the
+/// clock read out of the per-commit hot path matters on million-commit walks,
+/// while this still updates promptly when cursor or mode filtering rejects an
+/// entire decode batch's worth of commits.
+const CHUNK_VISIT_STRIDE: u64 = 256;
 /// Commit-decode threads in flight across the whole process. Object inflation is
 /// what a filtered walk spends its time on and it parallelizes cleanly, but the
 /// budget is shared: several repositories loading at once must not multiply into
@@ -992,6 +1140,7 @@ fn log_page_from_paged_walk_state(
     let mut batch: Vec<gix::traverse::commit::Info> = Vec::with_capacity(DECODE_BATCH);
     let mut decoded: Vec<Option<Commit>> = Vec::with_capacity(DECODE_BATCH);
     let mut walk_done = false;
+    let mut visited_since_emit = 0u64;
 
     while !walk_done {
         // An unfiltered page gathers only what it can use plus one commit to
@@ -1014,32 +1163,50 @@ fn log_page_from_paged_walk_state(
                 if let Some(cancellation) = cancellation {
                     cancellation.check_cancelled()?;
                 }
-                match walk_state.walk.next() {
+                let info = match walk_state.walk.next() {
                     None => {
                         walk_done = true;
                         break;
                     }
-                    Some(result) => {
-                        let info = result.map_err(|e| {
-                            Error::new(ErrorKind::Backend(format!("gix walk: {e}")))
-                        })?;
-                        if let Some(cursor_gate) = cursor_gate.as_deref_mut()
-                            && cursor_gate.should_skip_oid(info.id.as_ref())
-                        {
-                            continue;
+                    Some(Ok(info)) => info,
+                    Some(Err(error)) => {
+                        // The cancellable object lookup surfaces through gix's
+                        // iterator error. Preserve cancellation as its public
+                        // error kind instead of misreporting it as a backend
+                        // failure.
+                        if let Some(cancellation) = cancellation {
+                            cancellation.check_cancelled()?;
                         }
-                        if !include(&info) {
-                            continue;
-                        }
-                        batch.push(info);
-                        continue;
+                        return Err(Error::new(ErrorKind::Backend(format!("gix walk: {error}"))));
                     }
+                };
+
+                visited_since_emit = visited_since_emit.saturating_add(1);
+                if visited_since_emit >= CHUNK_VISIT_STRIDE {
+                    if let Some(chunks) = chunks.as_deref_mut() {
+                        chunks.visited(visited_since_emit, &commits);
+                    }
+                    visited_since_emit = 0;
                 }
+
+                if let Some(cursor_gate) = cursor_gate.as_deref_mut()
+                    && cursor_gate.should_skip_oid(info.id.as_ref())
+                {
+                    continue;
+                }
+                if !include(&info) {
+                    continue;
+                }
+                batch.push(info);
+                continue;
             };
             batch.push(info);
         }
 
         if batch.is_empty() {
+            if let Some(chunks) = chunks.as_deref_mut() {
+                chunks.visited(visited_since_emit, &commits);
+            }
             break;
         }
 
@@ -1048,7 +1215,6 @@ fn log_page_from_paged_walk_state(
             Some(_) => batch.len(),
             None => batch.len().min(limit.saturating_sub(commits.len())),
         };
-        let scanned = decode_len as u64;
         for info in batch.drain(decode_len..).rev() {
             walk_state.pending.push_front(info);
         }
@@ -1069,6 +1235,9 @@ fn log_page_from_paged_walk_state(
                 for info in batch.drain(index..).rev() {
                     walk_state.pending.push_front(info);
                 }
+                if let Some(chunks) = chunks.as_deref_mut() {
+                    chunks.visited(visited_since_emit, &commits);
+                }
                 return Ok((commits, true));
             }
             commits.push(commit);
@@ -1077,11 +1246,21 @@ fn log_page_from_paged_walk_state(
         // Reported after the batch lands, so a chunk always carries everything
         // found so far rather than trailing a batch behind.
         if let Some(chunks) = chunks.as_deref_mut() {
-            chunks.visited(scanned, &commits);
+            chunks.visited(visited_since_emit, &commits);
         }
+        visited_since_emit = 0;
 
         if commits.len() >= limit {
-            return Ok((commits, !walk_state.pending.is_empty()));
+            if !walk_state.pending.is_empty() {
+                return Ok((commits, true));
+            }
+            if walk_done {
+                return Ok((commits, false));
+            }
+            // A filtered page can fill exactly at the end of a decode batch.
+            // Only another matching commit or actual EOF can answer whether a
+            // successor exists, so keep walking instead of guessing from the
+            // empty pending queue.
         }
     }
 
@@ -1093,6 +1272,7 @@ impl GixRepo {
         &self,
         mode: HistoryMode,
         seed: super::LogPageSeed,
+        shallow: &super::ShallowSnapshot,
         limit: usize,
         cursor: Option<&LogCursor>,
         author: Option<&AuthorFilter>,
@@ -1100,18 +1280,12 @@ impl GixRepo {
         super::LogPageCacheKey {
             mode,
             seed,
-            shallow: self.shallow_stamp(),
+            shallow: shallow.clone(),
             limit,
             last_seen: cursor.map(|cursor| cursor.last_seen.clone()),
             resume_from: cursor.and_then(|cursor| cursor.resume_from.clone()),
             author: author.cloned(),
         }
-    }
-
-    /// Stamp of the shallow boundary file, for [`Self::log_page_cache_key`].
-    /// Read through gix so a `core.shallowFile` override is honoured.
-    fn shallow_stamp(&self) -> super::RepoFileStamp {
-        super::repo_file_stamp(&self._repo.to_thread_local().shallow_file())
     }
 
     /// Serves a cached page and refreshes its successor's LRU position.
@@ -1120,16 +1294,22 @@ impl GixRepo {
         let index = cache.iter().position(|entry| &entry.key == key)?;
         let entry = cache.remove(index);
         let page = entry.page.clone();
-        let successor_starts_at = page.commits.last().map(|commit| commit.id.clone());
+        let successor_key = page
+            .next_cursor
+            .as_ref()
+            .map(|cursor| super::LogPageCacheKey {
+                mode: key.mode,
+                seed: key.seed.clone(),
+                shallow: key.shallow.clone(),
+                limit: key.limit,
+                last_seen: Some(cursor.last_seen.clone()),
+                resume_from: cursor.resume_from.clone(),
+                author: key.author.clone(),
+            });
         cache.push(entry);
 
-        if let Some(last_seen) = successor_starts_at
-            && let Some(successor) = cache.iter().position(|entry| {
-                entry.key.last_seen.as_ref() == Some(&last_seen)
-                    && entry.key.mode == key.mode
-                    && entry.key.seed == key.seed
-                    && entry.key.author == key.author
-            })
+        if let Some(successor_key) = successor_key
+            && let Some(successor) = cache.iter().position(|entry| entry.key == successor_key)
         {
             let successor = cache.remove(successor);
             cache.push(successor);
@@ -1212,6 +1392,7 @@ impl GixRepo {
         token: &str,
         mode: HistoryMode,
         tips: &[gix::ObjectId],
+        shallow: &super::ShallowSnapshot,
         author: Option<&AuthorFilter>,
     ) -> Option<super::LogPagedWalkState> {
         let mut cache = self
@@ -1222,6 +1403,7 @@ impl GixRepo {
             entry.token.as_ref() == token
                 && entry.mode == mode
                 && entry.tips.as_ref() == tips
+                && &entry.shallow == shallow
                 && entry.author.as_ref() == author
         })?;
         Some(cache.entries.remove(index).state)
@@ -1231,6 +1413,7 @@ impl GixRepo {
         &self,
         mode: HistoryMode,
         tips: &Arc<[gix::ObjectId]>,
+        shallow: &super::ShallowSnapshot,
         author: Option<&AuthorFilter>,
         state: super::LogPagedWalkState,
     ) -> Arc<str> {
@@ -1266,6 +1449,7 @@ impl GixRepo {
             token: Arc::clone(&token),
             mode,
             tips: Arc::clone(tips),
+            shallow: shallow.clone(),
             author: author.cloned(),
             state,
         });
@@ -1521,11 +1705,12 @@ impl GixRepo {
         &self,
         mode: HistoryMode,
         tips: Arc<[gix::ObjectId]>,
+        shallow: &super::ShallowSnapshot,
         limit: usize,
         cursor: Option<&LogCursor>,
         cancellation: Option<&CancellationToken>,
         author: Option<&AuthorFilter>,
-        chunks: Option<&mut ChunkEmitter<'_>>,
+        mut chunks: Option<&mut ChunkEmitter<'_>>,
     ) -> Result<LogPage> {
         if tips.is_empty() {
             return Ok(empty_log_page());
@@ -1533,7 +1718,7 @@ impl GixRepo {
 
         let cached_walk_state = cursor
             .and_then(|cursor| cursor.resume_token.as_deref())
-            .and_then(|token| self.take_log_paged_walk(token, mode, &tips, author));
+            .and_then(|token| self.take_log_paged_walk(token, mode, &tips, shallow, author));
 
         // Tokens go stale on cache eviction or a change of tips, and then the
         // walk has to be rebuilt. A first-parent cursor carries `resume_from`,
@@ -1548,14 +1733,33 @@ impl GixRepo {
             .and_then(object_id_from_commit_id);
         let (mut walk_state, mut cursor_gate) = match (cached_walk_state, resume_tip) {
             (Some(walk_state), _) => (walk_state, None),
-            (None, Some(resume_tip)) => {
-                (new_log_paged_walk(&self._repo, [resume_tip], mode)?, None)
-            }
+            (None, Some(resume_tip)) => (
+                new_log_paged_walk(
+                    &self._repo,
+                    [resume_tip],
+                    mode,
+                    shallow,
+                    cancellation,
+                    chunks.as_deref_mut(),
+                )?,
+                None,
+            ),
             (None, None) => (
-                new_log_paged_walk(&self._repo, tips.iter().copied(), mode)?,
+                new_log_paged_walk(
+                    &self._repo,
+                    tips.iter().copied(),
+                    mode,
+                    shallow,
+                    cancellation,
+                    chunks.as_deref_mut(),
+                )?,
                 cursor.map(|cursor| CursorGate::new(Some(cursor))),
             ),
         };
+        // A parked walk outlives the request that created it. Rebind the lookup
+        // hook before resuming so an old token cannot poison this page, and so
+        // this page's cancellation reaches work performed inside gix.
+        walk_state.cancellation.replace(cancellation);
 
         let (commits, has_more) = log_page_from_paged_walk_state(
             &self._repo,
@@ -1574,7 +1778,9 @@ impl GixRepo {
             .map(|commit| LogCursor {
                 last_seen: commit.id.clone(),
                 resume_from: None,
-                resume_token: Some(self.store_log_paged_walk(mode, &tips, author, walk_state)),
+                resume_token: Some(
+                    self.store_log_paged_walk(mode, &tips, shallow, author, walk_state),
+                ),
             });
         let mut page = LogPage {
             commits,
@@ -1619,10 +1825,12 @@ impl GixRepo {
         }
 
         let repo = self._repo.to_thread_local();
+        let shallow = shallow_snapshot(&repo)?;
         let head_id = gix_head_id_or_none(&repo)?;
         let cache_key = self.log_page_cache_key(
             mode,
             super::LogPageSeed::Head(head_id),
+            &shallow,
             limit,
             cursor,
             author,
@@ -1635,6 +1843,7 @@ impl GixRepo {
             Some(head_id) => self.log_paged_page(
                 mode,
                 Arc::from(vec![head_id]),
+                &shallow,
                 limit,
                 cursor,
                 cancellation,
@@ -1666,9 +1875,9 @@ impl GixRepo {
 
     fn all_branches_tips(
         &self,
+        repo: &gix::Repository,
         cancellation: Option<&CancellationToken>,
     ) -> Result<Arc<[gix::ObjectId]>> {
-        let repo = self._repo.to_thread_local();
         let refs = repo
             .references()
             .map_err(|e| Error::new(ErrorKind::Backend(format!("gix references: {e}"))))?;
@@ -1676,7 +1885,7 @@ impl GixRepo {
         // Include custom ref namespaces while leaving tags out of the graph.
         let mut tips = Vec::new();
         let mut seen = FxHashSet::default();
-        if let Some(head_id) = gix_head_id_or_none(&repo)? {
+        if let Some(head_id) = gix_head_id_or_none(repo)? {
             tips.push(head_id);
             seen.insert(head_id);
         }
@@ -1705,7 +1914,7 @@ impl GixRepo {
         }
 
         // Older stash entries are reflog-only and need explicit tips.
-        for id in stash_reflog_tips(&repo, 50).unwrap_or_default() {
+        for id in stash_reflog_tips(repo, 50).unwrap_or_default() {
             if seen.insert(id) {
                 tips.push(id);
             }
@@ -1742,11 +1951,14 @@ impl GixRepo {
             return Ok(empty_log_page());
         }
 
-        let tips = self.all_branches_tips(cancellation)?;
+        let repo = self._repo.to_thread_local();
+        let shallow = shallow_snapshot(&repo)?;
+        let tips = self.all_branches_tips(&repo, cancellation)?;
 
         let cache_key = self.log_page_cache_key(
             HistoryMode::AllBranches,
             super::LogPageSeed::Tips(Arc::clone(&tips)),
+            &shallow,
             limit,
             cursor,
             author,
@@ -1758,6 +1970,7 @@ impl GixRepo {
         let page = self.log_paged_page(
             HistoryMode::AllBranches,
             tips,
+            &shallow,
             limit,
             cursor,
             cancellation,
@@ -2136,6 +2349,54 @@ mod tests {
     #[test]
     fn object_id_from_commit_id_rejects_invalid_hex() {
         assert!(object_id_from_commit_id(&CommitId("not-a-sha".into())).is_none());
+    }
+
+    #[test]
+    fn shallow_snapshot_uses_contents_even_when_stat_metadata_collides() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workdir = tmp.path();
+        init_test_repo(workdir);
+        let repo = open_repo(workdir);
+        let local_repo = repo._repo.to_thread_local();
+        let shallow_file = local_repo.shallow_file();
+
+        fs::write(&shallow_file, b"1111111111111111111111111111111111111111\n")
+            .expect("write first shallow boundary");
+        let first_metadata = fs::metadata(&shallow_file).expect("first shallow metadata");
+        let first_modified = first_metadata.modified().expect("first shallow mtime");
+        let first = shallow_snapshot(&local_repo).expect("first shallow snapshot");
+
+        fs::write(&shallow_file, b"2222222222222222222222222222222222222222\n")
+            .expect("replace shallow boundary with the same length");
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&shallow_file)
+            .expect("open shallow boundary")
+            .set_times(fs::FileTimes::new().set_modified(first_modified))
+            .expect("restore shallow mtime");
+
+        let second_metadata = fs::metadata(&shallow_file).expect("second shallow metadata");
+        assert_eq!(second_metadata.len(), first_metadata.len());
+        assert_eq!(second_metadata.modified().ok(), Some(first_modified));
+        let second = shallow_snapshot(&local_repo).expect("second shallow snapshot");
+        assert_ne!(
+            first, second,
+            "cache identity must come from the object ids"
+        );
+    }
+
+    #[test]
+    fn only_a_missing_object_allows_the_date_order_fallback() {
+        let oid = gix::ObjectId::from_hex(b"1111111111111111111111111111111111111111")
+            .expect("valid oid");
+        let missing = gix::traverse::commit::topo::Error::Find(
+            gix::objs::find::existing_iter::Error::NotFound { oid },
+        );
+
+        assert!(topo_build_error_is_missing_object(&missing));
+        assert!(!topo_build_error_is_missing_object(
+            &gix::traverse::commit::topo::Error::MissingStateUnexpected
+        ));
     }
 
     #[test]
@@ -2652,10 +2913,12 @@ mod tests {
         init_test_repo(workdir);
         commit_file(workdir, "a.txt", "one\n", "first");
         let repo = open_repo(workdir);
+        let shallow = shallow_snapshot(&repo._repo.to_thread_local()).expect("shallow snapshot");
 
         let key = repo.log_page_cache_key(
             HistoryMode::AllBranches,
             super::super::LogPageSeed::Tips(std::sync::Arc::from(Vec::new())),
+            &shallow,
             10,
             None,
             None,
@@ -2706,10 +2969,13 @@ mod tests {
         repo.log_history_mode_page_impl(mode, 4, Some(&cursor))
             .expect("second page");
 
-        let head = gix_head_id_or_none(&repo._repo.to_thread_local()).expect("head");
+        let local_repo = repo._repo.to_thread_local();
+        let head = gix_head_id_or_none(&local_repo).expect("head");
+        let shallow = shallow_snapshot(&local_repo).expect("shallow snapshot");
         let second_key = repo.log_page_cache_key(
             mode,
             super::super::LogPageSeed::Head(head),
+            &shallow,
             4,
             Some(&cursor),
             None,
@@ -2730,20 +2996,167 @@ mod tests {
     }
 
     #[test]
-    fn chunk_emitter_reports_progress_for_the_smallest_batch_a_page_can_ask_for() {
-        let mut seen: Vec<u64> = Vec::new();
-        let mut on_chunk = |chunk: LogChunk| seen.push(chunk.scanned);
-        let mut emitter = ChunkEmitter::new(&mut on_chunk);
-
-        std::thread::sleep(CHUNK_INTERVAL + std::time::Duration::from_millis(20));
-        for _ in 0..3 {
-            emitter.visited(200, &[]);
+    fn a_page_chunk_counts_lookahead_and_rejected_commits_as_visited() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workdir = tmp.path();
+        init_test_repo(workdir);
+        for index in 0..3 {
+            commit_file(
+                workdir,
+                "a.txt",
+                &format!("v{index}\n"),
+                &format!("c{index}"),
+            );
         }
+        let repo = open_repo(workdir);
+        let local_repo = repo._repo.to_thread_local();
+        let shallow = shallow_snapshot(&local_repo).expect("shallow snapshot");
+        let head = gix_head_id_or_none(&local_repo)
+            .expect("read head")
+            .expect("head commit");
 
-        assert!(
-            !seen.is_empty(),
-            "a batched caller must reach the clock: three 200-commit batches past \
-             the interval reported nothing"
+        let mut walk = new_log_paged_walk(
+            &repo._repo,
+            [head],
+            HistoryMode::FullReachable,
+            &shallow,
+            None,
+            None,
+        )
+        .expect("build page walk");
+        let mut scanned = Vec::new();
+        let (commits, has_more) = {
+            let mut on_chunk = |chunk: LogChunk| scanned.push(chunk.scanned);
+            let mut emitter = ChunkEmitter::with_interval(&mut on_chunk, std::time::Duration::ZERO);
+            log_page_from_paged_walk_state(
+                &repo._repo,
+                &mut walk,
+                2,
+                None,
+                None,
+                None,
+                Some(&mut emitter),
+                |_| true,
+            )
+            .expect("build page")
+        };
+        assert_eq!(commits.len(), 2);
+        assert!(has_more);
+        assert_eq!(
+            scanned.last(),
+            Some(&3),
+            "the lookahead row was visited even though it was not decoded"
         );
+
+        let mut rejected_walk = new_log_paged_walk(
+            &repo._repo,
+            [head],
+            HistoryMode::FullReachable,
+            &shallow,
+            None,
+            None,
+        )
+        .expect("build rejected-row walk");
+        let mut rejected_scanned = Vec::new();
+        let (commits, has_more) = {
+            let mut on_chunk = |chunk: LogChunk| rejected_scanned.push(chunk.scanned);
+            let mut emitter = ChunkEmitter::with_interval(&mut on_chunk, std::time::Duration::ZERO);
+            log_page_from_paged_walk_state(
+                &repo._repo,
+                &mut rejected_walk,
+                1,
+                None,
+                None,
+                None,
+                Some(&mut emitter),
+                |_| false,
+            )
+            .expect("build page with rejected rows")
+        };
+        assert!(commits.is_empty());
+        assert!(!has_more);
+        assert_eq!(
+            rejected_scanned.last(),
+            Some(&3),
+            "mode-rejected candidates still count as visited"
+        );
+    }
+
+    #[test]
+    fn topo_setup_emits_a_chunk_and_honours_cancellation() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workdir = tmp.path();
+        init_test_repo(workdir);
+        commit_file(workdir, "a.txt", "one\n", "one");
+        let repo = open_repo(workdir);
+        let cancellation = CancellationToken::new();
+        let cancel_from_chunk = cancellation.clone();
+        let mut chunks = Vec::new();
+        let error = {
+            let mut on_chunk = |chunk: LogChunk| {
+                chunks.push(chunk);
+                cancel_from_chunk.cancel();
+            };
+
+            repo.log_history_mode_page_streaming_impl(
+                HistoryMode::FullReachable,
+                None,
+                10,
+                None,
+                &cancellation,
+                &mut on_chunk,
+            )
+            .expect_err("cancellation during topo setup must stop the request")
+        };
+
+        assert!(matches!(error.kind(), ErrorKind::Cancelled));
+        assert_eq!(
+            chunks,
+            vec![LogChunk::default()],
+            "the ordering phase must become visible before it starts"
+        );
+    }
+
+    #[test]
+    fn a_resumed_topo_walk_uses_the_new_pages_cancellation_token() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workdir = tmp.path();
+        init_test_repo(workdir);
+        for index in 0..3 {
+            commit_file(
+                workdir,
+                "a.txt",
+                &format!("v{index}\n"),
+                &format!("c{index}"),
+            );
+        }
+        let repo = open_repo(workdir);
+        let first_cancellation = CancellationToken::new();
+        let first = repo
+            .log_history_mode_page_streaming_impl(
+                HistoryMode::FullReachable,
+                None,
+                1,
+                None,
+                &first_cancellation,
+                &mut |_| {},
+            )
+            .expect("first page");
+        first_cancellation.cancel();
+
+        let second_cancellation = CancellationToken::new();
+        let second = repo
+            .log_history_mode_page_streaming_impl(
+                HistoryMode::FullReachable,
+                None,
+                1,
+                first.next_cursor.as_ref(),
+                &second_cancellation,
+                &mut |_| {},
+            )
+            .expect("the old page token must not cancel the resumed walk");
+
+        assert_eq!(second.commits.len(), 1);
+        assert!(second.next_cursor.is_some());
     }
 }

--- a/crates/gitcomet-git-gix/src/repo/mod.rs
+++ b/crates/gitcomet-git-gix/src/repo/mod.rs
@@ -144,12 +144,7 @@ struct TreeIndexCacheEntry {
 /// What a cached log page was walked from.
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum LogPageSeed {
-    /// The current-branch modes walk from HEAD alone.
     Head(Option<gix::ObjectId>),
-    /// `AllBranches` walks from every ref. Held as the same `Arc` every page
-    /// with these tips was given — see `GixRepo::all_branches_tips` — so a
-    /// cacheful of pages costs one tip list and a refcount each, not a copy
-    /// each.
     Tips(Arc<[gix::ObjectId]>),
 }
 
@@ -157,11 +152,7 @@ enum LogPageSeed {
 struct LogPageCacheKey {
     mode: HistoryMode,
     seed: LogPageSeed,
-    /// The shallow boundary file, which is the one way a page can go stale
-    /// without a ref moving. `git fetch --deepen`/`--unshallow` leaves every tip
-    /// where it was and only makes ancestors resolvable, so a page keyed on tips
-    /// alone would keep serving the truncated history it walked before — with
-    /// nothing left to invalidate it, since the next ref move may be days away.
+    /// Invalidates cached pages when a shallow repository is deepened.
     shallow: RepoFileStamp,
     limit: usize,
     last_seen: Option<CommitId>,
@@ -194,24 +185,12 @@ struct LogFileFollowCacheEntry {
 /// so it can borrow nothing.
 type LogPagedWalkFilter = Box<dyn FnMut(&gix::oid) -> bool + Send>;
 
-/// A resumable log walk, in whichever of the two orderings
-/// [`log::log_row_order`] asked for. The variants are different gix traversals
-/// with different error types, so the log's one consumption site
-/// (`log_page_from_paged_walk_state`) goes through this rather than through
-/// either of them directly.
 enum LogPagedWalk {
-    /// Commits ordered purely by committer date, newest first. Cheap to start:
-    /// it yields the newest queued commit and only then looks up its parents.
     CommitTime(gix::traverse::commit::Simple<gix::OdbHandleArc, LogPagedWalkFilter>),
-    /// `git log --date-order`: committer date again, but no parent is yielded
-    /// before all of its children. Costs an in-degree pass over the tips before
-    /// the first row (bounded by generation number where a commit-graph exists).
     DateOrder(gix::traverse::commit::Topo<gix::OdbHandleArc, LogPagedWalkFilter>),
 }
 
 impl LogPagedWalk {
-    /// Whether this walk is one of the expensive-to-park kind. See
-    /// [`LOG_PAGED_TOPO_WALK_CACHE_LIMIT`].
     fn is_date_order(&self) -> bool {
         matches!(self, Self::DateOrder(_))
     }
@@ -232,11 +211,6 @@ impl Iterator for LogPagedWalk {
 }
 
 struct LogPagedWalkState {
-    /// Commits pulled from the walk but not yet placed on a page. Decoding runs
-    /// in batches, so a page can end mid-batch and the rest has to wait for the
-    /// next one — in walk order. Bounded by one batch, which is what keeps the
-    /// walks parked in [`LogPagedWalkCache`] from retaining an unbounded amount
-    /// of traversal state.
     pending: std::collections::VecDeque<gix::traverse::commit::Info>,
     walk: LogPagedWalk,
 }
@@ -265,22 +239,7 @@ struct LogPagedWalkCache {
 const LOG_PAGE_CACHE_LIMIT: usize = 32;
 const LOG_FILE_FOLLOW_CACHE_LIMIT: usize = 16;
 const LOG_PAGED_WALK_CACHE_LIMIT: usize = 32;
-/// How many *date-order* walks may sit parked, out of the
-/// [`LOG_PAGED_WALK_CACHE_LIMIT`] slots.
-///
-/// A commit-date walk parks its frontier and nothing else. A date-order walk
-/// parks the in-degree bookkeeping for everything it explored, which is the
-/// whole reachable region: measured on a 50k-commit repository, each additional
-/// parked walk holds ~3.3MB resident against ~77kB for a commit-date walk — a
-/// factor of 43, and it scales with the history rather than the page. Thirty-two
-/// of them would be ~105MB on those 50k commits and several GB on a repository
-/// the size of chromium.
-///
-/// Four is enough for the access pattern the cache exists for: paging is
-/// sequential, so one lineage needs one parked walk, and the extras cover a
-/// couple of modes or filters being scrolled in turn. Past that the oldest is
-/// dropped and its next page rebuilds the walk — slower, once, instead of
-/// resident forever.
+/// Date-order walks retain in-degree state for the reachable history.
 const LOG_PAGED_TOPO_WALK_CACHE_LIMIT: usize = 4;
 
 pub(crate) struct GixRepo {
@@ -290,10 +249,6 @@ pub(crate) struct GixRepo {
     branch_tracking_config: std::sync::Mutex<Option<BranchTrackingConfigCacheEntry>>,
     tree_index_cache: std::sync::Mutex<Option<TreeIndexCacheEntry>>,
     log_page_cache: std::sync::Mutex<Vec<LogPageCacheEntry>>,
-    /// The last `AllBranches` tip list, reused while the refs still produce the
-    /// same one. Every page request rebuilds the list from the refs; without
-    /// this each cached page would hold its own copy of it, and a repository
-    /// with tens of thousands of `refs/pull/*` heads makes that copy large.
     all_branches_tips: std::sync::Mutex<Option<Arc<[gix::ObjectId]>>>,
     log_file_follow_cache: std::sync::Mutex<Vec<LogFileFollowCacheEntry>>,
     log_paged_walk_cache: std::sync::Mutex<LogPagedWalkCache>,

--- a/crates/gitcomet-git-gix/src/repo/mod.rs
+++ b/crates/gitcomet-git-gix/src/repo/mod.rs
@@ -141,10 +141,28 @@ struct TreeIndexCacheEntry {
     staged: Vec<gitcomet_core::domain::FileStatus>,
 }
 
+/// What a cached log page was walked from.
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct LogHeadPageCacheKey {
+enum LogPageSeed {
+    /// The current-branch modes walk from HEAD alone.
+    Head(Option<gix::ObjectId>),
+    /// `AllBranches` walks from every ref. Held as the same `Arc` every page
+    /// with these tips was given — see `GixRepo::all_branches_tips` — so a
+    /// cacheful of pages costs one tip list and a refcount each, not a copy
+    /// each.
+    Tips(Arc<[gix::ObjectId]>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LogPageCacheKey {
     mode: HistoryMode,
-    head_oid: Option<gix::ObjectId>,
+    seed: LogPageSeed,
+    /// The shallow boundary file, which is the one way a page can go stale
+    /// without a ref moving. `git fetch --deepen`/`--unshallow` leaves every tip
+    /// where it was and only makes ancestors resolvable, so a page keyed on tips
+    /// alone would keep serving the truncated history it walked before — with
+    /// nothing left to invalidate it, since the next ref move may be days away.
+    shallow: RepoFileStamp,
     limit: usize,
     last_seen: Option<CommitId>,
     resume_from: Option<CommitId>,
@@ -153,8 +171,8 @@ struct LogHeadPageCacheKey {
 }
 
 #[derive(Clone, Debug)]
-struct LogHeadPageCacheEntry {
-    key: LogHeadPageCacheKey,
+struct LogPageCacheEntry {
+    key: LogPageCacheKey,
     page: LogPage,
 }
 
@@ -176,7 +194,42 @@ struct LogFileFollowCacheEntry {
 /// so it can borrow nothing.
 type LogPagedWalkFilter = Box<dyn FnMut(&gix::oid) -> bool + Send>;
 
-type LogPagedWalk = gix::traverse::commit::Simple<gix::OdbHandleArc, LogPagedWalkFilter>;
+/// A resumable log walk, in whichever of the two orderings
+/// [`log::log_row_order`] asked for. The variants are different gix traversals
+/// with different error types, so the log's one consumption site
+/// (`log_page_from_paged_walk_state`) goes through this rather than through
+/// either of them directly.
+enum LogPagedWalk {
+    /// Commits ordered purely by committer date, newest first. Cheap to start:
+    /// it yields the newest queued commit and only then looks up its parents.
+    CommitTime(gix::traverse::commit::Simple<gix::OdbHandleArc, LogPagedWalkFilter>),
+    /// `git log --date-order`: committer date again, but no parent is yielded
+    /// before all of its children. Costs an in-degree pass over the tips before
+    /// the first row (bounded by generation number where a commit-graph exists).
+    DateOrder(gix::traverse::commit::Topo<gix::OdbHandleArc, LogPagedWalkFilter>),
+}
+
+impl LogPagedWalk {
+    /// Whether this walk is one of the expensive-to-park kind. See
+    /// [`LOG_PAGED_TOPO_WALK_CACHE_LIMIT`].
+    fn is_date_order(&self) -> bool {
+        matches!(self, Self::DateOrder(_))
+    }
+}
+
+impl Iterator for LogPagedWalk {
+    type Item = std::result::Result<
+        gix::traverse::commit::Info,
+        Box<dyn std::error::Error + Send + Sync + 'static>,
+    >;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::CommitTime(walk) => walk.next().map(|info| info.map_err(Into::into)),
+            Self::DateOrder(walk) => walk.next().map(|info| info.map_err(Into::into)),
+        }
+    }
+}
 
 struct LogPagedWalkState {
     /// Commits pulled from the walk but not yet placed on a page. Decoding runs
@@ -209,9 +262,26 @@ struct LogPagedWalkCache {
     entries: Vec<LogPagedWalkCacheEntry>,
 }
 
-const LOG_HEAD_PAGE_CACHE_LIMIT: usize = 32;
+const LOG_PAGE_CACHE_LIMIT: usize = 32;
 const LOG_FILE_FOLLOW_CACHE_LIMIT: usize = 16;
 const LOG_PAGED_WALK_CACHE_LIMIT: usize = 32;
+/// How many *date-order* walks may sit parked, out of the
+/// [`LOG_PAGED_WALK_CACHE_LIMIT`] slots.
+///
+/// A commit-date walk parks its frontier and nothing else. A date-order walk
+/// parks the in-degree bookkeeping for everything it explored, which is the
+/// whole reachable region: measured on a 50k-commit repository, each additional
+/// parked walk holds ~3.3MB resident against ~77kB for a commit-date walk — a
+/// factor of 43, and it scales with the history rather than the page. Thirty-two
+/// of them would be ~105MB on those 50k commits and several GB on a repository
+/// the size of chromium.
+///
+/// Four is enough for the access pattern the cache exists for: paging is
+/// sequential, so one lineage needs one parked walk, and the extras cover a
+/// couple of modes or filters being scrolled in turn. Past that the oldest is
+/// dropped and its next page rebuilds the walk — slower, once, instead of
+/// resident forever.
+const LOG_PAGED_TOPO_WALK_CACHE_LIMIT: usize = 4;
 
 pub(crate) struct GixRepo {
     spec: RepoSpec,
@@ -219,7 +289,12 @@ pub(crate) struct GixRepo {
     gitlink_status_capability: std::sync::Mutex<Option<GitlinkStatusCapabilityCacheEntry>>,
     branch_tracking_config: std::sync::Mutex<Option<BranchTrackingConfigCacheEntry>>,
     tree_index_cache: std::sync::Mutex<Option<TreeIndexCacheEntry>>,
-    log_head_page_cache: std::sync::Mutex<Vec<LogHeadPageCacheEntry>>,
+    log_page_cache: std::sync::Mutex<Vec<LogPageCacheEntry>>,
+    /// The last `AllBranches` tip list, reused while the refs still produce the
+    /// same one. Every page request rebuilds the list from the refs; without
+    /// this each cached page would hold its own copy of it, and a repository
+    /// with tens of thousands of `refs/pull/*` heads makes that copy large.
+    all_branches_tips: std::sync::Mutex<Option<Arc<[gix::ObjectId]>>>,
     log_file_follow_cache: std::sync::Mutex<Vec<LogFileFollowCacheEntry>>,
     log_paged_walk_cache: std::sync::Mutex<LogPagedWalkCache>,
 }
@@ -232,7 +307,8 @@ impl GixRepo {
             gitlink_status_capability: std::sync::Mutex::new(None),
             branch_tracking_config: std::sync::Mutex::new(None),
             tree_index_cache: std::sync::Mutex::new(None),
-            log_head_page_cache: std::sync::Mutex::new(Vec::new()),
+            log_page_cache: std::sync::Mutex::new(Vec::new()),
+            all_branches_tips: std::sync::Mutex::new(None),
             log_file_follow_cache: std::sync::Mutex::new(Vec::new()),
             log_paged_walk_cache: std::sync::Mutex::new(LogPagedWalkCache::default()),
         }

--- a/crates/gitcomet-git-gix/src/repo/mod.rs
+++ b/crates/gitcomet-git-gix/src/repo/mod.rs
@@ -148,12 +148,34 @@ enum LogPageSeed {
     Tips(Arc<[gix::ObjectId]>),
 }
 
+/// An exact, parsed snapshot of the repository's shallow boundary.
+///
+/// The shallow file is tiny and its object ids are the state that affects a
+/// history walk. Keeping those ids directly avoids the same-length/same-mtime
+/// collisions a stat-only stamp permits, and lets walk construction use the
+/// exact same boundary that keyed its caches.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct ShallowSnapshot(Arc<[gix::ObjectId]>);
+
+impl ShallowSnapshot {
+    fn from_commits(mut commits: Vec<gix::ObjectId>) -> Self {
+        commits.sort();
+        commits.dedup();
+        Self(Arc::from(commits))
+    }
+
+    fn is_shallow(&self) -> bool {
+        !self.0.is_empty()
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct LogPageCacheKey {
     mode: HistoryMode,
     seed: LogPageSeed,
-    /// Invalidates cached pages when a shallow repository is deepened.
-    shallow: RepoFileStamp,
+    /// Invalidates cached pages when a shallow repository is deepened or its
+    /// boundary is otherwise replaced without moving a ref.
+    shallow: ShallowSnapshot,
     limit: usize,
     last_seen: Option<CommitId>,
     resume_from: Option<CommitId>,
@@ -187,7 +209,7 @@ type LogPagedWalkFilter = Box<dyn FnMut(&gix::oid) -> bool + Send>;
 
 enum LogPagedWalk {
     CommitTime(gix::traverse::commit::Simple<gix::OdbHandleArc, LogPagedWalkFilter>),
-    DateOrder(gix::traverse::commit::Topo<gix::OdbHandleArc, LogPagedWalkFilter>),
+    DateOrder(gix::traverse::commit::Topo<log::CancellableLogWalkFind, LogPagedWalkFilter>),
 }
 
 impl LogPagedWalk {
@@ -213,6 +235,7 @@ impl Iterator for LogPagedWalk {
 struct LogPagedWalkState {
     pending: std::collections::VecDeque<gix::traverse::commit::Info>,
     walk: LogPagedWalk,
+    cancellation: log::LogWalkCancellation,
 }
 
 struct LogPagedWalkCacheEntry {
@@ -222,6 +245,9 @@ struct LogPagedWalkCacheEntry {
     /// ref for `AllBranches`. A walk started from different tips covers a
     /// different history, so a token minted for one must not resume the other.
     tips: Arc<[gix::ObjectId]>,
+    /// The exact shallow boundary the walk was built against. A cursor minted
+    /// before a deepen must not resume the old, truncated walk.
+    shallow: ShallowSnapshot,
     /// Author filter the walk was started with, or `None` for the unfiltered
     /// walk. The walk's *position* depends on the filter — every non-matching
     /// commit was already consumed — so resuming one walk under a different

--- a/crates/gitcomet-git-gix/tests/log_integration.rs
+++ b/crates/gitcomet-git-gix/tests/log_integration.rs
@@ -126,6 +126,45 @@ fn run_git_at(repo: &Path, args: &[&str], unix_seconds: i64) {
     run_git_with_env(repo, args, &envs);
 }
 
+/// A linear history of `count` commits, built in one `git fast-import` pass.
+/// Used where a test needs more commits than a page's gather batch holds and
+/// does not care what is in them.
+fn fast_import_linear_history(repo: &Path, count: usize) {
+    let mut stream = String::new();
+    for index in 0..count {
+        let message = format!("c{index}");
+        stream.push_str("commit refs/heads/master\n");
+        stream.push_str(&format!("mark :{}\n", index + 1));
+        stream.push_str(&format!(
+            "committer You <you@example.com> {} +0000\n",
+            1_600_000_000 + index as i64
+        ));
+        stream.push_str(&format!("data {}\n{message}\n", message.len()));
+        if index > 0 {
+            stream.push_str(&format!("from :{}\n", index));
+        }
+        let body = format!("v{index}\n");
+        stream.push_str(&format!(
+            "M 100644 inline file.txt\ndata {}\n{body}",
+            body.len()
+        ));
+    }
+    stream.push_str("done\n");
+
+    let mut cmd = Command::new("git");
+    test_git_env::apply(&mut cmd);
+    let mut child = cmd
+        .arg("-C")
+        .arg(repo)
+        .args(["fast-import", "--quiet", "--done"])
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .expect("git fast-import to start");
+    std::io::Write::write_all(child.stdin.as_mut().unwrap(), stream.as_bytes()).unwrap();
+    assert!(child.wait().unwrap().success(), "git fast-import failed");
+    run_git(repo, &["reset", "-q", "--hard", "master"]);
+}
+
 fn commit_file_at(repo: &Path, relative_path: &str, contents: &str, message: &str, time: i64) {
     let path = repo.join(relative_path);
     if let Some(parent) = path.parent() {
@@ -761,6 +800,468 @@ fn log_all_branches_includes_remote_tracking_branches() {
     assert!(
         all.commits.iter().any(|c| c.id.as_ref() == feature_tip),
         "all-branches log should include remote-tracking branch commit"
+    );
+}
+
+/// Issue #390. A commit whose committer date is newer than one of its children's
+/// -- a rebase with `--committer-date-is-author-date`, a `git am`, a machine
+/// whose clock runs behind -- comes out of a plain commit-date priority queue
+/// *between* its own children. The graph then paints a parent above its child,
+/// its lane cannot connect downwards, and every row below it sits one off what
+/// `git log` shows, which reads as ref labels on the wrong commits.
+#[test]
+fn log_all_branches_orders_rows_like_git_date_order_under_committer_date_skew() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+
+    run_git(repo, &["init", "-b", "master"]);
+    run_git(repo, &["config", "user.email", "you@example.com"]);
+    run_git(repo, &["config", "user.name", "You"]);
+
+    let commit_at = |name: &str, date: &str| {
+        std::fs::write(repo.join(format!("{name}.txt")), name).unwrap();
+        run_git(repo, &["add", "-A"]);
+        run_git_with_env(
+            repo,
+            &["-c", "commit.gpgsign=false", "commit", "-m", name],
+            &[("GIT_AUTHOR_DATE", date), ("GIT_COMMITTER_DATE", date)],
+        );
+    };
+
+    commit_at("base", "2026-08-20T10:00:00+0000");
+    commit_at("master-tip", "2026-08-20T12:00:00+0000");
+    // Both branches are children of master's tip, and their committer dates
+    // straddle it.
+    run_git(repo, &["checkout", "-q", "-b", "topic-b", "master"]);
+    commit_at("topic-b-tip", "2026-08-20T11:50:00+0000");
+    run_git(repo, &["checkout", "-q", "-b", "topic-a", "master"]);
+    commit_at("topic-a-tip", "2026-08-20T12:10:00+0000");
+    run_git(repo, &["checkout", "-q", "master"]);
+
+    let expected: Vec<String> = git_stdout(repo, &["log", "--all", "--date-order", "--format=%H"])
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(expected.len(), 4, "expected a four-commit history");
+
+    let backend = GixBackend;
+    let opened = backend.open(repo).unwrap();
+    let page = opened.log_all_branches_page(200, None).unwrap();
+    let actual: Vec<String> = page
+        .commits
+        .iter()
+        .map(|commit| commit.id.as_ref().to_owned())
+        .collect();
+
+    let summaries: Vec<&str> = page
+        .commits
+        .iter()
+        .map(|commit| commit.summary.as_ref())
+        .collect();
+    assert_eq!(
+        actual, expected,
+        "log rows must match `git log --all --date-order`; got {summaries:?}"
+    );
+    assert_eq!(
+        summaries,
+        vec!["topic-a-tip", "topic-b-tip", "master-tip", "base"],
+        "a parent must not be listed before its own child"
+    );
+}
+
+/// Issue #390 across the history modes. The reordering needs a commit with two
+/// children whose committer date sits between theirs, so every mode that can
+/// queue a fork is affected: `FullReachable`, `NoMerges`, `MergesOnly` and
+/// `AllBranches`. `FirstParent` cannot be — it is seeded from one tip and
+/// follows one parent per step, so only ever one commit is queued — and it
+/// stays on the commit-date walk, which is also what keeps it reporting a single
+/// parent per row in `Commit::parent_ids`.
+#[test]
+fn every_history_mode_matches_git_row_order_under_committer_date_skew() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+
+    run_git(repo, &["init", "-b", "master"]);
+    run_git(repo, &["config", "user.email", "you@example.com"]);
+    run_git(repo, &["config", "user.name", "You"]);
+
+    let commit_at = |name: &str, date: &str| {
+        std::fs::write(repo.join(format!("{name}.txt")), name).unwrap();
+        run_git(repo, &["add", "-A"]);
+        run_git_with_env(
+            repo,
+            &["-c", "commit.gpgsign=false", "commit", "-m", name],
+            &[("GIT_AUTHOR_DATE", date), ("GIT_COMMITTER_DATE", date)],
+        );
+    };
+    let merge_at = |branch: &str, name: &str, date: &str| {
+        run_git_with_env(
+            repo,
+            &[
+                "-c",
+                "commit.gpgsign=false",
+                "merge",
+                "--no-ff",
+                "-m",
+                name,
+                branch,
+            ],
+            &[("GIT_AUTHOR_DATE", date), ("GIT_COMMITTER_DATE", date)],
+        );
+    };
+
+    // `P` is the fork: `X`, `Z` and `Y` all hang off it, and its committer date
+    // sits between theirs. `X` and `Z` are then merged back into master, so the
+    // skew is reachable from HEAD alone and not only in the all-branches scope.
+    commit_at("base", "2026-08-20T10:00:00+0000");
+    commit_at("P", "2026-08-20T12:00:00+0000");
+    let fork = git_stdout(repo, &["rev-parse", "HEAD"]);
+
+    run_git(repo, &["checkout", "-q", "-b", "topic-b", "master"]);
+    commit_at("X", "2026-08-20T11:50:00+0000");
+    run_git(repo, &["checkout", "-q", "-b", "topic-a", "master"]);
+    commit_at("Y", "2026-08-20T12:10:00+0000");
+    run_git(repo, &["checkout", "-q", "-b", "topic-c", fork.as_str()]);
+    commit_at("Z", "2026-08-20T11:40:00+0000");
+
+    run_git(repo, &["checkout", "-q", "master"]);
+    merge_at("topic-b", "M", "2026-08-20T12:20:00+0000");
+    merge_at("topic-c", "N", "2026-08-20T11:45:00+0000");
+
+    let backend = GixBackend;
+    let opened = backend.open(repo).unwrap();
+
+    for (mode, git_args) in [
+        (
+            HistoryMode::FullReachable,
+            vec!["log", "--date-order", "--format=%s"],
+        ),
+        (
+            HistoryMode::FirstParent,
+            vec!["log", "--date-order", "--first-parent", "--format=%s"],
+        ),
+        (
+            HistoryMode::NoMerges,
+            vec!["log", "--date-order", "--no-merges", "--format=%s"],
+        ),
+        (
+            HistoryMode::MergesOnly,
+            vec!["log", "--date-order", "--merges", "--format=%s"],
+        ),
+        (
+            HistoryMode::AllBranches,
+            vec!["log", "--all", "--date-order", "--format=%s"],
+        ),
+    ] {
+        let expected: Vec<String> = git_stdout(repo, &git_args)
+            .lines()
+            .map(str::to_owned)
+            .collect();
+        let page = opened.log_history_mode_page(mode, 50, None).unwrap();
+        let actual: Vec<String> = page
+            .commits
+            .iter()
+            .map(|commit| commit.summary.to_string())
+            .collect();
+        assert_eq!(
+            actual, expected,
+            "{mode:?} rows must match `git {git_args:?}`"
+        );
+    }
+
+    // First-parent mode shows the merged-in branch nowhere, so its rows must not
+    // claim a second parent either: that list is what the graph draws lanes from.
+    let first_parent = opened
+        .log_history_mode_page(HistoryMode::FirstParent, 50, None)
+        .unwrap();
+    assert!(
+        first_parent
+            .commits
+            .iter()
+            .all(|commit| commit.parent_ids.len() <= 1),
+        "first-parent rows must report only the parent the walk followed"
+    );
+    let full = opened
+        .log_history_mode_page(HistoryMode::FullReachable, 50, None)
+        .unwrap();
+    assert!(
+        full.commits
+            .iter()
+            .any(|commit| commit.parent_ids.len() == 2),
+        "the merges must still report both parents everywhere else"
+    );
+}
+
+/// The all-branches page is cached against the tips it was walked from, which
+/// is what keeps a refresh that touched no ref from re-walking the history. The
+/// cache is only safe while every way the tip set can change invalidates it —
+/// commits, branches that HEAD does not point at, ref deletion, and the stash
+/// reflog, which seeds tips of its own.
+///
+/// Deepening a shallow clone changes the history without changing a tip at all;
+/// that one has its own test below.
+#[test]
+fn the_all_branches_page_cache_is_invalidated_by_every_kind_of_ref_move() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+    run_git(repo, &["init", "-b", "master"]);
+    run_git(repo, &["config", "user.email", "you@example.com"]);
+    run_git(repo, &["config", "user.name", "You"]);
+
+    // Explicit, increasing commit times: with date order the row sequence is
+    // otherwise a tie-break between commits made in the same second, which is
+    // not what this test is about.
+    let mut clock = 0i64;
+    let mut commit = |name: &str| {
+        clock += 60;
+        commit_file_at(repo, &format!("{name}.txt"), name, name, clock);
+        clock
+    };
+
+    commit("one");
+    let backend = GixBackend;
+    let opened = backend.open(repo).unwrap();
+
+    let summaries = || -> Vec<String> {
+        opened
+            .log_all_branches_page(50, None)
+            .unwrap()
+            .commits
+            .iter()
+            .map(|commit| commit.summary.to_string())
+            .collect()
+    };
+
+    assert_eq!(summaries(), vec!["one"]);
+    // Served from cache the second time; same answer either way.
+    assert_eq!(summaries(), vec!["one"]);
+
+    // HEAD moves.
+    commit("two");
+    assert_eq!(summaries(), vec!["two", "one"]);
+
+    // A branch that HEAD does not point at moves.
+    run_git(repo, &["checkout", "-q", "-b", "side"]);
+    commit("three");
+    run_git(repo, &["checkout", "-q", "master"]);
+    assert_eq!(summaries(), vec!["three", "two", "one"]);
+
+    // A stash entry appears: the stash reflog seeds tips too. The stash commit
+    // and its index parent both become rows, so the assertion is on the exact
+    // set — a length check would pass for any growth, including a wrong one.
+    std::fs::write(repo.join("one.txt"), "dirty").unwrap();
+    run_git(repo, &["stash", "push", "-m", "stashed"]);
+    let with_stash = summaries();
+    // The stash commit and the index commit under it are both rows. Their date
+    // is "now" rather than anything this test set, so they are matched by what
+    // they are and not by where they land.
+    assert_eq!(
+        with_stash.len(),
+        5,
+        "expected the stash commit and its index parent, got {with_stash:?}"
+    );
+    assert!(
+        with_stash.iter().any(|row| row == "On master: stashed"),
+        "the stash commit must be a row, got {with_stash:?}"
+    );
+    assert!(
+        with_stash
+            .iter()
+            .any(|row| row.starts_with("index on master:")),
+        "the stash's index commit must be a row, got {with_stash:?}"
+    );
+    let kept: Vec<&String> = with_stash
+        .iter()
+        .filter(|row| *row != "On master: stashed" && !row.starts_with("index on master:"))
+        .collect();
+    assert_eq!(
+        kept,
+        ["three", "two", "one"],
+        "the rows that were already there must be unchanged, got {with_stash:?}"
+    );
+
+    // A ref is deleted: the tip set shrinks, which a keyed-on-tips cache has to
+    // notice just as it notices growth.
+    run_git(repo, &["stash", "drop"]);
+    run_git(repo, &["branch", "-D", "side"]);
+    let after_delete = summaries();
+    assert_eq!(
+        after_delete,
+        vec!["two", "one"],
+        "deleting a branch must drop the commits only it reached"
+    );
+
+    // Tags are deliberately not tips — `git log --all` walks them, this does
+    // not, so that a tag cannot pull an abandoned line of history back into the
+    // graph. A tag therefore neither invalidates the page nor adds a row.
+    run_git(repo, &["tag", "-a", "v1", "-m", "v1", "master"]);
+    assert_eq!(
+        summaries(),
+        vec!["two", "one"],
+        "a tag on a commit that is already reachable changes nothing"
+    );
+    let unreachable = git_stdout(repo, &["rev-parse", "master"]);
+    let _ = commit("four");
+    run_git(repo, &["tag", "orphan", unreachable.as_str()]);
+    run_git(repo, &["update-ref", "refs/heads/master", &unreachable]);
+    run_git(repo, &["reset", "-q", "--hard", "master"]);
+    assert_eq!(
+        summaries(),
+        vec!["two", "one"],
+        "a commit reachable only through a tag stays out of the graph"
+    );
+}
+
+/// The all-branches page cache is keyed on the tips it walked from, on the
+/// grounds that the objects a page names never change. A shallow deepen breaks
+/// exactly that assumption: `git fetch --unshallow` moves no ref, it only makes
+/// ancestors that were always named by those tips resolvable. The cached page
+/// is then a truncated history that nothing will ever invalidate.
+#[test]
+fn deepening_a_shallow_clone_invalidates_the_all_branches_page_cache() {
+    let dir = tempfile::tempdir().unwrap();
+    let origin_work = dir.path().join("origin-work");
+    let origin_bare = dir.path().join("origin.git");
+    let shallow = dir.path().join("shallow");
+    std::fs::create_dir_all(&origin_work).unwrap();
+
+    run_git(&origin_work, &["init", "-b", "main"]);
+    run_git(&origin_work, &["config", "user.email", "you@example.com"]);
+    run_git(&origin_work, &["config", "user.name", "You"]);
+    run_git(&origin_work, &["config", "commit.gpgsign", "false"]);
+    for (index, name) in ["base", "one", "two", "three", "tip"].iter().enumerate() {
+        commit_file_at(
+            &origin_work,
+            &format!("{name}.txt"),
+            &format!("{name}\n"),
+            name,
+            index as i64 + 1,
+        );
+    }
+
+    let origin_work_str = origin_work.to_string_lossy().to_string();
+    let origin_bare_str = origin_bare.to_string_lossy().to_string();
+    let shallow_str = shallow.to_string_lossy().to_string();
+    run_git(
+        dir.path(),
+        &[
+            "clone",
+            "--bare",
+            origin_work_str.as_str(),
+            origin_bare_str.as_str(),
+        ],
+    );
+    let origin_url = git_force_file_transport_url(&origin_bare);
+    run_git(
+        dir.path(),
+        &[
+            "clone",
+            "--depth",
+            "2",
+            origin_url.as_str(),
+            shallow_str.as_str(),
+        ],
+    );
+
+    let opened = GixBackend.open(&shallow).unwrap();
+    let tips_before = git_stdout(
+        &shallow,
+        &["for-each-ref", "--format=%(objectname) %(refname)"],
+    );
+    let truncated = opened.log_all_branches_page(50, None).unwrap();
+    assert_eq!(
+        truncated.commits.len(),
+        2,
+        "a depth-2 clone starts with two rows"
+    );
+
+    run_git(&shallow, &["fetch", "--unshallow"]);
+    assert_eq!(
+        git_stdout(&shallow, &["rev-parse", "--is-shallow-repository"]),
+        "false"
+    );
+    assert_eq!(
+        git_stdout(
+            &shallow,
+            &["for-each-ref", "--format=%(objectname) %(refname)"]
+        ),
+        tips_before,
+        "the deepen must not move a ref, or the test proves nothing"
+    );
+
+    let deepened = opened.log_all_branches_page(50, None).unwrap();
+    assert_eq!(
+        deepened.commits.len(),
+        5,
+        "the deepened history must not be served from the page cached before the deepen"
+    );
+}
+
+/// A history whose objects are not all present must still render the rows above
+/// the hole. A page that stops short of a missing ancestor never had to resolve
+/// it, so it is a complete page — a repository with a pruned reflog entry or a
+/// half-fetched pack has to stay readable.
+///
+/// The history is deliberately longer than one gather batch and the hole is at
+/// its root, so a lazy walk cannot reach the hole while filling the page. What
+/// must not happen is failing before the first row, which is what an up-front
+/// in-degree pass over the whole reachable graph does.
+#[test]
+fn a_missing_ancestor_object_still_renders_the_rows_above_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+    run_git(repo, &["init", "-b", "master"]);
+    run_git(repo, &["config", "user.email", "you@example.com"]);
+    run_git(repo, &["config", "user.name", "You"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    fast_import_linear_history(repo, 600);
+
+    let root = git_stdout(repo, &["rev-list", "--max-parents=0", "HEAD"]);
+    // fast-import packs; unpack so a single commit object can be removed.
+    let pack_dir = repo.join(".git/objects/pack");
+    let packs: Vec<std::path::PathBuf> = std::fs::read_dir(&pack_dir)
+        .unwrap()
+        .filter_map(|entry| {
+            let path = entry.unwrap().path();
+            (path.extension().is_some_and(|ext| ext == "pack")).then_some(path)
+        })
+        .collect();
+    for pack in &packs {
+        // The pack has to leave the object store first: `unpack-objects` skips
+        // anything the repository can already find.
+        let bytes = std::fs::read(pack).unwrap();
+        std::fs::remove_file(pack).unwrap();
+        std::fs::remove_file(pack.with_extension("idx")).ok();
+        let mut cmd = Command::new("git");
+        test_git_env::apply(&mut cmd);
+        let mut child = cmd
+            .arg("-C")
+            .arg(repo)
+            .args(["unpack-objects", "-q"])
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        std::io::Write::write_all(child.stdin.as_mut().unwrap(), &bytes).unwrap();
+        assert!(child.wait().unwrap().success(), "git unpack-objects failed");
+    }
+
+    let loose = repo.join(".git/objects").join(&root[..2]).join(&root[2..]);
+    assert!(loose.exists(), "expected a loose root commit at {loose:?}");
+    std::fs::remove_file(&loose).unwrap();
+
+    let opened = GixBackend.open(repo).unwrap();
+    let page = opened
+        .log_history_mode_page(HistoryMode::FullReachable, 2, None)
+        .expect("a page that stops above the hole must not fail");
+    let summaries: Vec<&str> = page
+        .commits
+        .iter()
+        .map(|commit| commit.summary.as_ref())
+        .collect();
+    assert_eq!(
+        summaries,
+        vec!["c599", "c598"],
+        "the rows above the hole must still render"
     );
 }
 

--- a/crates/gitcomet-git-gix/tests/log_integration.rs
+++ b/crates/gitcomet-git-gix/tests/log_integration.rs
@@ -126,9 +126,6 @@ fn run_git_at(repo: &Path, args: &[&str], unix_seconds: i64) {
     run_git_with_env(repo, args, &envs);
 }
 
-/// A linear history of `count` commits, built in one `git fast-import` pass.
-/// Used where a test needs more commits than a page's gather batch holds and
-/// does not care what is in them.
 fn fast_import_linear_history(repo: &Path, count: usize) {
     let mut stream = String::new();
     for index in 0..count {
@@ -501,11 +498,6 @@ fn full_reachable_history_mode_paginates_without_repeating_commits() {
     assert_eq!(legacy_second.commits, second.commits);
 }
 
-/// Every history mode pages through the resumable walk, first-parent and
-/// all-branches included. Without a resume token the walk is rebuilt from the
-/// tips and re-traversed to the cursor for every page, so an author filter that
-/// had to cross the whole history to fill one page crosses it again for the
-/// next, and again for the one after that.
 #[test]
 fn every_history_mode_paginates_through_a_resumable_walk() {
     let fixture = HistoryModeFixture::new();
@@ -554,8 +546,6 @@ fn every_history_mode_paginates_through_a_resumable_walk() {
     }
 }
 
-/// The scope this mattered most for: `AllBranches` walks from every ref, so
-/// rebuilding it per page is the most expensive rebuild there is.
 #[test]
 fn all_branches_author_filter_resumes_instead_of_re_walking() {
     let fixture = HistoryModeFixture::new();
@@ -589,9 +579,6 @@ fn all_branches_author_filter_resumes_instead_of_re_walking() {
     );
 }
 
-/// A shallow clone pages through the same resumable walk as everything else —
-/// its boundary is a filter on the traversal, not a reason to re-walk from the
-/// tip for every page — and still stops dead at the boundary.
 #[test]
 fn shallow_history_modes_paginate_and_stop_at_the_boundary() {
     let dir = tempfile::tempdir().unwrap();
@@ -803,12 +790,6 @@ fn log_all_branches_includes_remote_tracking_branches() {
     );
 }
 
-/// Issue #390. A commit whose committer date is newer than one of its children's
-/// -- a rebase with `--committer-date-is-author-date`, a `git am`, a machine
-/// whose clock runs behind -- comes out of a plain commit-date priority queue
-/// *between* its own children. The graph then paints a parent above its child,
-/// its lane cannot connect downwards, and every row below it sits one off what
-/// `git log` shows, which reads as ref labels on the wrong commits.
 #[test]
 fn log_all_branches_orders_rows_like_git_date_order_under_committer_date_skew() {
     let dir = tempfile::tempdir().unwrap();
@@ -830,8 +811,6 @@ fn log_all_branches_orders_rows_like_git_date_order_under_committer_date_skew() 
 
     commit_at("base", "2026-08-20T10:00:00+0000");
     commit_at("master-tip", "2026-08-20T12:00:00+0000");
-    // Both branches are children of master's tip, and their committer dates
-    // straddle it.
     run_git(repo, &["checkout", "-q", "-b", "topic-b", "master"]);
     commit_at("topic-b-tip", "2026-08-20T11:50:00+0000");
     run_git(repo, &["checkout", "-q", "-b", "topic-a", "master"]);
@@ -869,13 +848,6 @@ fn log_all_branches_orders_rows_like_git_date_order_under_committer_date_skew() 
     );
 }
 
-/// Issue #390 across the history modes. The reordering needs a commit with two
-/// children whose committer date sits between theirs, so every mode that can
-/// queue a fork is affected: `FullReachable`, `NoMerges`, `MergesOnly` and
-/// `AllBranches`. `FirstParent` cannot be — it is seeded from one tip and
-/// follows one parent per step, so only ever one commit is queued — and it
-/// stays on the commit-date walk, which is also what keeps it reporting a single
-/// parent per row in `Commit::parent_ids`.
 #[test]
 fn every_history_mode_matches_git_row_order_under_committer_date_skew() {
     let dir = tempfile::tempdir().unwrap();
@@ -910,9 +882,6 @@ fn every_history_mode_matches_git_row_order_under_committer_date_skew() {
         );
     };
 
-    // `P` is the fork: `X`, `Z` and `Y` all hang off it, and its committer date
-    // sits between theirs. `X` and `Z` are then merged back into master, so the
-    // skew is reachable from HEAD alone and not only in the all-branches scope.
     commit_at("base", "2026-08-20T10:00:00+0000");
     commit_at("P", "2026-08-20T12:00:00+0000");
     let fork = git_stdout(repo, &["rev-parse", "HEAD"]);
@@ -969,8 +938,6 @@ fn every_history_mode_matches_git_row_order_under_committer_date_skew() {
         );
     }
 
-    // First-parent mode shows the merged-in branch nowhere, so its rows must not
-    // claim a second parent either: that list is what the graph draws lanes from.
     let first_parent = opened
         .log_history_mode_page(HistoryMode::FirstParent, 50, None)
         .unwrap();
@@ -992,14 +959,6 @@ fn every_history_mode_matches_git_row_order_under_committer_date_skew() {
     );
 }
 
-/// The all-branches page is cached against the tips it was walked from, which
-/// is what keeps a refresh that touched no ref from re-walking the history. The
-/// cache is only safe while every way the tip set can change invalidates it —
-/// commits, branches that HEAD does not point at, ref deletion, and the stash
-/// reflog, which seeds tips of its own.
-///
-/// Deepening a shallow clone changes the history without changing a tip at all;
-/// that one has its own test below.
 #[test]
 fn the_all_branches_page_cache_is_invalidated_by_every_kind_of_ref_move() {
     let dir = tempfile::tempdir().unwrap();
@@ -1008,9 +967,6 @@ fn the_all_branches_page_cache_is_invalidated_by_every_kind_of_ref_move() {
     run_git(repo, &["config", "user.email", "you@example.com"]);
     run_git(repo, &["config", "user.name", "You"]);
 
-    // Explicit, increasing commit times: with date order the row sequence is
-    // otherwise a tie-break between commits made in the same second, which is
-    // not what this test is about.
     let mut clock = 0i64;
     let mut commit = |name: &str| {
         clock += 60;
@@ -1033,28 +989,19 @@ fn the_all_branches_page_cache_is_invalidated_by_every_kind_of_ref_move() {
     };
 
     assert_eq!(summaries(), vec!["one"]);
-    // Served from cache the second time; same answer either way.
     assert_eq!(summaries(), vec!["one"]);
 
-    // HEAD moves.
     commit("two");
     assert_eq!(summaries(), vec!["two", "one"]);
 
-    // A branch that HEAD does not point at moves.
     run_git(repo, &["checkout", "-q", "-b", "side"]);
     commit("three");
     run_git(repo, &["checkout", "-q", "master"]);
     assert_eq!(summaries(), vec!["three", "two", "one"]);
 
-    // A stash entry appears: the stash reflog seeds tips too. The stash commit
-    // and its index parent both become rows, so the assertion is on the exact
-    // set — a length check would pass for any growth, including a wrong one.
     std::fs::write(repo.join("one.txt"), "dirty").unwrap();
     run_git(repo, &["stash", "push", "-m", "stashed"]);
     let with_stash = summaries();
-    // The stash commit and the index commit under it are both rows. Their date
-    // is "now" rather than anything this test set, so they are matched by what
-    // they are and not by where they land.
     assert_eq!(
         with_stash.len(),
         5,
@@ -1080,8 +1027,6 @@ fn the_all_branches_page_cache_is_invalidated_by_every_kind_of_ref_move() {
         "the rows that were already there must be unchanged, got {with_stash:?}"
     );
 
-    // A ref is deleted: the tip set shrinks, which a keyed-on-tips cache has to
-    // notice just as it notices growth.
     run_git(repo, &["stash", "drop"]);
     run_git(repo, &["branch", "-D", "side"]);
     let after_delete = summaries();
@@ -1091,9 +1036,7 @@ fn the_all_branches_page_cache_is_invalidated_by_every_kind_of_ref_move() {
         "deleting a branch must drop the commits only it reached"
     );
 
-    // Tags are deliberately not tips — `git log --all` walks them, this does
-    // not, so that a tag cannot pull an abandoned line of history back into the
-    // graph. A tag therefore neither invalidates the page nor adds a row.
+    // Tags are not all-branches tips.
     run_git(repo, &["tag", "-a", "v1", "-m", "v1", "master"]);
     assert_eq!(
         summaries(),
@@ -1112,11 +1055,6 @@ fn the_all_branches_page_cache_is_invalidated_by_every_kind_of_ref_move() {
     );
 }
 
-/// The all-branches page cache is keyed on the tips it walked from, on the
-/// grounds that the objects a page names never change. A shallow deepen breaks
-/// exactly that assumption: `git fetch --unshallow` moves no ref, it only makes
-/// ancestors that were always named by those tips resolvable. The cached page
-/// is then a truncated history that nothing will ever invalidate.
 #[test]
 fn deepening_a_shallow_clone_invalidates_the_all_branches_page_cache() {
     let dir = tempfile::tempdir().unwrap();
@@ -1197,15 +1135,6 @@ fn deepening_a_shallow_clone_invalidates_the_all_branches_page_cache() {
     );
 }
 
-/// A history whose objects are not all present must still render the rows above
-/// the hole. A page that stops short of a missing ancestor never had to resolve
-/// it, so it is a complete page — a repository with a pruned reflog entry or a
-/// half-fetched pack has to stay readable.
-///
-/// The history is deliberately longer than one gather batch and the hole is at
-/// its root, so a lazy walk cannot reach the hole while filling the page. What
-/// must not happen is failing before the first row, which is what an up-front
-/// in-degree pass over the whole reachable graph does.
 #[test]
 fn a_missing_ancestor_object_still_renders_the_rows_above_it() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/gitcomet-git-gix/tests/log_integration.rs
+++ b/crates/gitcomet-git-gix/tests/log_integration.rs
@@ -127,14 +127,23 @@ fn run_git_at(repo: &Path, args: &[&str], unix_seconds: i64) {
 }
 
 fn fast_import_linear_history(repo: &Path, count: usize) {
+    fast_import_linear_history_with_authors(repo, count, |_| "You <you@example.com>");
+}
+
+fn fast_import_linear_history_with_authors(
+    repo: &Path,
+    count: usize,
+    mut author_at: impl FnMut(usize) -> &'static str,
+) {
     let mut stream = String::new();
     for index in 0..count {
         let message = format!("c{index}");
+        let timestamp = 1_600_000_000 + index as i64;
         stream.push_str("commit refs/heads/master\n");
         stream.push_str(&format!("mark :{}\n", index + 1));
+        stream.push_str(&format!("author {} {timestamp} +0000\n", author_at(index)));
         stream.push_str(&format!(
-            "committer You <you@example.com> {} +0000\n",
-            1_600_000_000 + index as i64
+            "committer You <you@example.com> {timestamp} +0000\n"
         ));
         stream.push_str(&format!("data {}\n{message}\n", message.len()));
         if index > 0 {
@@ -1043,10 +1052,11 @@ fn the_all_branches_page_cache_is_invalidated_by_every_kind_of_ref_move() {
         vec!["two", "one"],
         "a tag on a commit that is already reachable changes nothing"
     );
-    let unreachable = git_stdout(repo, &["rev-parse", "master"]);
+    let reachable = git_stdout(repo, &["rev-parse", "master"]);
     let _ = commit("four");
+    let unreachable = git_stdout(repo, &["rev-parse", "master"]);
     run_git(repo, &["tag", "orphan", unreachable.as_str()]);
-    run_git(repo, &["update-ref", "refs/heads/master", &unreachable]);
+    run_git(repo, &["update-ref", "refs/heads/master", &reachable]);
     run_git(repo, &["reset", "-q", "--hard", "master"]);
     assert_eq!(
         summaries(),
@@ -1112,6 +1122,18 @@ fn deepening_a_shallow_clone_invalidates_the_all_branches_page_cache() {
         2,
         "a depth-2 clone starts with two rows"
     );
+    let first = opened
+        .log_history_mode_page(HistoryMode::FullReachable, 1, None)
+        .unwrap();
+    assert_eq!(
+        first
+            .commits
+            .iter()
+            .map(|commit| commit.summary.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["tip"]
+    );
+    let shallow_cursor = first.next_cursor.clone().expect("one shallow row remains");
 
     run_git(&shallow, &["fetch", "--unshallow"]);
     assert_eq!(
@@ -1133,6 +1155,20 @@ fn deepening_a_shallow_clone_invalidates_the_all_branches_page_cache() {
         5,
         "the deepened history must not be served from the page cached before the deepen"
     );
+
+    let continued = opened
+        .log_history_mode_page(HistoryMode::FullReachable, 10, Some(&shallow_cursor))
+        .unwrap();
+    assert_eq!(
+        continued
+            .commits
+            .iter()
+            .map(|commit| commit.summary.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["three", "two", "one", "base"],
+        "a cursor issued before deepening must rebuild from the new shallow boundary"
+    );
+    assert!(continued.next_cursor.is_none());
 }
 
 #[test]
@@ -2159,6 +2195,47 @@ fn author_filter_pages_without_repeating_or_skipping() {
             .all(|c| first.commits.iter().all(|f| f.id != c.id)),
         "pages must not repeat commits"
     );
+}
+
+#[test]
+fn author_filter_page_filled_at_a_decode_boundary_still_has_a_successor() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+    run_git(repo, &["init", "-b", "master"]);
+    run_git(repo, &["config", "user.email", "you@example.com"]);
+    run_git(repo, &["config", "user.name", "You"]);
+
+    // The walk's first 2,048 commits contain exactly 200 matches. There are
+    // another 102 matches beyond that decode boundary, separated from the
+    // first group by non-matching commits.
+    fast_import_linear_history_with_authors(repo, 2_150, |index| {
+        if !(102..1_950).contains(&index) {
+            "Match <match@example.com>"
+        } else {
+            "Other <other@example.com>"
+        }
+    });
+
+    let opened = GixBackend.open(repo).unwrap();
+    let first = opened
+        .log_history_mode_page_filtered(HistoryMode::FullReachable, Some("Match"), 200, None)
+        .unwrap();
+    assert_eq!(first.commits.len(), 200);
+    let cursor = first
+        .next_cursor
+        .as_ref()
+        .expect("matches beyond the decode boundary must remain reachable");
+
+    let second = opened
+        .log_history_mode_page_filtered(
+            HistoryMode::FullReachable,
+            Some("Match"),
+            200,
+            Some(cursor),
+        )
+        .unwrap();
+    assert_eq!(second.commits.len(), 102);
+    assert!(second.next_cursor.is_none());
 }
 
 /// A walk resumed under a different filter would silently skip everything the


### PR DESCRIPTION
Should fix  https://github.com/Auto-Explore/GitComet/issues/390

The log walk sorted with `Sorting::ByCommitTime`, a plain priority queue over everything currently queued. `git log --date-order` additionally guarantees no parent is shown before all of its children, so the two diverge the moment a commit's committer date is newer than one of its children's — a rebase with `--committer-date-is-author-date`, a `git am`, a machine whose clock runs behind. A parent was then drawn above its own child and every row below it sat one off git's listing, which reads as ref labels on the wrong commits.

The walk now uses `topo::Builder` with `Sorting::DateOrder`. Three fallbacks to the commit-date queue remain, none of them a performance judgement: first-parent mode (which would otherwise start reporting merges as merges), shallow repositories (whose boundary parents fail the in-degree pass), and a failed `Topo::build`, so one unreachable ancestor no longer fails a page that would never have touched it.

Date order is not free and is kept anyway: on a 50k-commit repository with no commit-graph the first 200-row page costs 423ms against 2.5ms, where `git log --date-order -n 200` pays 147ms against 3ms. With a commit-graph it is 1.4ms. `GITCOMET_LOG_DATE_ORDER=0` restores the old ordering.

Alongside, from review of the above:

- Cache all-branches pages against their tips, and key every log page on the `.git/shallow` stamp as well — a `fetch --unshallow` moves no ref, so a tips-only key served the truncated history indefinitely.
- Bound parked date-order walks to 4. Each retains ~3.3MB per 50k commits of in-degree state against ~77kB for a commit-date walk, and 32 of them scaled with history rather than page size.
- Keep a page's successor alive in the page cache with it. Once page 2 has been read, page 1's cached cursor names a consumed walk; if page 2 had aged out, the next scroll rebuilt the walk — 3.1ms against 426ms measured.
- Cap the gather at what a page can use and lower `DECODE_PARALLEL_MIN` to 96 to match. The cap is a fifth less decoding and no measurable time; leaving the threshold at 256 would have dropped a 200-row page to a single thread and cost ~30%.
- Report progress once per decode batch. The clock stride was `DECODE_BATCH`, so a capped batch never moved it and streamed chunks stopped firing.
- Finish both page paths through one helper, so the all-branches path can no longer return a completed page for a cancelled request.
- Intern the all-branches tip list; 32 cached pages held 32 copies of it, 13MB measured on a 20k-ref repository.
- Read the row-order env var through a pure function the tests can reach, and take the shallow flag from the filter that already computed it.