### PR TITLE
Security separate user-typed positionals from git options in clone, submodule add, worktree

### DIFF
--- a/crates/gitcomet-git-gix/src/repo/submodules.rs
+++ b/crates/gitcomet-git-gix/src/repo/submodules.rs
@@ -180,22 +180,7 @@ impl GixRepo {
             .unwrap_or_else(|| path.to_path_buf());
         validate_submodule_git_dir_name(&logical_name)?;
 
-        cmd.arg("submodule").arg("add");
-        let mut command = "git submodule add".to_string();
-        if let Some(branch) = branch {
-            cmd.arg("--branch").arg(branch);
-            command.push_str(&format!(" --branch {branch}"));
-        }
-        if force {
-            cmd.arg("--force");
-            command.push_str(" --force");
-        }
-        if let Some(name) = name {
-            cmd.arg("--name").arg(name);
-            command.push_str(&format!(" --name {name}"));
-        }
-        cmd.arg(url).arg(path);
-        command.push_str(&format!(" {url} {}", path.display()));
+        let command = push_submodule_add_args(&mut cmd, url, path, branch, name, force);
         match run_git_with_output(cmd, &command) {
             Ok(output) => Ok(output),
             Err(err) => Err(cleanup_failed_submodule_add_error(
@@ -425,6 +410,38 @@ fn collect_repo_submodules(
     }
 
     Ok(())
+}
+
+/// Append the `git submodule add` arguments and return the display label.
+///
+/// `--` keeps a user-typed URL or path that starts with `-` out of the option
+/// parser (`--reference=<path>` would borrow objects from an arbitrary repo).
+fn push_submodule_add_args(
+    cmd: &mut Command,
+    url: &str,
+    path: &Path,
+    branch: Option<&str>,
+    name: Option<&str>,
+    force: bool,
+) -> String {
+    cmd.arg("submodule").arg("add");
+    let mut command = "git submodule add".to_string();
+    if let Some(branch) = branch {
+        cmd.arg("--branch").arg(branch);
+        command.push_str(&format!(" --branch {branch}"));
+    }
+    if force {
+        cmd.arg("--force");
+        command.push_str(" --force");
+    }
+    if let Some(name) = name {
+        cmd.arg("--name").arg(name);
+        command.push_str(&format!(" --name {name}"));
+    }
+    // The label stays a human-readable summary; `--` is an argv concern only.
+    cmd.arg("--").arg(url).arg(path);
+    command.push_str(&format!(" {url} {}", path.display()));
+    command
 }
 
 fn collect_repo_untrusted_submodule_sources(
@@ -1886,8 +1903,9 @@ fn object_id_to_commit_id(id: gix::ObjectId) -> CommitId {
 mod tests {
     use super::{
         GixRepo, allow_file_submodule_transport, is_git_config_contention_error,
-        remove_submodule_git_dir, resolve_submodule_logical_name, retry_git_config_contention,
-        submodule_file_transport_consent_key, validate_submodule_git_dir_name,
+        push_submodule_add_args, remove_submodule_git_dir, resolve_submodule_logical_name,
+        retry_git_config_contention, submodule_file_transport_consent_key,
+        validate_submodule_git_dir_name,
     };
     use gitcomet_core::domain::{CommitId, DiffArea, DiffTarget, SubmoduleDiffRangeKind};
     use gitcomet_core::error::{Error, ErrorKind, GitFailure, GitFailureId};
@@ -1923,6 +1941,39 @@ mod tests {
     fn open_repo(workdir: &Path) -> GixRepo {
         let thread_safe_repo = gix::open(workdir).expect("open repo").into_sync();
         GixRepo::new(workdir.to_path_buf(), thread_safe_repo)
+    }
+
+    #[test]
+    fn submodule_add_args_separate_positionals_from_options() {
+        let mut cmd = Command::new("git");
+        let label = push_submodule_add_args(
+            &mut cmd,
+            "--reference=/tmp/evil",
+            Path::new("sub"),
+            Some("main"),
+            Some("lib/sub"),
+            true,
+        );
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(
+            args,
+            [
+                OsStr::new("submodule"),
+                OsStr::new("add"),
+                OsStr::new("--branch"),
+                OsStr::new("main"),
+                OsStr::new("--force"),
+                OsStr::new("--name"),
+                OsStr::new("lib/sub"),
+                OsStr::new("--"),
+                OsStr::new("--reference=/tmp/evil"),
+                OsStr::new("sub"),
+            ]
+        );
+        assert_eq!(
+            label,
+            "git submodule add --branch main --force --name lib/sub --reference=/tmp/evil sub"
+        );
     }
 
     #[test]

--- a/crates/gitcomet-git-gix/src/repo/worktrees.rs
+++ b/crates/gitcomet-git-gix/src/repo/worktrees.rs
@@ -1,9 +1,12 @@
 use super::GixRepo;
-use crate::util::{path_buf_from_git_bytes, run_git_capture_bytes, run_git_with_output};
+use crate::util::{
+    path_buf_from_git_bytes, run_git_capture_bytes, run_git_with_output, validate_ref_like_arg,
+};
 use gitcomet_core::domain::{CommitId, Worktree};
 use gitcomet_core::path_utils::canonicalize_or_original;
 use gitcomet_core::services::{CommandOutput, Result};
 use std::path::Path;
+use std::process::Command;
 
 impl GixRepo {
     pub(super) fn list_worktrees_impl(&self) -> Result<Vec<Worktree>> {
@@ -19,20 +22,14 @@ impl GixRepo {
         reference: Option<&str>,
     ) -> Result<CommandOutput> {
         let mut cmd = self.git_workdir_cmd();
-        cmd.arg("worktree").arg("add").arg(path);
-        let label = if let Some(reference) = reference {
-            cmd.arg(reference);
-            format!("git worktree add {} {}", path.display(), reference)
-        } else {
-            format!("git worktree add {}", path.display())
-        };
+        let label = push_worktree_args(&mut cmd, &["add"], path, reference)?;
         run_git_with_output(cmd, &label)
     }
 
     pub(super) fn remove_worktree_with_output_impl(&self, path: &Path) -> Result<CommandOutput> {
         let mut cmd = self.git_workdir_cmd();
-        cmd.arg("worktree").arg("remove").arg(path);
-        run_git_with_output(cmd, &format!("git worktree remove {}", path.display()))
+        let label = push_worktree_args(&mut cmd, &["remove"], path, None)?;
+        run_git_with_output(cmd, &label)
     }
 
     pub(super) fn force_remove_worktree_with_output_impl(
@@ -40,12 +37,36 @@ impl GixRepo {
         path: &Path,
     ) -> Result<CommandOutput> {
         let mut cmd = self.git_workdir_cmd();
-        cmd.arg("worktree").arg("remove").arg("--force").arg(path);
-        run_git_with_output(
-            cmd,
-            &format!("git worktree remove --force {}", path.display()),
-        )
+        let label = push_worktree_args(&mut cmd, &["remove", "--force"], path, None)?;
+        run_git_with_output(cmd, &label)
     }
+}
+
+/// Append `git worktree <args> -- <path> [<reference>]` and return the display
+/// label.
+///
+/// `path` and `reference` are typed by the user, so `--` keeps a value that
+/// starts with `-` out of the option parser, and the reference is checked the
+/// way every other ref argument in this crate is.
+fn push_worktree_args(
+    cmd: &mut Command,
+    args: &[&str],
+    path: &Path,
+    reference: Option<&str>,
+) -> Result<String> {
+    if let Some(reference) = reference {
+        validate_ref_like_arg(reference, "worktree reference")?;
+    }
+    // The label is a human-readable summary that the UI also inspects to
+    // recover the worktree path, so `--` stays an argv concern only.
+    cmd.arg("worktree").args(args).arg("--").arg(path);
+    let mut label = format!("git worktree {} {}", args.join(" "), path.display());
+    if let Some(reference) = reference {
+        cmd.arg(reference);
+        label.push(' ');
+        label.push_str(reference);
+    }
+    Ok(label)
 }
 
 fn parse_git_worktree_list_porcelain_z(output: &[u8]) -> Result<Vec<Worktree>> {
@@ -110,9 +131,62 @@ fn canonicalize_worktree_path(worktree: &mut Worktree) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_git_worktree_list_porcelain_z;
+    use super::{parse_git_worktree_list_porcelain_z, push_worktree_args};
     use gitcomet_core::path_utils::canonicalize_or_original;
-    use std::path::PathBuf;
+    use std::ffi::OsStr;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    #[test]
+    fn worktree_add_places_separator_before_path_and_reference() {
+        let mut cmd = Command::new("git");
+        let label = push_worktree_args(&mut cmd, &["add"], Path::new("-linked"), Some("main"))
+            .expect("valid worktree arguments");
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(
+            args,
+            [
+                OsStr::new("worktree"),
+                OsStr::new("add"),
+                OsStr::new("--"),
+                OsStr::new("-linked"),
+                OsStr::new("main"),
+            ]
+        );
+        assert_eq!(label, "git worktree add -linked main");
+    }
+
+    #[test]
+    fn worktree_add_rejects_option_like_reference() {
+        let mut cmd = Command::new("git");
+        let err = push_worktree_args(&mut cmd, &["add"], Path::new("linked"), Some("--detach"))
+            .expect_err("an option-looking reference must be refused");
+        assert!(err.to_string().contains("worktree reference"), "{err}");
+        assert_eq!(
+            cmd.get_args().count(),
+            0,
+            "nothing should be appended on refusal"
+        );
+    }
+
+    #[test]
+    fn worktree_remove_keeps_flags_before_separator() {
+        let mut cmd = Command::new("git");
+        let label = push_worktree_args(&mut cmd, &["remove", "--force"], Path::new("linked"), None)
+            .expect("valid worktree arguments");
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(
+            args,
+            [
+                OsStr::new("worktree"),
+                OsStr::new("remove"),
+                OsStr::new("--force"),
+                OsStr::new("--"),
+                OsStr::new("linked"),
+            ]
+        );
+        assert_eq!(label, "git worktree remove --force linked");
+    }
 
     #[test]
     fn parse_git_worktree_list_porcelain_z_parses_regular_and_detached_entries() {

--- a/crates/gitcomet-git-gix/tests/worktrees_integration.rs
+++ b/crates/gitcomet-git-gix/tests/worktrees_integration.rs
@@ -69,8 +69,9 @@ fn worktree_add_list_remove_round_trip() {
     let linked_path = root.join("linked\ntree");
     #[cfg(not(unix))]
     let linked_path = root.join("linked tree");
+    // `HEAD` is not a branch, so git checks the new worktree out detached.
     let add_output = opened
-        .add_worktree_with_output(&linked_path, Some("--detach"))
+        .add_worktree_with_output(&linked_path, Some("HEAD"))
         .expect("add linked worktree");
     assert_eq!(add_output.exit_code, Some(0));
 

--- a/crates/gitcomet-state/src/store/effects/clone.rs
+++ b/crates/gitcomet-state/src/store/effects/clone.rs
@@ -12,7 +12,7 @@ use rustc_hash::FxHashMap;
 use std::fs;
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStderr, ChildStdout, ExitStatus, Stdio};
+use std::process::{Child, ChildStderr, ChildStdout, Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -161,6 +161,15 @@ fn validate_clone_url(url: &str) -> Result<(), Error> {
         )));
     }
 
+    // Schemeless inputs (`/tmp/repo.git`, `git@host:org/repo.git`, `C:\\repo`)
+    // are handed to git as-is, so this is the only place an option-looking
+    // value would be caught before `git clone` parses it as one.
+    if url.starts_with('-') {
+        return Err(Error::new(ErrorKind::Backend(format!(
+            "clone URL cannot start with '-': {url:?}"
+        ))));
+    }
+
     let Some(scheme_end) = explicit_url_scheme_end(url) else {
         return Ok(());
     };
@@ -179,6 +188,20 @@ fn validate_clone_url(url: &str) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+/// `--` keeps a URL or destination that starts with `-` from being parsed as
+/// a `git clone` option (`--upload-pack=<cmd>` would run `<cmd>` locally).
+fn build_clone_command(url: &str, dest: &Path) -> Command {
+    let mut cmd = git_command();
+    cmd.arg("-c")
+        .arg("color.ui=false")
+        .arg("clone")
+        .arg("--progress")
+        .arg("--")
+        .arg(url)
+        .arg(dest);
+    cmd
 }
 
 fn decode_clone_progress_fragment(fragment: &[u8]) -> Option<String> {
@@ -294,14 +317,8 @@ pub(super) fn schedule_clone_repo(
             return;
         }
 
-        let mut cmd = git_command();
-        cmd.arg("-c")
-            .arg("color.ui=false")
-            .arg("clone")
-            .arg("--progress")
-            .arg(&url)
-            .arg(&dest)
-            .stdout(Stdio::piped())
+        let mut cmd = build_clone_command(&url, &dest);
+        cmd.stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(Stdio::null())
             .env("GIT_TERMINAL_PROMPT", "0");
@@ -535,6 +552,41 @@ mod tests {
     #[test]
     fn validate_clone_url_rejects_malformed_allowlisted_schemes() {
         assert!(validate_clone_url("ssh:git@example.com/org/repo.git").is_err());
+    }
+
+    #[test]
+    fn validate_clone_url_rejects_option_like_inputs() {
+        for url in [
+            "-",
+            "-o=evil",
+            "--upload-pack=touch /tmp/pwned",
+            "  --template=/tmp/x",
+        ] {
+            let err = validate_clone_url(url).expect_err(url);
+            assert!(
+                err.to_string().contains("cannot start with '-'"),
+                "{url}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_clone_command_separates_positionals_from_options() {
+        let dest = Path::new("/tmp/gitcomet-clone-dest");
+        let cmd = build_clone_command("git@github.com:org/repo.git", dest);
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(
+            args,
+            [
+                std::ffi::OsStr::new("-c"),
+                std::ffi::OsStr::new("color.ui=false"),
+                std::ffi::OsStr::new("clone"),
+                std::ffi::OsStr::new("--progress"),
+                std::ffi::OsStr::new("--"),
+                std::ffi::OsStr::new("git@github.com:org/repo.git"),
+                dest.as_os_str(),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION

Three git invocations placed user-typed values where git's option parser would read a leading `-` as a flag:

- `git clone --progress <url> <dest>`: `validate_clone_url` allowlists schemes but deliberately accepts schemeless inputs, so a pasted `--upload-pack=<cmd>` passed validation and git would run `<cmd>` locally. Reject leading-`-` input and build the argv with `--`.
- `git submodule add ... <url> <path>`: no `--`, so `--reference=<path>` typed as a URL reached the option parser.
- `git worktree add|remove <path> [<reference>]`: no `--`, and the reference skipped `validate_ref_like_arg` unlike every other ref argument in the crate.

The argv builders are factored out so unit tests can assert the `--` placement; display labels are unchanged because the UI inspects the `git worktree remove` label to recover the path. The worktree integration test used the unvalidated reference to smuggle `--detach`; it now passes `HEAD`, which git checks out detached.