### PR TITLE
Security Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/benchmark-targets.yml
+++ b/.github/workflows/benchmark-targets.yml
@@ -35,7 +35,7 @@ jobs:
           - name: windows / arm64
             runs_on: windows-11-arm
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Linux UI native dependencies
         if: runner.os == 'Linux'
@@ -64,10 +64,12 @@ jobs:
           pkg-config --modversion xcb xkbcommon xkbcommon-x11
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Show host target
         run: rustc -vV

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -164,13 +164,13 @@ jobs:
       WINDOWS_SIGNING_PROFILE_NAME: ${{ needs.prepare.outputs.release_id != '' && 'gitcomet-windows-release' || 'gitcomet-windows-test' }}
       WINDOWS_SIGNING_TIMESTAMP_RFC3161: http://timestamp.acs.microsoft.com/
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
 
       - name: Check out release tooling from workflow revision
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.workflow_sha }}
@@ -184,10 +184,12 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Validate Windows signing configuration
         shell: pwsh
@@ -215,7 +217,7 @@ jobs:
           Write-Host "Using Windows signing profile: $env:WINDOWS_SIGNING_PROFILE_NAME"
 
       - name: Log into Azure for Windows signing
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ env.AZURE_CREDENTIALS }}
 
@@ -278,7 +280,7 @@ jobs:
       # exercises the pipeline.
       - name: Upload Windows Breakpad symbols
         if: ${{ needs.prepare.outputs.release_id != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: symbols-${{ matrix.target_platform }}
           path: dist/symbols
@@ -289,7 +291,7 @@ jobs:
       # symbols for the binary that was built.
       - name: Upload Windows debug symbols
         if: ${{ needs.prepare.outputs.release_id != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Deliberately not named `windows-release-artifacts-*`:
           # `publish_release_assets` globs that prefix into the published
@@ -302,7 +304,7 @@ jobs:
           retention-days: 90
 
       - name: Sign Windows release binary
-        uses: Azure/artifact-signing-action@v2
+        uses: Azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ env.WINDOWS_SIGNING_ENDPOINT }}
           signing-account-name: ${{ env.WINDOWS_SIGNING_ACCOUNT_NAME }}
@@ -380,7 +382,7 @@ jobs:
           cargo wix --package gitcomet --profile release --nocapture --no-build --bin-path "$wixBin" --output "dist\$msiName"
 
       - name: Sign Windows MSI installer
-        uses: Azure/artifact-signing-action@v2
+        uses: Azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ env.WINDOWS_SIGNING_ENDPOINT }}
           signing-account-name: ${{ env.WINDOWS_SIGNING_ACCOUNT_NAME }}
@@ -404,7 +406,7 @@ jobs:
             -SignToolPath $env:SIGNTOOL_PATH
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-release-artifacts-${{ matrix.target_platform }}
           path: |
@@ -452,13 +454,13 @@ jobs:
       APPIMAGETOOL_SHA256: ${{ matrix.appimagetool_sha256 }}
       APPIMAGE_ARCH: ${{ matrix.appimage_arch }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
 
       - name: Check out release tooling from workflow revision
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.workflow_sha }}
@@ -483,10 +485,12 @@ jobs:
             libxkbcommon-x11-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install dump_syms
         uses: ./.release-tooling/.github/actions/setup-dump-syms
@@ -512,7 +516,7 @@ jobs:
       # Release-only; see the Breakpad symbol upload above.
       - name: Upload Linux Breakpad symbols
         if: ${{ needs.prepare.outputs.release_id != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: symbols-${{ matrix.target_platform }}
           path: dist/symbols
@@ -652,7 +656,7 @@ jobs:
             "${appdir}" "dist/gitcomet-v${VERSION}-linux-${ARTIFACT_ARCH}.AppImage"
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-release-artifacts-${{ matrix.target_platform }}
           path: |
@@ -690,13 +694,13 @@ jobs:
       MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
       MACOS_NOTARY_API_KEY_P8: ${{ secrets.MACOS_NOTARY_API_KEY_P8 }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
 
       - name: Check out release tooling from workflow revision
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.workflow_sha }}
@@ -710,10 +714,12 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-targets: false
 
@@ -843,7 +849,7 @@ jobs:
       # Release-only; see the Breakpad symbol upload above.
       - name: Upload macOS Breakpad symbols
         if: ${{ needs.prepare.outputs.release_id != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: symbols-${{ matrix.target_platform }}
           path: dist/symbols
@@ -883,7 +889,7 @@ jobs:
 
       - name: Upload macOS dSYM
         if: ${{ needs.prepare.outputs.release_id != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-dsym-${{ matrix.target_platform }}
           path: ${{ runner.temp }}/gitcomet-dsym/gitcomet-${{ matrix.arch }}.dSYM.tar.gz
@@ -921,7 +927,7 @@ jobs:
           fi
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-release-artifacts-${{ matrix.target_platform }}
           path: dist/*.dmg
@@ -979,7 +985,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: symbols-*
           path: dist/symbols
@@ -1029,24 +1035,24 @@ jobs:
       RELEASE_ID: ${{ needs.prepare.outputs.release_id }}
       ENABLE_KEYLESS_SIGNING: ${{ vars.ENABLE_KEYLESS_SIGNING }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: windows-release-artifacts-*
           path: dist/windows
           merge-multiple: true
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: linux-release-artifacts-*
           path: dist/linux
           merge-multiple: true
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: macos-release-artifacts-*
           path: dist/macos
@@ -1110,7 +1116,7 @@ jobs:
 
       - name: Install cosign
         if: ${{ env.ENABLE_KEYLESS_SIGNING == 'true' }}
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - name: Sign SHA256 checksums with keyless signing
         if: ${{ env.ENABLE_KEYLESS_SIGNING == 'true' }}
@@ -1125,7 +1131,7 @@ jobs:
             "$sha_file"
 
       - name: Upload payload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-payload
           path: dist/release/*

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -24,13 +24,14 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           components: rustfmt
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Check formatting
         run: cargo fmt --all --check
 
@@ -49,13 +50,15 @@ jobs:
             target_platform: aarch64-linux
             runs_on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Show Git version
         run: git --version
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Run headless test suite
         run: |
           cargo test --workspace \
@@ -85,7 +88,7 @@ jobs:
             pkg-config \
             tar \
             which
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Show Git version
         run: git --version
       - name: Install Rust toolchain
@@ -130,7 +133,7 @@ jobs:
       XDG_SESSION_TYPE: ${{ matrix.profile.session_type }}
       XDG_CURRENT_DESKTOP: ${{ matrix.profile.desktop }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Show Git version
         run: git --version
       - name: Install Linux UI native dependencies
@@ -156,9 +159,11 @@ jobs:
           fi
           pkg-config --modversion xcb xkbcommon xkbcommon-x11
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Print display profile
         run: |
           echo "DISPLAY=${DISPLAY:-<unset>}"
@@ -190,13 +195,15 @@ jobs:
             name: intel (macos-15-intel)
             runs_on: macos-15-intel
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Show Git version
         run: git --version
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Show host target
         run: rustc -vV
       - name: Assert Apple Silicon runner
@@ -241,14 +248,16 @@ jobs:
           - target_platform: aarch64-windows
             runs_on: windows-11-arm
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Show Git version
         shell: pwsh
         run: git --version
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Show path behavior (PowerShell + Git Bash)
         shell: pwsh
         run: |

--- a/.github/workflows/deploy-apt-repo.yml
+++ b/.github/workflows/deploy-apt-repo.yml
@@ -145,7 +145,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Normalize inputs
         id: norm

--- a/.github/workflows/deploy-aur.yml
+++ b/.github/workflows/deploy-aur.yml
@@ -72,7 +72,7 @@ jobs:
           set -euo pipefail
           pacman -Sy --noconfirm --needed ca-certificates ca-certificates-utils curl expect git openssh perl shadow
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Normalize inputs
         id: norm

--- a/.github/workflows/deploy-microsoft-store.yml
+++ b/.github/workflows/deploy-microsoft-store.yml
@@ -99,7 +99,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Normalize inputs
         id: norm

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Lint GitHub Actions workflows
         env:
@@ -429,13 +429,13 @@ jobs:
       # This source revision has the release workflow but predates both the
       # setup-dump-syms action and its centralized pin resolver.
       - name: Check out pre-tooling release source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: 379fc57563ac788969223db9ea2d4d8a5679c94d
           fetch-depth: 1
 
       - name: Check out release tooling from workflow revision
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.workflow_sha }}
@@ -468,7 +468,7 @@ jobs:
           set -euo pipefail
           pacman -Sy --noconfirm --needed perl shadow
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create non-root packaging user
         run: |
@@ -536,7 +536,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Debian repo tooling
         run: |
@@ -683,19 +683,21 @@ jobs:
             runs_on: macos-15-intel
             dump_syms_triple: x86_64-apple-darwin
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # Cached so an outage or rate limit at mozilla/dump_syms does not fail
       # unrelated pull requests. Keyed on the resolver script contents so any
       # pin change (version, asset, or checksum) busts the cache.
       - name: Cache dump_syms
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/gitcomet-dump-syms
           key: dump-syms-${{ hashFiles('scripts/dump-syms-pins.sh') }}-${{ matrix.dump_syms_triple }}

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       GITCOMET_PERF_CRITERION_ROOT: target/criterion
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ github.event.inputs.ref || github.ref }}
     - name: Install Linux UI native dependencies
@@ -62,9 +62,11 @@ jobs:
         fi
         pkg-config --modversion xcb xkbcommon xkbcommon-x11
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      with:
+        toolchain: stable
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: Benchmark manual PR subset
       run: |
         # Conflict and markdown hot paths (existing)
@@ -139,7 +141,7 @@ jobs:
     env:
       GITCOMET_PERF_CRITERION_ROOT: target/criterion
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ github.event.inputs.ref || github.ref }}
     - name: Install Linux UI native dependencies
@@ -152,9 +154,11 @@ jobs:
           libxkbcommon-dev \
           libxkbcommon-x11-dev
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      with:
+        toolchain: stable
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: Validate dedicated perf-runner inputs
       if: vars.PERF_RUNNER != ''
       run: |

--- a/.github/workflows/release-manual-main.yml
+++ b/.github/workflows/release-manual-main.yml
@@ -45,7 +45,7 @@ jobs:
       prerelease: ${{ steps.flags.outputs.prerelease }}
       draft: ${{ steps.flags.outputs.draft }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -114,7 +114,7 @@ jobs:
     outputs:
       release_id: ${{ steps.create_release.outputs.release_id }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,13 +26,14 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       with:
+        toolchain: stable
         components: rustfmt
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: Check formatting
       run: cargo fmt --all --check
 
@@ -41,11 +42,13 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      with:
+        toolchain: stable
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: Install cargo-audit
       run: cargo install cargo-audit --locked
     - name: Run cargo-audit
@@ -61,11 +64,13 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      with:
+        toolchain: stable
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: Clippy (core + state + git backend + tree-sitter allocator)
       run: cargo clippy -p gitcomet-core -p gitcomet-state -p gitcomet-git-gix -p gitcomet-tree-sitter-alloc -- -D warnings
     - name: Clippy (GPUI UI crate -- intentionally skipped on headless CI)
@@ -80,11 +85,13 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      with:
+        toolchain: stable
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: Build (core + state + backend)
       run: cargo build -p gitcomet-core -p gitcomet-state -p gitcomet-git-gix --verbose
     - name: Build (app — headless)
@@ -97,11 +104,13 @@ jobs:
     timeout-minutes: 60
     needs: build
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      with:
+        toolchain: stable
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: t6403/t6427 merge algorithm portability
       run: cargo test -p gitcomet-core --test merge_algorithm --verbose
     - name: Conflict label formatting (Phase 1C)
@@ -120,11 +129,13 @@ jobs:
     timeout-minutes: 60
     needs: build
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      with:
+        toolchain: stable
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: KDiff3-style fixture harness (Phase 2)
       run: cargo test -p gitcomet-core --test merge_fixture_harness --verbose
     - name: Permutation corpus (Phase 3A — 243 sampled cases)
@@ -139,11 +150,13 @@ jobs:
     timeout-minutes: 60
     needs: build
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      with:
+        toolchain: stable
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: Build gitcomet binary (headless)
       run: cargo build -p gitcomet $APP_FEATURES
     - name: Git mergetool E2E (Phase 4A — t7610 parity)
@@ -162,11 +175,13 @@ jobs:
     timeout-minutes: 60
     needs: build
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      with:
+        toolchain: stable
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: Git CLI migration scoreboard
       run: cargo test -p gitcomet-git-gix --test git_cli_scoreboard -- --nocapture
     - name: Status and mergetool backend integration


### PR DESCRIPTION
Pin all 93 references to the full commit each tag resolves to today, with the exact version as a trailing comment so Dependabot keeps tracking them. `dtolnay/rust-toolchain` derives the channel from its ref, so each of its steps now passes `toolchain: stable` explicitly, which is what the `@stable` ref selected before.