### PR TITLE
Feat/style changes

### DIFF
--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/commit.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/context_menu/commit.rs
@@ -169,6 +169,7 @@ pub(super) fn model(this: &PopoverHost, repo_id: RepoId, commit_id: &CommitId) -
     let mut items = vec![ContextMenuItem::Header(
         components::ContextMenuText::new(header_text).max_lines(2),
     )];
+    let mut entry_tooltips = FxHashMap::default();
     if !commit_summary.is_empty() {
         items.push(ContextMenuItem::Label(
             components::ContextMenuText::new(commit_summary).max_lines(4),
@@ -337,11 +338,13 @@ pub(super) fn model(this: &PopoverHost, repo_id: RepoId, commit_id: &CommitId) -
             commit_id: commit_id.clone(),
         }),
     });
+    let add_tag_disabled = !this.state.git_log_settings.show_history_tags;
+    let add_tag_ix = items.len();
     items.push(ContextMenuItem::Entry {
         label: "Add tag…".into(),
         icon: Some("icons/tag.svg".into()),
         shortcut: Some("T".into()),
-        disabled: false,
+        disabled: add_tag_disabled,
         action: Box::new(ContextMenuAction::OpenPopover {
             kind: PopoverKind::CreateTagPrompt {
                 repo_id,
@@ -349,6 +352,12 @@ pub(super) fn model(this: &PopoverHost, repo_id: RepoId, commit_id: &CommitId) -
             },
         }),
     });
+    if add_tag_disabled {
+        entry_tooltips.insert(
+            add_tag_ix,
+            "Enable “Show tags in history view” in Settings > Git log to add tags.".into(),
+        );
+    }
     items.push(ContextMenuItem::Entry {
         label: "Checkout (detached)".into(),
         icon: Some("icons/git_branch.svg".into()),
@@ -532,7 +541,7 @@ pub(super) fn model(this: &PopoverHost, repo_id: RepoId, commit_id: &CommitId) -
         });
     }
 
-    ContextMenuModel::new(items)
+    ContextMenuModel::new(items).with_entry_tooltips(entry_tooltips)
 }
 
 #[cfg(test)]

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/fingerprint.rs
@@ -7,6 +7,9 @@ use std::hash::{Hash, Hasher};
 pub(super) fn notify_fingerprint(state: &AppState, popover: &PopoverKind) -> u64 {
     let mut hasher = FxHasher::default();
     hash_popover_kind(popover, &mut hasher);
+    if matches!(popover, PopoverKind::CommitMenu { .. }) {
+        state.git_log_settings.show_history_tags.hash(&mut hasher);
+    }
 
     match popover {
         PopoverKind::CloneRepo => match &state.clone {
@@ -1184,6 +1187,31 @@ mod tests {
 
         state.repos[0].branches_rev = state.repos[0].branches_rev.wrapping_add(1);
         assert_ne!(after_head_branch, notify_fingerprint(&state, &popover));
+    }
+
+    #[test]
+    fn commit_menu_fingerprint_changes_when_history_tag_visibility_changes() {
+        let repo_id = RepoId(9);
+        let repo = RepoState::new_opening(
+            repo_id,
+            gitcomet_core::domain::RepoSpec {
+                workdir: std::env::temp_dir().join("gitcomet_commit_menu_fingerprint"),
+            },
+        );
+        let mut state = AppState {
+            active_repo: Some(repo_id),
+            ..AppState::default()
+        };
+        state.repos.push(repo);
+
+        let popover = PopoverKind::CommitMenu {
+            repo_id,
+            commit_id: CommitId("deadbeef".into()),
+        };
+        let before = notify_fingerprint(&state, &popover);
+        state.git_log_settings.show_history_tags = !state.git_log_settings.show_history_tags;
+
+        assert_ne!(before, notify_fingerprint(&state, &popover));
     }
 
     #[test]

--- a/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/file_actions.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panels/popover/tests/file_actions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::view::panels::popover::context_menu::context_menu_shortcut_entry_ix;
 use crate::view::panels::tests::wait_for_main_pane_condition;
 use crate::view::panels::tests::{
     app_state_with_repo, opening_repo_state, push_test_state, set_test_file_status,
@@ -95,6 +96,19 @@ fn commit_menu_has_add_tag_entry(cx: &mut gpui::TestAppContext) {
             _ => None,
         });
 
+        let add_tag_ix = model
+            .items
+            .iter()
+            .position(|item| {
+                matches!(
+                    item,
+                    ContextMenuItem::Entry { label, .. } if label.as_ref() == "Add tag…"
+                )
+            })
+            .expect("expected Add tag… context menu entry");
+        assert!(!context_menu_entry_disabled(&model, "Add tag…"));
+        assert!(!model.entry_tooltips.contains_key(&add_tag_ix));
+
         let Some(ContextMenuAction::OpenPopover { kind }) = add_tag_action else {
             panic!("expected Add tag… to open a popover");
         };
@@ -109,6 +123,59 @@ fn commit_menu_has_add_tag_entry(cx: &mut gpui::TestAppContext) {
 
         assert_eq!(rid, repo_id);
         assert_eq!(target, commit_id.as_ref().to_string());
+    });
+}
+
+#[gpui::test]
+fn commit_menu_disables_add_tag_when_history_tags_are_hidden(cx: &mut gpui::TestAppContext) {
+    let (store, events) = AppStore::new(Arc::new(TestBackend));
+    let (view, cx) =
+        cx.add_window_view(|window, cx| GitCometView::new(store, events, None, window, cx));
+
+    let repo_id = RepoId(1);
+    let commit_id = CommitId("deadbeefdeadbeef".into());
+
+    cx.update(|_window, app| {
+        view.update(app, |this, cx| {
+            let repo = commit_menu_test_repo(repo_id, &commit_id);
+            let mut state = app_state_with_repo(repo, repo_id);
+            Arc::make_mut(&mut state).git_log_settings.show_history_tags = false;
+            push_test_state(this, state, cx);
+        });
+    });
+
+    cx.update(|_window, app| {
+        let model = view
+            .update(app, |this, cx| {
+                this.popover_host.update(cx, |host, cx| {
+                    host.context_menu_model(
+                        &PopoverKind::CommitMenu {
+                            repo_id,
+                            commit_id: commit_id.clone(),
+                        },
+                        cx,
+                    )
+                })
+            })
+            .expect("expected commit context menu model");
+
+        let add_tag_ix = model
+            .items
+            .iter()
+            .position(|item| {
+                matches!(
+                    item,
+                    ContextMenuItem::Entry { label, .. } if label.as_ref() == "Add tag…"
+                )
+            })
+            .expect("expected Add tag… context menu entry");
+
+        assert!(context_menu_entry_disabled(&model, "Add tag…"));
+        assert_eq!(context_menu_shortcut_entry_ix(&model, "T"), None);
+        assert_eq!(
+            model.entry_tooltips.get(&add_tag_ix).map(|t| t.as_ref()),
+            Some("Enable “Show tags in history view” in Settings > Git log to add tags.")
+        );
     });
 }
 

--- a/crates/gitcomet-ui-gpui/src/view/panes/history/history_panel.rs
+++ b/crates/gitcomet-ui-gpui/src/view/panes/history/history_panel.rs
@@ -47,9 +47,7 @@ impl HistoryView {
                 None => {
                     components::empty_state(theme, "History", "No repository.").into_any_element()
                 }
-                Some(Loadable::Loading) => {
-                    components::empty_state(theme, "History", "Loading").into_any_element()
-                }
+                Some(Loadable::Loading) => div().into_any_element(),
                 Some(Loadable::Error(e)) => {
                     components::empty_state(theme, "History", e.clone()).into_any_element()
                 }

--- a/crates/gitcomet-ui-gpui/src/view/rows/history_canvas.rs
+++ b/crates/gitcomet-ui-gpui/src/view/rows/history_canvas.rs
@@ -316,6 +316,7 @@ fn history_chip_visual(
     kind: HistoryChipStyleKind,
     context_menu_open: bool,
 ) -> HistoryChipVisual {
+    let active_branch_icon = gpui::rgba(0xffffffff);
     let visual = match kind {
         HistoryChipStyleKind::Tag => HistoryChipVisual {
             border: with_alpha(theme.colors.accent.foreground, 0.35),
@@ -349,8 +350,10 @@ fn history_chip_visual(
             border: with_alpha(theme.colors.accent.foreground, 0.85),
             bg: with_alpha(theme.colors.accent.foreground, 0.22),
             text: selected_branch_label_color(theme),
-            local_branch_icon: theme.colors.accent.foreground,
-            remote_branch_icon: theme.colors.foreground.secondary,
+            // Every branch-location glyph is an outline. Keep both layers of
+            // the combined computer/cloud glyph pure white on the active fill.
+            local_branch_icon: active_branch_icon,
+            remote_branch_icon: active_branch_icon,
         },
         HistoryChipStyleKind::Branch { selected: false } => HistoryChipVisual {
             border: with_alpha(theme.colors.stroke.default, 0.90),
@@ -375,12 +378,19 @@ fn history_chip_visual(
         },
         // The menu-open state is deliberately stronger than sidebar selection,
         // so a selected branch still changes when its own menu is pinned open.
-        HistoryChipStyleKind::Tag | HistoryChipStyleKind::Branch { .. } => HistoryChipVisual {
+        HistoryChipStyleKind::Tag => HistoryChipVisual {
             border: theme.colors.accent.foreground,
             bg: with_alpha(theme.colors.accent.foreground, 0.30),
             text: selected_branch_label_color(theme),
             local_branch_icon: theme.colors.accent.foreground,
             remote_branch_icon: theme.colors.foreground.secondary,
+        },
+        HistoryChipStyleKind::Branch { .. } => HistoryChipVisual {
+            border: theme.colors.accent.foreground,
+            bg: with_alpha(theme.colors.accent.foreground, 0.30),
+            text: selected_branch_label_color(theme),
+            local_branch_icon: active_branch_icon,
+            remote_branch_icon: active_branch_icon,
         },
     }
 }
@@ -2229,6 +2239,37 @@ mod tests {
                 theme.colors.accent.on_solid,
                 "the combined computer must retain contrast on a solid HEAD chip"
             );
+        }
+    }
+
+    #[test]
+    fn active_branch_chip_icons_are_white_outlines() {
+        let white = gpui::rgba(0xffffffff);
+        for theme in [AppTheme::gitcomet_dark(), AppTheme::gitcomet_light()] {
+            for visual in [
+                history_chip_visual(
+                    theme,
+                    HistoryChipStyleKind::Branch { selected: true },
+                    false,
+                ),
+                history_chip_visual(
+                    theme,
+                    HistoryChipStyleKind::Branch { selected: false },
+                    true,
+                ),
+                history_chip_visual(theme, HistoryChipStyleKind::Branch { selected: true }, true),
+            ] {
+                assert_eq!(HistoryBranchChipIcon::Local.color(&visual), white);
+                assert_eq!(HistoryBranchChipIcon::Remote.color(&visual), white);
+                assert_eq!(HistoryBranchChipIcon::LocalRemote.color(&visual), white);
+                assert_eq!(
+                    HistoryBranchChipIcon::LocalRemote
+                        .foreground_layer(&visual)
+                        .expect("the combined icon should paint its computer layer")
+                        .1,
+                    white
+                );
+            }
         }
     }
 

--- a/crates/gitcomet-ui-gpui/src/view/splash.rs
+++ b/crates/gitcomet-ui-gpui/src/view/splash.rs
@@ -6,10 +6,6 @@ use std::sync::OnceLock;
 
 const SPLASH_BACKDROP_PNG_BYTES: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/splash_backdrop.png"));
-/// Gap (on the 8px grid) around the inset content/details cards so they read as
-/// rounded surfaces floating on the shared window canvas, with the sidebar
-/// blended into that canvas.
-const CONTENT_CARD_GAP_PX: f32 = 8.0;
 /// Bottom margin the main content card leaves for the bottom bar. The collapsed
 /// section popover matches it so its top/bottom gaps read symmetric.
 const CONTENT_CARD_BOTTOM_MARGIN_PX: f32 = 2.0;
@@ -21,12 +17,10 @@ const CONTENT_CARD_BOTTOM_MARGIN_PX: f32 = 2.0;
 const COLLAPSED_POPOVER_WIDTH_PX: f32 = 340.0;
 static SPLASH_BACKDROP_IMAGE_CACHE: OnceLock<Arc<gpui::Image>> = OnceLock::new();
 
-/// Corner radius of the main content card — squarer than the shared `panel`
-/// radius the floating dialogs and splash cards keep. This surface is chrome
-/// fused to the tab strip above it and the sidebar beside it, not a card
-/// floating on the canvas, so it takes the same radius as the controls
-/// (buttons, tabs) it sits among. The corner caps derive from this, so both
-/// move together.
+/// Left corner radius of the main content card — squarer than the shared
+/// `panel` radius the floating dialogs and splash cards keep. The right edge is
+/// square because the card runs flush to the window edge. The corner caps
+/// derive from this, so both move together.
 fn main_content_card_radius(theme: AppTheme) -> f32 {
     theme.radii.control
 }
@@ -56,18 +50,16 @@ pub(in crate::view) fn load_splash_backdrop_image() -> Arc<gpui::Image> {
 }
 
 /// Children clip to rectangles, so full-bleed content inside the card can
-/// square off its rounded corners. These caps repaint the four corner
+/// square off its rounded left corners. These caps repaint the two left corner
 /// notches (the area between the content rectangle's corner and the card's
 /// inner arc) in the surrounding surface color, restoring the rounding over
 /// anything the content paints. Canvas elements take no hitboxes, so the
 /// overlay is invisible to the mouse.
-fn card_corner_caps(radius: Pixels, color: gpui::Rgba) -> AnyElement {
+fn card_left_corner_caps(radius: Pixels, color: gpui::Rgba) -> AnyElement {
     #[derive(Clone, Copy)]
     enum CapCorner {
         TopLeft,
-        TopRight,
         BottomLeft,
-        BottomRight,
     }
 
     let cap = move |corner: CapCorner| {
@@ -84,20 +76,6 @@ fn card_corner_caps(radius: Pixels, color: gpui::Rgba) -> AnyElement {
                     point(bounds.left() + r, bounds.top()),
                     point(bounds.left(), bounds.top() + r - k),
                     point(bounds.left() + r - k, bounds.top()),
-                ),
-                CapCorner::TopRight => (
-                    point(bounds.right(), bounds.top()),
-                    point(bounds.left(), bounds.top()),
-                    point(bounds.right(), bounds.top() + r),
-                    point(bounds.left() + k, bounds.top()),
-                    point(bounds.right(), bounds.top() + r - k),
-                ),
-                CapCorner::BottomRight => (
-                    point(bounds.right(), bounds.bottom()),
-                    point(bounds.right(), bounds.top()),
-                    point(bounds.left(), bounds.bottom()),
-                    point(bounds.right(), bounds.top() + k),
-                    point(bounds.left() + k, bounds.bottom()),
                 ),
                 CapCorner::BottomLeft => (
                     point(bounds.left(), bounds.bottom()),
@@ -119,9 +97,7 @@ fn card_corner_caps(radius: Pixels, color: gpui::Rgba) -> AnyElement {
         let positioned = div().absolute().size(radius);
         let positioned = match corner {
             CapCorner::TopLeft => positioned.top_0().left_0(),
-            CapCorner::TopRight => positioned.top_0().right_0(),
             CapCorner::BottomLeft => positioned.bottom_0().left_0(),
-            CapCorner::BottomRight => positioned.bottom_0().right_0(),
         };
         positioned.child(
             gpui::canvas(
@@ -138,9 +114,7 @@ fn card_corner_caps(radius: Pixels, color: gpui::Rgba) -> AnyElement {
         .left_0()
         .size_full()
         .child(cap(CapCorner::TopLeft))
-        .child(cap(CapCorner::TopRight))
         .child(cap(CapCorner::BottomLeft))
-        .child(cap(CapCorner::BottomRight))
         .into_any_element()
 }
 
@@ -1162,8 +1136,8 @@ impl GitCometView {
                         .child(
                             // Main + details share one card silhouette; the panes stay
                             // independently resizable inside it. The card sits flush
-                            // against the action bar and sidebar (no top/left gap); the
-                            // sidebar resize strip overlays the card's left edge below.
+                            // against the action bar, sidebar, and right window edge;
+                            // the sidebar resize strip overlays its left edge below.
                             div()
                                 .flex_1()
                                 .min_w(px(0.0))
@@ -1173,9 +1147,9 @@ impl GitCometView {
                                 // Kept minimal so the bottom bar's icons (pane
                                 // toggles + zoom) read as one row hugging the card.
                                 .mb(px(CONTENT_CARD_BOTTOM_MARGIN_PX))
-                                .mr(px(CONTENT_CARD_GAP_PX))
                                 .relative()
-                                .rounded(px(main_content_card_radius(theme)))
+                                .rounded_tl(px(main_content_card_radius(theme)))
+                                .rounded_bl(px(main_content_card_radius(theme)))
                                 .border_1()
                                 .border_color(theme.colors.stroke.default)
                                 .overflow_hidden()
@@ -1239,7 +1213,7 @@ impl GitCometView {
                                             cx,
                                         )),
                                 )
-                                .child(card_corner_caps(
+                                .child(card_left_corner_caps(
                                     px((main_content_card_radius(theme) - 1.0).max(0.0)),
                                     theme.colors.surface.chrome,
                                 )),


### PR DESCRIPTION
- Disable Add Tag context menu option when Git tags are not shown in git log history  due to disabled setting
- Removed history loading text - it loads so fast that it causes just "flickering"
- Removed 8px right hand side padding from main canvas to make more room for actual content