### PR TITLE
Security mask URL credentials in remote, submodule and clone command labels

### DIFF
--- a/crates/gitcomet-core/src/text_utils.rs
+++ b/crates/gitcomet-core/src/text_utils.rs
@@ -27,6 +27,33 @@ pub fn panic_payload_to_string(payload: &(dyn Any + Send), fallback: &str) -> St
 ///
 /// Used for shell command fragments such as `GIT_EDITOR` values, which git
 /// hands to `sh` on every platform.
+/// Mask credentials embedded in a URL's userinfo for display.
+///
+/// `scheme://user:secret@host/…` becomes `scheme://user:***@host/…`. For
+/// http(s), where a token is commonly the whole userinfo
+/// (`https://ghp_…@github.com`), the userinfo is masked entirely. Other
+/// schemes keep a bare username (`ssh://git@host`), and inputs without an
+/// authority — scp-like `git@host:path`, local paths — are returned as-is.
+/// Only display strings go through here; the URL git receives is untouched.
+pub fn redact_url_userinfo(url: &str) -> String {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return url.to_string();
+    };
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let Some(at) = rest[..authority_end].rfind('@') else {
+        return url.to_string();
+    };
+    let userinfo = &rest[..at];
+    let masked = match userinfo.split_once(':') {
+        Some((user, _)) => format!("{user}:***"),
+        None if scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https") => {
+            "***".to_string()
+        }
+        None => return url.to_string(),
+    };
+    format!("{scheme}://{masked}{}", &rest[at..])
+}
+
 pub fn shell_single_quote(raw: &str) -> String {
     format!("'{}'", raw.replace('\'', "'\"'\"'"))
 }
@@ -791,6 +818,39 @@ pub(crate) fn delete_last_line(text: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn redact_url_userinfo_masks_secrets_and_keeps_the_rest() {
+        use super::redact_url_userinfo;
+        assert_eq!(
+            redact_url_userinfo("https://user:s3cret@example.com/org/repo.git"),
+            "https://user:***@example.com/org/repo.git"
+        );
+        assert_eq!(
+            redact_url_userinfo("https://ghp_token@github.com/org/repo.git"),
+            "https://***@github.com/org/repo.git"
+        );
+        assert_eq!(
+            redact_url_userinfo("HTTP://user@example.com:8080/repo?x=a@b#f"),
+            "HTTP://***@example.com:8080/repo?x=a@b#f"
+        );
+        assert_eq!(
+            redact_url_userinfo("ssh://git@example.com/org/repo.git"),
+            "ssh://git@example.com/org/repo.git"
+        );
+        assert_eq!(
+            redact_url_userinfo("ssh://git:pass@example.com/org/repo.git"),
+            "ssh://git:***@example.com/org/repo.git"
+        );
+        for untouched in [
+            "git@github.com:org/repo.git",
+            "/tmp/repo.git",
+            "https://example.com/repo?token=a@b",
+            "",
+        ] {
+            assert_eq!(redact_url_userinfo(untouched), untouched);
+        }
+    }
+
     use super::{LineEndingDetectionMode, chars_to_tokens, detect_line_ending_from_texts};
 
     #[test]

--- a/crates/gitcomet-git-gix/src/repo/remotes.rs
+++ b/crates/gitcomet-git-gix/src/repo/remotes.rs
@@ -10,10 +10,25 @@ use gitcomet_core::services::{
     CancellationToken, CommandOutput, ForcePushLease, PullMode, RemoteUrlKind, Result,
     SafePushAfterCommitContext, SafePushAfterCommitDecision, SafePushAfterCommitTarget,
 };
+use gitcomet_core::text_utils::redact_url_userinfo;
 use gix::bstr::ByteSlice as _;
 use rustc_hash::FxHashSet;
 use std::process::Command;
 use std::str;
+
+/// Display label for `git remote add`; the URL is masked because the label
+/// ends up in the command log and error toasts, unlike the argv.
+fn remote_add_label(name: &str, url: &str) -> String {
+    format!("git remote add {name} {}", redact_url_userinfo(url))
+}
+
+fn remote_set_url_label(name: &str, url: &str, kind: RemoteUrlKind) -> String {
+    let url = redact_url_userinfo(url);
+    match kind {
+        RemoteUrlKind::Fetch => format!("git remote set-url {name} {url}"),
+        RemoteUrlKind::Push => format!("git remote set-url --push {name} {url}"),
+    }
+}
 
 fn parse_refname_set(output: &str) -> FxHashSet<String> {
     output
@@ -912,7 +927,7 @@ impl GixRepo {
 
         let mut cmd = self.git_workdir_cmd();
         cmd.arg("remote").arg("add").arg("--").arg(name).arg(url);
-        run_git_with_output(cmd, &format!("git remote add {name} {url}"))
+        run_git_with_output(cmd, &remote_add_label(name, url))
     }
 
     pub(super) fn remove_remote_with_output_impl(&self, name: &str) -> Result<CommandOutput> {
@@ -940,11 +955,7 @@ impl GixRepo {
             }
         }
         cmd.arg("--").arg(name).arg(url);
-        let label = match kind {
-            RemoteUrlKind::Fetch => format!("git remote set-url {name} {url}"),
-            RemoteUrlKind::Push => format!("git remote set-url --push {name} {url}"),
-        };
-        run_git_with_output(cmd, &label)
+        run_git_with_output(cmd, &remote_set_url_label(name, url, kind))
     }
 
     pub(super) fn push_set_upstream_impl(&self, remote: &str, branch: &str) -> Result<()> {
@@ -1331,5 +1342,30 @@ feature/no-upstream\t\n";
         assert!(!simple_called.get());
         assert!(with_output_called.get());
         assert_eq!(output, expected);
+    }
+}
+
+#[cfg(test)]
+mod remote_label_tests {
+    use super::{RemoteUrlKind, remote_add_label, remote_set_url_label};
+
+    #[test]
+    fn remote_labels_mask_credentials_in_urls() {
+        assert_eq!(
+            remote_add_label("origin", "https://user:s3cret@example.com/org/repo.git"),
+            "git remote add origin https://user:***@example.com/org/repo.git"
+        );
+        assert_eq!(
+            remote_set_url_label(
+                "origin",
+                "https://ghp_token@github.com/org/repo.git",
+                RemoteUrlKind::Fetch
+            ),
+            "git remote set-url origin https://***@github.com/org/repo.git"
+        );
+        assert_eq!(
+            remote_set_url_label("origin", "git@github.com:org/repo.git", RemoteUrlKind::Push),
+            "git remote set-url --push origin git@github.com:org/repo.git"
+        );
     }
 }

--- a/crates/gitcomet-git-gix/src/repo/submodules.rs
+++ b/crates/gitcomet-git-gix/src/repo/submodules.rs
@@ -14,6 +14,7 @@ use gitcomet_core::path_utils::canonicalize_or_original;
 use gitcomet_core::services::{
     CancellationToken, CommandOutput, Result, SubmoduleTrustDecision, SubmoduleTrustTarget,
 };
+use gitcomet_core::text_utils::redact_url_userinfo;
 use gix::bstr::ByteSlice as _;
 use std::collections::BTreeMap;
 use std::fs;
@@ -438,9 +439,10 @@ fn push_submodule_add_args(
         cmd.arg("--name").arg(name);
         command.push_str(&format!(" --name {name}"));
     }
-    // The label stays a human-readable summary; `--` is an argv concern only.
+    // The label stays a human-readable summary; `--` is an argv concern only,
+    // and credentials in the URL are masked because the label is displayed.
     cmd.arg("--").arg(url).arg(path);
-    command.push_str(&format!(" {url} {}", path.display()));
+    command.push_str(&format!(" {} {}", redact_url_userinfo(url), path.display()));
     command
 }
 
@@ -1974,6 +1976,18 @@ mod tests {
             label,
             "git submodule add --branch main --force --name lib/sub --reference=/tmp/evil sub"
         );
+    }
+
+    #[test]
+    fn submodule_add_label_masks_credentials_but_argv_keeps_the_url() {
+        let mut cmd = Command::new("git");
+        let url = "https://user:s3cret@example.com/lib.git";
+        let label = push_submodule_add_args(&mut cmd, url, Path::new("lib"), None, None, false);
+        assert_eq!(
+            label,
+            "git submodule add https://user:***@example.com/lib.git lib"
+        );
+        assert!(cmd.get_args().any(|arg| arg == OsStr::new(url)));
     }
 
     #[test]

--- a/crates/gitcomet-state/src/store/effects/clone.rs
+++ b/crates/gitcomet-state/src/store/effects/clone.rs
@@ -8,6 +8,7 @@ use gitcomet_core::auth::askpass::{
 use gitcomet_core::error::{Error, ErrorKind};
 use gitcomet_core::process::{bytes_to_text_preserving_utf8, git_command};
 use gitcomet_core::services::CommandOutput;
+use gitcomet_core::text_utils::redact_url_userinfo;
 use rustc_hash::FxHashMap;
 use std::fs;
 use std::io::Read as _;
@@ -190,6 +191,16 @@ fn validate_clone_url(url: &str) -> Result<(), Error> {
     Ok(())
 }
 
+/// The label shown in the command log and in failure messages; the URL is
+/// masked there because a pasted `https://user:token@host` must not be echoed.
+fn clone_command_label(url: &str, dest: &Path) -> String {
+    format!(
+        "git clone --progress {} {}",
+        redact_url_userinfo(url),
+        dest.display()
+    )
+}
+
 /// `--` keeps a URL or destination that starts with `-` from being parsed as
 /// a `git clone` option (`--upload-pack=<cmd>` would run `<cmd>` locally).
 fn build_clone_command(url: &str, dest: &Path) -> Command {
@@ -343,7 +354,7 @@ pub(super) fn schedule_clone_repo(
             }
         };
 
-        let command_str = format!("git clone --progress {} {}", url, dest.display());
+        let command_str = clone_command_label(&url, &dest);
 
         let child = match cmd.spawn() {
             Ok(child) => child,
@@ -568,6 +579,21 @@ mod tests {
                 "{url}: {err}"
             );
         }
+    }
+
+    #[test]
+    fn clone_command_label_masks_credentials_in_the_url() {
+        let dest = Path::new("/tmp/gitcomet-clone-dest");
+        assert_eq!(
+            clone_command_label("https://user:s3cret@example.com/org/repo.git", dest),
+            "git clone --progress https://user:***@example.com/org/repo.git /tmp/gitcomet-clone-dest"
+        );
+        let cmd = build_clone_command("https://user:s3cret@example.com/org/repo.git", dest);
+        assert!(
+            cmd.get_args()
+                .any(|arg| arg == "https://user:s3cret@example.com/org/repo.git"),
+            "argv must carry the real URL"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The display labels for `git remote add`, `git remote set-url`, `git submodule add` and `git clone` embedded the URL verbatim. Those labels feed the command log, error toasts and failure messages, so a `https://user:token@host` URL — pasted once — was echoed on screen every time the command was shown. Nothing persisted it, so the exposure was shoulder-surfing and screenshots.

Add `redact_url_userinfo` to core text utilities: it masks the password (`user:***`), masks the whole userinfo for http(s) where a token commonly travels as the username, leaves a bare username on other schemes (`ssh://git@host`), and returns scp-like and local inputs untouched. Apply it to the four labels only; the argv git receives is unchanged, which the tests assert alongside the masked labels.