### PR TITLE
Add nightly prerelease build workflow for dev branch

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -16,6 +16,16 @@ on:
       release_id:
         required: false
         type: string
+      upload_symbols:
+        description: "Upload Breakpad symbols to the symbol store (off for nightly builds)"
+        required: false
+        type: boolean
+        default: true
+      generate_cask:
+        description: "Generate the Homebrew cask asset (off for nightly builds)"
+        required: false
+        type: boolean
+        default: true
     secrets:
       AZURE_CREDENTIALS:
         required: false
@@ -107,7 +117,7 @@ jobs:
             exit 1
           fi
 
-          if [[ "$tag" != v* ]]; then
+          if [[ "$tag" != v* ]] && [[ "$tag" != nightly* ]]; then
             tag="v${tag}"
           fi
 
@@ -115,12 +125,19 @@ jobs:
             version="${tag#v}"
           fi
 
-          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-            echo "::error title=Invalid version::Expected semver like 1.2.3 or 1.2.3-rc.1."
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-nightly\.[0-9]{8})?$ ]]; then
+            echo "::error title=Invalid version::Expected semver like 1.2.3, 1.2.3-rc.1, or 1.2.3-nightly.20260830."
             exit 1
           fi
 
-          if [ "$tag" != "v${version}" ]; then
+          if [[ "$version" == *"-nightly."* ]]; then
+            # Nightly builds stage under 'nightly-new' and are renamed to the
+            # stable 'nightly' tag only after a successful build.
+            if [ "$tag" != "nightly" ] && [ "$tag" != "nightly-new" ]; then
+              echo "::error title=Tag/version mismatch::Nightly versions must use the 'nightly' or 'nightly-new' tag."
+              exit 1
+            fi
+          elif [ "$tag" != "v${version}" ]; then
             echo "::error title=Tag/version mismatch::Tag '$tag' does not match version '$version'."
             exit 1
           fi
@@ -248,6 +265,7 @@ jobs:
       # the x64 binary under emulation. dump_syms parses the .pdb as a file
       # format, so the host architecture does not have to match the target.
       - name: Install dump_syms
+        if: ${{ inputs.upload_symbols }}
         uses: ./.release-tooling/.github/actions/setup-dump-syms
         with:
           triple: ${{ matrix.dump_syms_triple }}
@@ -267,6 +285,7 @@ jobs:
       # Runs under bash so all three platforms share one guard against
       # silently-empty symbols; Git for Windows provides it on the runner.
       - name: Emit Breakpad symbols
+        if: ${{ inputs.upload_symbols }}
         shell: bash
         run: |
           scripts/emit-breakpad-symbols.sh \
@@ -277,7 +296,7 @@ jobs:
       # release_id too. Symbols are still generated above, which is what
       # exercises the pipeline.
       - name: Upload Windows Breakpad symbols
-        if: ${{ needs.prepare.outputs.release_id != '' }}
+        if: ${{ inputs.upload_symbols && needs.prepare.outputs.release_id != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: symbols-${{ matrix.target_platform }}
@@ -288,7 +307,7 @@ jobs:
       # Uploaded before packaging so a later failure in this job still leaves
       # symbols for the binary that was built.
       - name: Upload Windows debug symbols
-        if: ${{ needs.prepare.outputs.release_id != '' }}
+        if: ${{ inputs.upload_symbols && needs.prepare.outputs.release_id != '' }}
         uses: actions/upload-artifact@v7
         with:
           # Deliberately not named `windows-release-artifacts-*`:
@@ -489,6 +508,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install dump_syms
+        if: ${{ inputs.upload_symbols }}
         uses: ./.release-tooling/.github/actions/setup-dump-syms
         with:
           triple: ${{ matrix.dump_syms_triple }}
@@ -503,6 +523,7 @@ jobs:
         run: cargo build -p gitcomet --release --locked --features ui-gpui,gix --bin gitcomet
 
       - name: Emit Breakpad symbols
+        if: ${{ inputs.upload_symbols }}
         run: |
           set -euo pipefail
           scripts/emit-breakpad-symbols.sh \
@@ -511,7 +532,7 @@ jobs:
 
       # Release-only; see the Breakpad symbol upload above.
       - name: Upload Linux Breakpad symbols
-        if: ${{ needs.prepare.outputs.release_id != '' }}
+        if: ${{ inputs.upload_symbols && needs.prepare.outputs.release_id != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: symbols-${{ matrix.target_platform }}
@@ -552,6 +573,7 @@ jobs:
         run: |
           set -euo pipefail
           deb_upstream_version="${VERSION/-rc./~rc.}"
+          deb_upstream_version="${deb_upstream_version/-nightly./~nightly.}"
           deb_revision="${DEB_REVISION}"
           deb_version="${deb_upstream_version}-${deb_revision}"
           if [[ -e debian ]]; then
@@ -718,6 +740,7 @@ jobs:
           cache-targets: false
 
       - name: Install dump_syms
+        if: ${{ inputs.upload_symbols }}
         uses: ./.release-tooling/.github/actions/setup-dump-syms
         with:
           triple: ${{ matrix.dump_syms_triple }}
@@ -826,8 +849,13 @@ jobs:
             --arch "${ARCH}"
             --release
             --out-dir dist
-            --symbols-out dist/symbols
           )
+
+          # dump_syms is only installed when symbols are wanted; without
+          # --symbols-out, package-macos.sh skips Breakpad extraction entirely.
+          if [ "${{ inputs.upload_symbols }}" = "true" ]; then
+            package_args+=(--symbols-out dist/symbols)
+          fi
 
           if [ "${{ steps.macos_signing_mode.outputs.enabled }}" = "true" ]; then
             package_args+=(
@@ -842,7 +870,7 @@ jobs:
 
       # Release-only; see the Breakpad symbol upload above.
       - name: Upload macOS Breakpad symbols
-        if: ${{ needs.prepare.outputs.release_id != '' }}
+        if: ${{ inputs.upload_symbols && needs.prepare.outputs.release_id != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: symbols-${{ matrix.target_platform }}
@@ -858,7 +886,7 @@ jobs:
       # with the `.dSYM` wrapper lost and the bundle no longer loadable. Staged
       # outside dist/ so it stays out of the artifacts published to the release.
       - name: Archive macOS dSYM
-        if: ${{ needs.prepare.outputs.release_id != '' }}
+        if: ${{ inputs.upload_symbols && needs.prepare.outputs.release_id != '' }}
         env:
           DSYM_DIR: ${{ runner.temp }}/gitcomet-dsym
         run: |
@@ -882,7 +910,7 @@ jobs:
             -C target/release gitcomet.dSYM
 
       - name: Upload macOS dSYM
-        if: ${{ needs.prepare.outputs.release_id != '' }}
+        if: ${{ inputs.upload_symbols && needs.prepare.outputs.release_id != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: macos-dsym-${{ matrix.target_platform }}
@@ -943,7 +971,7 @@ jobs:
     # `release_id` is empty for test builds, which must not push ~1.4 GiB into
     # the production store for a release that may never exist — the same
     # distinction the Windows signing profile makes.
-    if: ${{ needs.prepare.outputs.release_id != '' && needs.publish_release_assets.result == 'success' }}
+    if: ${{ inputs.upload_symbols && needs.prepare.outputs.release_id != '' && needs.publish_release_assets.result == 'success' }}
     # Symbols are auxiliary triage data. This job lives inside a reusable
     # workflow whose overall result gates publish_release and every deploy job
     # in release-manual-main.yml, so a transient Azure error must not strand a
@@ -1067,6 +1095,7 @@ jobs:
           ls -lah dist/release
 
       - name: Generate Homebrew cask
+        if: ${{ inputs.generate_cask }}
         run: |
           set -euo pipefail
           linux_arm_appimage="gitcomet-v${VERSION}-linux-arm64.AppImage"

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: true
+      sign_binaries:
+        description: "Sign Windows binaries and codesign/notarize macOS artifacts (off for nightly builds)"
+        required: false
+        type: boolean
+        default: true
     secrets:
       AZURE_CREDENTIALS:
         required: false
@@ -207,6 +212,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Validate Windows signing configuration
+        if: ${{ inputs.sign_binaries }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -232,11 +238,13 @@ jobs:
           Write-Host "Using Windows signing profile: $env:WINDOWS_SIGNING_PROFILE_NAME"
 
       - name: Log into Azure for Windows signing
+        if: ${{ inputs.sign_binaries }}
         uses: azure/login@v3
         with:
           creds: ${{ env.AZURE_CREDENTIALS }}
 
       - name: Locate SignTool
+        if: ${{ inputs.sign_binaries }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -321,6 +329,7 @@ jobs:
           retention-days: 90
 
       - name: Sign Windows release binary
+        if: ${{ inputs.sign_binaries }}
         uses: Azure/artifact-signing-action@v2
         with:
           endpoint: ${{ env.WINDOWS_SIGNING_ENDPOINT }}
@@ -335,6 +344,7 @@ jobs:
           cache-dependencies: false
 
       - name: Verify signed Windows release binary
+        if: ${{ inputs.sign_binaries }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -399,6 +409,7 @@ jobs:
           cargo wix --package gitcomet --profile release --nocapture --no-build --bin-path "$wixBin" --output "dist\$msiName"
 
       - name: Sign Windows MSI installer
+        if: ${{ inputs.sign_binaries }}
         uses: Azure/artifact-signing-action@v2
         with:
           endpoint: ${{ env.WINDOWS_SIGNING_ENDPOINT }}
@@ -413,6 +424,7 @@ jobs:
           cache-dependencies: false
 
       - name: Verify signed Windows MSI installer
+        if: ${{ inputs.sign_binaries }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -749,6 +761,14 @@ jobs:
         id: macos_signing_mode
         run: |
           set -euo pipefail
+
+          # Nightly builds are untrusted, rapidly-changing dev artifacts, so
+          # never sign them even if signing secrets are configured.
+          if [ "${{ inputs.sign_binaries }}" = "false" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Signing disabled for this build (nightly); building unsigned macOS artifacts."
+            exit 0
+          fi
 
           required=(
             MACOS_SIGNING_IDENTITY

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/deploy-apt-repo.yml"
       - ".github/workflows/deploy-windows-installer.yml"
       - ".github/workflows/deploy-microsoft-store.yml"
+      - ".github/workflows/nightly-build.yml"
       - ".github/workflows/release-manual-main.yml"
       - ".github/actions/setup-dump-syms/action.yml"
       - "scripts/update-aur.sh"
@@ -43,6 +44,7 @@ on:
       - ".github/workflows/deploy-apt-repo.yml"
       - ".github/workflows/deploy-windows-installer.yml"
       - ".github/workflows/deploy-microsoft-store.yml"
+      - ".github/workflows/nightly-build.yml"
       - ".github/workflows/release-manual-main.yml"
       - ".github/actions/setup-dump-syms/action.yml"
       - "scripts/update-aur.sh"
@@ -145,6 +147,7 @@ jobs:
             .github/workflows/deploy-windows-installer.yml
             .github/workflows/deploy-microsoft-store.yml
             .github/workflows/deployment-ci.yml
+            .github/workflows/nightly-build.yml
             .github/workflows/release-manual-main.yml
           ].each { |path| YAML.load_file(path) }'
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -174,6 +174,7 @@ jobs:
       release_id: ${{ needs.create_release.outputs.release_id }}
       upload_symbols: false
       generate_cask: false
+      sign_binaries: false
     secrets: inherit
 
   finalize:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,247 @@
+name: Nightly Build
+
+# Builds a nightly prerelease from `dev` at 00:00 UTC. Only one nightly
+# release exists at any time: it is published under the stable `nightly` tag,
+# and the previous day's release is replaced only after a successful build.
+#
+# The in-flight build stages under the `nightly-new` tag as a draft; once all
+# artifacts are uploaded, the release is re-tagged to `nightly` and published.
+# If the build fails, the draft is discarded and the previous nightly is left
+# untouched, so the last known-good build stays downloadable.
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Build even if the last nightly release already covers HEAD"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: nightly-build
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  prepare:
+    name: Check for new commits and compute version
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+      version: ${{ steps.version.outputs.version }}
+      head_sha: ${{ steps.check.outputs.head_sha }}
+      last_sha: ${{ steps.check.outputs.last_sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Decide whether to build
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Drop any in-flight release left behind by a crashed run. It is
+          # never the published nightly, so it is always safe to discard.
+          gh release delete nightly-new --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes >/dev/null 2>&1 || true
+
+          head_sha="$(git rev-parse HEAD)"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+          force="${{ github.event.inputs.force || 'false' }}"
+          if [ "$force" = "true" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Forced nightly build at ${head_sha:0:12}."
+            exit 0
+          fi
+
+          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            last_sha="$(gh release view nightly --repo "$GITHUB_REPOSITORY" --json targetCommitish --jq .targetCommitish)"
+            is_draft="$(gh release view nightly --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)"
+            echo "last_sha=$last_sha" >> "$GITHUB_OUTPUT"
+            if [ "$is_draft" = "true" ]; then
+              # A crashed run left the nightly unpublished; rebuild so the
+              # finalize step can publish it.
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              echo "Previous nightly was left unpublished; rebuilding to finalize it."
+            elif [ "$last_sha" = "$head_sha" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "No new commits on dev since the last nightly (${head_sha:0:12}); skipping."
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              echo "New commits since the last nightly (${last_sha:0:12}..${head_sha:0:12}); building."
+            fi
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "No nightly release exists yet; building."
+          fi
+
+      - name: Compute nightly version
+        if: steps.check.outputs.skip != 'true'
+        id: version
+        run: |
+          set -euo pipefail
+          crate_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)"
+          if ! [[ "$crate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=Invalid crate version::Cargo.toml version '$crate_version' is not plain semver X.Y.Z."
+            exit 1
+          fi
+          version="${crate_version}-nightly.$(date -u +%Y%m%d)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Nightly version: $version"
+
+  create_release:
+    name: Open a draft nightly release
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    needs: prepare
+    if: needs.prepare.outputs.skip != 'true'
+    outputs:
+      release_id: ${{ steps.create.outputs.release_id }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Create draft nightly release at HEAD
+        id: create
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          head_sha="${{ needs.prepare.outputs.head_sha }}"
+          last_sha="${{ needs.prepare.outputs.last_sha }}"
+          version="${{ needs.prepare.outputs.version }}"
+
+          date_label="$(echo "$version" | sed -n 's/.*-nightly\.\([0-9]\{8\}\)$/\1/p')"
+          if [ -z "$date_label" ]; then
+            date_label="$(date -u +%Y%m%d)"
+          fi
+          title="GitComet Nightly ${date_label:0:4}-${date_label:4:2}-${date_label:6:2}"
+
+          notes_file="${RUNNER_TEMP}/nightly-notes.md"
+          {
+            echo "Automatic nightly build from \`dev\` at \`${head_sha:0:12}\`."
+            echo ""
+            echo "### Commits since the last nightly"
+            echo '```'
+            if [ -n "$last_sha" ]; then
+              range="${last_sha}..${head_sha}"
+            else
+              range="HEAD~30..HEAD"
+            fi
+            git log --oneline --no-merges "$range" 2>/dev/null | head -100 || true
+            echo '```'
+          } > "$notes_file"
+
+          # Make sure no stale tag from a previous rename is in the way.
+          git push origin :refs/tags/nightly-new >/dev/null 2>&1 || true
+
+          gh release create nightly-new \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$title" \
+            --target "$head_sha" \
+            --prerelease \
+            --draft \
+            --notes-file "$notes_file"
+
+          release_id="$(gh release view nightly-new --repo "$GITHUB_REPOSITORY" --json id --jq .id)"
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build nightly artifacts
+    needs: [prepare, create_release]
+    if: needs.prepare.outputs.skip != 'true'
+    uses: ./.github/workflows/build-release-artifacts.yml
+    with:
+      tag: nightly-new
+      version: ${{ needs.prepare.outputs.version }}
+      deb_revision: "1"
+      release_id: ${{ needs.create_release.outputs.release_id }}
+      upload_symbols: false
+      generate_cask: false
+    secrets: inherit
+
+  finalize:
+    name: Publish nightly and replace the previous one
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    needs: [prepare, create_release, build]
+    if: ${{ needs.prepare.outputs.skip != 'true' && needs.build.result == 'success' }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Swap the previous nightly for the new one
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          head_sha="${{ needs.prepare.outputs.head_sha }}"
+
+          # Only now that the new build succeeded, drop the previous release.
+          gh release delete nightly --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes >/dev/null 2>&1 || true
+          git push origin :refs/tags/nightly >/dev/null 2>&1 || true
+
+          # Point the stable 'nightly' tag at the new commit and attach the
+          # release to it, then publish the draft.
+          git push origin "$head_sha:refs/tags/nightly" >/dev/null
+          new_id="$(gh release view nightly-new --repo "$GITHUB_REPOSITORY" --json id --jq .id)"
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$new_id" \
+            -f tag_name="nightly" >/dev/null
+          gh release edit nightly --repo "$GITHUB_REPOSITORY" --draft=false
+
+          # Drop the staging tag if the API left it behind.
+          git push origin :refs/tags/nightly-new >/dev/null 2>&1 || true
+
+      - name: Emit summary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Nightly build published"
+            echo ""
+            echo "- Version: \`${{ needs.prepare.outputs.version }}\`"
+            echo "- Commit: \`${{ needs.prepare.outputs.head_sha }}\`"
+            echo ""
+            echo "Assets:"
+            gh release view nightly --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' | sed 's/^/- `/;s/$/`/'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  restore:
+    name: Discard failed nightly
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    needs: [prepare, create_release, build]
+    if: ${{ needs.prepare.outputs.skip != 'true' && needs.build.result != 'success' }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Delete the failed draft and its tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release delete nightly-new --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes >/dev/null 2>&1 || true
+          git push origin :refs/tags/nightly-new >/dev/null 2>&1 || true
+          echo "Removed the failed nightly build; the previous nightly remains published."


### PR DESCRIPTION
## Summary

Adds a scheduled nightly build that publishes a single rolling prerelease from the `dev` branch, replacing the previous day's build.

## What it does

- **Schedule**: runs daily at 00:00 UTC (`cron: "0 0 * * *"`) and can be triggered manually via `workflow_dispatch` (with a `force` flag to bypass the commit check).
- **Skips when nothing changed**: compares `HEAD` of `dev` against the commit the existing `nightly` release points to, so a nightly is only built when there are new commits since the last successful run.
- **Single rolling prerelease**: the build stages under the `nightly-new` tag as a draft release; only after a successful build is it re-tagged to the stable `nightly` tag and published, replacing the previous nightly. On failure the draft is discarded and the last known-good nightly stays live.
- **Versioning**: artifacts use `X.Y.Z-nightly.YYYYMMDD` derived from the crate version in `Cargo.toml` plus the build date.
- **Full parity with release builds**: complete 6-platform matrix (Windows/Linux/macOS × x64/arm64), Windows signing and macOS codesign/notarization, checksums.
- **Deliberately excluded**: Breakpad symbol uploads to Azure (~1.4 GiB per run), the Homebrew cask asset, and all downstream deploys (Homebrew tap, AUR, APT repo, MS Store) — the nightly is an isolated GitHub prerelease.

## Changes

- `.github/workflows/nightly-build.yml` — new nightly workflow.
- `.github/workflows/build-release-artifacts.yml` — new `upload_symbols` and `generate_cask` inputs (default `true`, no behavior change for stable releases); accepts `-nightly.YYYYMMDD` versions with the `nightly` / `nightly-new` tags; skips the `v` tag prefix for nightly tags; maps the nightly suffix to `~nightly.` in Debian versions; gates all symbol-related steps (including `--symbols-out` in `package-macos.sh`) on `upload_symbols`.
- `.github/workflows/deployment-ci.yml` — nightly workflow covered by the existing actionlint and YAML validation steps.

## Validation

`actionlint` v1.7.12 (the version pinned in `deployment-ci.yml`) passes cleanly on the entire `.github/workflows` directory.