### PR TITLE
Security refuse worktree saves that would write through a symlink

### DIFF
--- a/crates/gitcomet-core/src/path_utils.rs
+++ b/crates/gitcomet-core/src/path_utils.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::path::{Path, PathBuf};
 
 /// When a workdir path ends with ".git" and contains a `.git` entry (e.g.
@@ -51,11 +52,90 @@ pub fn strip_windows_verbatim_prefix(path: PathBuf) -> PathBuf {
     path
 }
 
+/// Resolve `relative` under `workdir` for a write, refusing when any component
+/// on the way is a symlink.
+///
+/// A lexical check on `relative` stops `..` from leaving the worktree, but the
+/// filesystem can still redirect the write: a tracked symlink such as
+/// `notes.md -> ~/.ssh/authorized_keys` lists like a plain file and
+/// `fs::write` follows it. Git itself never writes *through* a symlink when it
+/// checks files out, so refusing here keeps the editor at parity. Components
+/// that do not exist yet are fine; the caller creates them.
+pub fn symlink_free_write_target(workdir: &Path, relative: &Path) -> io::Result<PathBuf> {
+    let mut candidate = workdir.to_path_buf();
+    for component in relative.components() {
+        candidate.push(component.as_os_str());
+        match std::fs::symlink_metadata(&candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "refusing to write through symlink '{}'",
+                        candidate
+                            .strip_prefix(workdir)
+                            .unwrap_or(&candidate)
+                            .display()
+                    ),
+                ));
+            }
+            Ok(_) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => break,
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(workdir.join(relative))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::git_dir_for_workdir;
+    use super::{git_dir_for_workdir, symlink_free_write_target};
     use std::fs;
+    use std::path::Path;
     use tempfile::tempdir;
+
+    #[test]
+    fn symlink_free_write_target_accepts_regular_and_missing_paths() {
+        let dir = tempdir().expect("create temp dir");
+        fs::create_dir_all(dir.path().join("docs")).expect("create docs");
+        fs::write(dir.path().join("docs/notes.md"), "x").expect("write notes");
+
+        assert_eq!(
+            symlink_free_write_target(dir.path(), Path::new("docs/notes.md")).expect("regular"),
+            dir.path().join("docs/notes.md")
+        );
+        assert_eq!(
+            symlink_free_write_target(dir.path(), Path::new("new/dir/file.txt"))
+                .expect("missing components are created later"),
+            dir.path().join("new/dir/file.txt")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_free_write_target_refuses_symlinked_file() {
+        let dir = tempdir().expect("create temp dir");
+        let outside = tempdir().expect("create outside dir");
+        let target = outside.path().join("victim");
+        fs::write(&target, "keep").expect("write victim");
+        std::os::unix::fs::symlink(&target, dir.path().join("notes.md")).expect("symlink");
+
+        let err = symlink_free_write_target(dir.path(), Path::new("notes.md"))
+            .expect_err("a symlinked file must be refused");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("notes.md"), "{err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_free_write_target_refuses_symlinked_parent() {
+        let dir = tempdir().expect("create temp dir");
+        let outside = tempdir().expect("create outside dir");
+        std::os::unix::fs::symlink(outside.path(), dir.path().join("docs")).expect("symlink");
+
+        let err = symlink_free_write_target(dir.path(), Path::new("docs/notes.md"))
+            .expect_err("a symlinked parent must be refused");
+        assert!(err.to_string().contains("docs"), "{err}");
+    }
 
     #[test]
     fn normal_workdir_returns_unchanged() {

--- a/crates/gitcomet-state/src/store/effects/repo_commands.rs
+++ b/crates/gitcomet-state/src/store/effects/repo_commands.rs
@@ -241,6 +241,20 @@ fn normalize_worktree_relative_path(path: &Path) -> Result<PathBuf, Error> {
     Ok(normalized)
 }
 
+/// Where a worktree save for `path` lands, or why it must not.
+///
+/// Containment is checked twice: lexically, so `..` cannot leave the workdir,
+/// and on the filesystem, so a symlink cannot redirect the write outside it.
+fn resolve_worktree_save_target(workdir: &Path, path: &Path) -> Result<(PathBuf, PathBuf), Error> {
+    let relative_path = normalize_worktree_relative_path(path)?;
+    let full = gitcomet_core::path_utils::symlink_free_write_target(workdir, &relative_path)
+        .map_err(|err| match err.kind() {
+            std::io::ErrorKind::InvalidInput => Error::new(ErrorKind::Backend(err.to_string())),
+            kind => Error::new(ErrorKind::Io(kind)),
+        })?;
+    Ok((relative_path, full))
+}
+
 fn run_with_git_auth<R>(
     auth: Option<StagedGitAuth>,
     run: impl FnOnce() -> Result<R, Error>,
@@ -284,8 +298,7 @@ pub(super) fn schedule_save_worktree_file(
             stage,
         },
         move |repo| {
-            let relative_path = normalize_worktree_relative_path(&path)?;
-            let full = repo.spec().workdir.join(&relative_path);
+            let (relative_path, full) = resolve_worktree_save_target(&repo.spec().workdir, &path)?;
             if let Some(parent) = full.parent() {
                 std::fs::create_dir_all(parent).map_err(|e| Error::new(ErrorKind::Io(e.kind())))?;
             }
@@ -1559,6 +1572,52 @@ pub(super) fn schedule_launch_mergetool(
             }
         },
     );
+}
+
+#[cfg(test)]
+mod worktree_save_target_tests {
+    use super::resolve_worktree_save_target;
+    use gitcomet_core::error::ErrorKind;
+    use std::path::Path;
+
+    #[test]
+    fn nested_relative_path_resolves_under_workdir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (relative, full) =
+            resolve_worktree_save_target(dir.path(), Path::new("./src/../src/lib.rs"))
+                .expect("nested path");
+        assert_eq!(relative, Path::new("src/lib.rs"));
+        assert_eq!(full, dir.path().join("src/lib.rs"));
+    }
+
+    #[test]
+    fn parent_dir_escape_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = resolve_worktree_save_target(dir.path(), Path::new("../outside.txt"))
+            .expect_err("lexical escape");
+        assert!(matches!(err.kind(), ErrorKind::Backend(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_through_symlink_out_of_workdir_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside dir");
+        let victim = outside.path().join("authorized_keys");
+        std::fs::write(&victim, "original").expect("write victim");
+        std::os::unix::fs::symlink(&victim, dir.path().join("notes.md")).expect("symlink");
+
+        let err = resolve_worktree_save_target(dir.path(), Path::new("notes.md"))
+            .expect_err("symlinked file");
+        let ErrorKind::Backend(message) = err.kind() else {
+            panic!("expected a backend refusal, got {err:?}");
+        };
+        assert!(message.contains("symlink"), "{message}");
+        assert_eq!(
+            std::fs::read_to_string(&victim).expect("victim"),
+            "original"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The built-in editor's save resolved its target with a purely lexical check (`normalize_worktree_relative_path`), which stops `..` from leaving the workdir, and then called `fs::write`, which follows symlinks. The file browser lists tracked symlinks as ordinary files, so a repository carrying `notes.md -> ~/.ssh/authorized_keys` let an edit-and-save land outside the worktree. Git itself never writes through a symlink on checkout.

Add `symlink_free_write_target` to core path utilities: it walks the relative path component by component with `symlink_metadata` and refuses the write if any existing component is a symlink, while still allowing components that do not exist yet. The save effect resolves its target through it after the lexical normalisation.

Tests cover regular and not-yet-existing paths, a symlinked file, a symlinked parent directory, and the combined resolver asserting the symlink target is left untouched.